### PR TITLE
Disabled DINERS card brand for CC_AVENUE gateway in siOnEmi transactions

### DIFF
--- a/src/decider/gatewaydecider/constants.rs
+++ b/src/decider/gatewaydecider/constants.rs
@@ -346,6 +346,13 @@ impl SC::ServiceConfigKey for SI_ON_EMI_CARD_SUPPORTED_GATEWAYS {
     }
 }
 
+pub struct SI_ON_EMI_DISABLED_CARD_BRAND_GATEWAY_MAPPING;
+impl SC::ServiceConfigKey for SI_ON_EMI_DISABLED_CARD_BRAND_GATEWAY_MAPPING {
+    fn get_key(&self) -> String {
+        "SI_ON_EMI_DISABLED_CARD_BRAND_GATEWAY_MAPPING".to_string()
+    }
+}
+
 pub struct TOKEN_PROVIDER_GATEWAY_MAPPING;
 impl SC::ServiceConfigKey for TOKEN_PROVIDER_GATEWAY_MAPPING {
     fn get_key(&self) -> String {

--- a/src/decider/gatewaydecider/gw_filter.rs
+++ b/src/decider/gatewaydecider/gw_filter.rs
@@ -2186,7 +2186,7 @@ pub async fn filterGatewaysForEmi(this: &mut DeciderFlow<'_>) -> GatewayList {
                 let gbes_v2_list_ = SGBES::getGatewayBankEmiSupportV2(
                     txn_detail.emiBank.clone(),
                     gws.clone(),
-                    scope.to_string(),
+                    scope_.to_string(),
                     txn_detail.emiTenure,
                 )
                 .await;
@@ -2217,10 +2217,10 @@ pub async fn filterGatewaysForEmi(this: &mut DeciderFlow<'_>) -> GatewayList {
                     logger::info!(
                         tag = "GBESV2 Entry Not Found",
                         action = "GBESV2 Entry Not Found",
-                        "GBESV2 Entry Not Found For emiBank - {:?}, gateways - {:?}, scope - {:?}, tenure - {:?}",
+                        "GBESV2 Entry Not Found For emiBank - {:?}, gateways - {:?}, scope_ - {:?}, tenure - {:?}",
                         txn_detail.emiBank,
                         gws.clone(),
-                        scope,
+                        scope_,
                         txn_detail.emiTenure
                     );
                 }
@@ -2246,7 +2246,7 @@ pub async fn filterGatewaysForEmi(this: &mut DeciderFlow<'_>) -> GatewayList {
                 let gbes_list_ = SGBES::getGatewayBankEmiSupport(
                     txn_detail.emiBank.clone(),
                     gws.clone(),
-                    scope.to_string(),
+                    scope_.to_string(),
                 )
                 .await;
 

--- a/src/decider/gatewaydecider/gw_filter_new.rs
+++ b/src/decider/gatewaydecider/gw_filter_new.rs
@@ -506,15 +506,11 @@ pub async fn filterGatewaysForEmi(this: &mut DeciderFlow<'_>) -> GatewayList {
                 .cloned()
                 .unwrap_or_default();
             
-            logDebugV::<String>("GW_Filtering".to_string(),
-                vec![
-                    "For txn with id =".to_string(),
-                    txn_detail.txnId.review(ETTD::transaction_id_text()),
-                    "Filtering out gateways:".to_string(),
-                    format!("{:?}", disabled_gws),
-                    "for card brand:".to_string(),
-                    card_brand.unwrap_or_else(|| "UNKNOWN".to_string())
-                ]
+            logger::debug!(
+                "For txn with id = {:?}, Filtering out gateways: {:?} for card brand: {:?}",
+                txn_detail.txnId.review(ETTD::transaction_id_text()),
+                disabled_gws,
+                card_brand.unwrap_or_else(|| "UNKNOWN".to_string())
             );
             
             st.into_iter()


### PR DESCRIPTION
1. Problem Description : disabled DINERS for siOnEmi transactions for CCAVENUE_V2 gateway in Decider
2. If this is a bug fix or an enhancement, how did you identify the issue? : Enhancement
4. Explain the solution implemented in the PR : 
- filtered out the CCAVENUE_V2 gateway while using DINERS Card as payment Method for EMI Transactions 
- make service config for SI_ON_EMI_DISABLED_CARD_BRAND_GATEWAY_MAPPING to filter Diner card for CCAVENUE_V2