### PR TITLE
refactor(debit_routing): remove transaction type is local or international check

### DIFF
--- a/src/decider/network_decider/co_badged_card_info.rs
+++ b/src/decider/network_decider/co_badged_card_info.rs
@@ -130,9 +130,8 @@ impl CoBadgedCardInfoList {
 pub async fn get_co_badged_cards_info(
     app_state: &app::TenantAppState,
     card_isin: String,
-    acquirer_country: &types::CountryAlpha2,
 ) -> CustomResult<Option<types::CoBadgedCardInfoResponse>, error::ApiError> {
-    // pad the card number to 19 digits to match the co-badged card bin length
+    // Pad the card number to 19 digits to match the co-badged card bin length
     let card_number_str = CoBadgedCardInfoList::pad_card_number_to_19_digit(card_isin);
 
     let parsed_number: i64 = card_number_str
@@ -187,18 +186,7 @@ pub async fn get_co_badged_cards_info(
                 .flatten()
                 .and_then(|filtered_list| filtered_list.is_valid_length().then_some(filtered_list));
 
-            filtered_list_optional
-                .and_then(|filtered_list| {
-                    filtered_list
-                        .is_local_transaction(acquirer_country)
-                        .change_context(error::ApiError::UnknownError)
-                        .attach_printable(
-                            "Failed to check if the transaction is local or international",
-                        )
-                        .map(|is_local_transaction| is_local_transaction.then_some(filtered_list))
-                        .transpose()
-                })
-                .transpose()
+            Ok(filtered_list_optional)
         }
     }?;
 

--- a/src/decider/network_decider/helpers.rs
+++ b/src/decider/network_decider/helpers.rs
@@ -107,7 +107,7 @@ impl types::CoBadgedCardRequest {
         }
 
         let card_isin = card_isin_optional?;
-        co_badged_card_info::get_co_badged_cards_info(app_state, card_isin, &self.acquirer_country)
+        co_badged_card_info::get_co_badged_cards_info(app_state, card_isin)
             .await
             .map_err(|error| {
                 logger::warn!(?error, "Failed to fetch co-badged card info");


### PR DESCRIPTION

### Refactoring of `get_co_badged_cards_info`:

* Removed the `acquirer_country` parameter from the `get_co_badged_cards_info` function, simplifying its signature and logic. [[1]](diffhunk://#diff-fb86b9875cae3a007ce4da535676e5bac0e9b003456a839880b1fb686aa80f68L133-R134) [[2]](diffhunk://#diff-abe53ac8f9001e34e1642a3498bbce708aaf6bddcff4496b769144e08d7612c8L110-R110)
* Eliminated the logic for checking whether a transaction is local or international, which included the use of `is_local_transaction` and associated error handling.

