### PR TITLE
add pagos bin lookup api support for debit routing

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -17,11 +17,11 @@ tti = 7200          # Idle time after a get/insert of a cache entry to free the 
 max_capacity = 5000 # Max capacity of a single table cache
 
 [database]
-username = "sam"   # username for the database
-password = "damn"  # password of the database
-host = "localhost" # the host where the database is hosted on
-port = 5432        # the port of the database
-dbname = "open_router"  # the name of the database where the cards are stored
+username = "sam"       # username for the database
+password = "damn"      # password of the database
+host = "localhost"     # the host where the database is hosted on
+port = 5432            # the port of the database
+dbname = "open_router" # the name of the database where the cards are stored
 
 [secrets]
 open_router_private_key = "" # the open_router private key to used used and the private key present with the tenant
@@ -69,3 +69,8 @@ client_idle_timeout = 90    # timeout for idle sockets being kept-alive
 pool_max_idle_per_host = 10 # maximum idle connection per host allowed in the pool.
 identity = ""               # identity to be used for client certificate authentication in mtls.
 
+
+[pagos_api]
+base_url = "https://parrot.prod.pagosapi.com" # Corrected Pagos API base URL
+api_key = "your_pagos_api_key_here"           # Your Pagos API Key (sensitive, manage securely)
+use_api_for_co_badged_lookup = false          # Set to true to use Pagos API for co-badged card info, false for DB lookup (default)

--- a/config/development.toml
+++ b/config/development.toml
@@ -196,3 +196,8 @@ merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 0.04 }
 merchant_category_code_0001.nyce = { percentage = 1.30, fixed_amount = 0.11 }
 merchant_category_code_0001.pulse = { percentage = 1.60, fixed_amount = 0.15 }
 merchant_category_code_0001.star = { percentage = 1.63, fixed_amount = 0.15 }
+
+[pagos_api]
+base_url = "https://parrot.prod.pagosapi.com" # Pagos API base URL
+api_key = "your_pagos_api_key_here"           # Your Pagos API Key (sensitive, manage securely)
+use_api_for_co_badged_lookup = true           # Set to true to use Pagos API for co-badged card info, false for DB lookup

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,16 @@ pub struct GlobalConfig {
     pub routing_config: Option<TomlConfig>,
     #[serde(default)]
     pub debit_routing_config: network_decider::types::DebitRoutingConfig,
+    #[serde(default)]
+    pub pagos_api: Option<PagosApiConfig>,
+}
+
+#[derive(Clone, serde::Deserialize, Debug, Default)]
+pub struct PagosApiConfig {
+    pub base_url: String,
+    pub api_key: masking::Secret<String>,
+    #[serde(default)]
+    pub use_api_for_co_badged_lookup: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -46,6 +56,7 @@ pub struct TenantConfig {
     pub tenant_secrets: TenantSecrets,
     pub routing_config: Option<TomlConfig>,
     pub debit_routing_config: network_decider::types::DebitRoutingConfig,
+    pub pagos_api: Option<PagosApiConfig>,
 }
 
 impl TenantConfig {
@@ -66,6 +77,7 @@ impl TenantConfig {
                 .cloned()
                 .unwrap(),
             debit_routing_config: global_config.debit_routing_config.clone(),
+            pagos_api: global_config.pagos_api.clone(),
         }
     }
 }

--- a/src/decider/network_decider/co_badged_card_info.rs
+++ b/src/decider/network_decider/co_badged_card_info.rs
@@ -1,10 +1,223 @@
 use crate::app;
 use crate::{
     decider::{gatewaydecider, network_decider::types, storage::utils::co_badged_card_info},
-    error, logger,
+    error, logger, pagos_client,
     utils::CustomResult,
 };
 use error_stack::ResultExt;
+
+fn get_parsed_bin_range_from_pagos(
+    pagos_card_details: &crate::types::pagos::PagosCardDetails,
+    additional_brand_info: Option<&crate::types::pagos::PagosAdditionalCardBrand>,
+    card_brand_to_parse: &str,
+) -> CustomResult<(i64, i64), error::ApiError> {
+    let (bin_min_str_opt, bin_max_str_opt) = if let Some(brand_info_ref) = additional_brand_info {
+        (
+            brand_info_ref.bin_min.as_ref(),
+            brand_info_ref.bin_max.as_ref(),
+        )
+    } else {
+        (
+            pagos_card_details.bin_min.as_ref(),
+            pagos_card_details.bin_max.as_ref(),
+        )
+    };
+
+    let final_bin_min: i64 = bin_min_str_opt
+        .ok_or_else(|| error::ApiError::ParsingError("Missing bin_min from Pagos response"))
+        .attach_printable_lazy(|| {
+            format!("Missing bin_min for card_brand: {}", card_brand_to_parse)
+        })?
+        .parse::<i64>()
+        .change_context(error::ApiError::ParsingError(
+            "Failed to parse bin_min from Pagos response to i64",
+        ))
+        .attach_printable_lazy(|| {
+            format!(
+                "Failed to parse bin_min for card_brand: {}",
+                card_brand_to_parse
+            )
+        })?;
+
+    let final_bin_max: i64 = bin_max_str_opt
+        .ok_or_else(|| error::ApiError::ParsingError("Missing bin_max from Pagos response"))
+        .attach_printable_lazy(|| {
+            format!("Missing bin_max for card_brand: {}", card_brand_to_parse)
+        })?
+        .parse::<i64>()
+        .change_context(error::ApiError::ParsingError(
+            "Failed to parse bin_max from Pagos response to i64",
+        ))
+        .attach_printable_lazy(|| {
+            format!(
+                "Failed to parse bin_max for card_brand: {}",
+                card_brand_to_parse
+            )
+        })?;
+    Ok((final_bin_min, final_bin_max))
+}
+
+fn try_convert_pagos_card_to_domain_data(
+    pagos_card_details: &crate::types::pagos::PagosCardDetails,
+    additional_brand_info: Option<&crate::types::pagos::PagosAdditionalCardBrand>,
+    card_brand_to_parse: &str,
+) -> CustomResult<types::CoBadgedCardInfoDomainData, error::ApiError> {
+    let parsed_network = card_brand_to_parse
+        .parse::<gatewaydecider::types::NETWORK>()
+        .change_context(error::ApiError::ParsingError("NETWORK"))
+        .attach_printable_lazy(|| {
+            format!(
+                "Failed to parse card_brand from Pagos: {}",
+                card_brand_to_parse
+            )
+        })?;
+
+    let card_brand_is_additional = additional_brand_info.is_some();
+
+    let (final_bin_min, final_bin_max) = get_parsed_bin_range_from_pagos(
+        pagos_card_details,
+        additional_brand_info,
+        card_brand_to_parse,
+    )?;
+
+    let pan_or_token = pagos_card_details
+        .pan_or_token
+        .clone()
+        .ok_or_else(|| error::ApiError::ParsingError("Missing pan_or_token from Pagos response"))?;
+
+    Ok(types::CoBadgedCardInfoDomainData {
+        card_bin_min: final_bin_min,
+        card_bin_max: final_bin_max,
+        issuing_bank_name: pagos_card_details
+            .bank
+            .as_ref()
+            .and_then(|bank_details| bank_details.name.clone()),
+        card_network: parsed_network,
+        country_code: pagos_card_details
+            .country
+            .as_ref()
+            .and_then(|country_details| country_details.alpha2.clone()),
+        card_type: pagos_card_details
+            .card_type
+            .as_ref()
+            .and_then(|pagos_card_type| pagos_card_type.to_domain_card_type()),
+        regulated: pagos_card_details.cost.as_ref().and_then(|cost| {
+            cost.interchange
+                .as_ref()
+                .and_then(|interchange_details| interchange_details.regulated)
+        }),
+        regulated_name: pagos_card_details.cost.as_ref().and_then(|cost| {
+            cost.interchange
+                .as_ref()
+                .and_then(|interchange_details| interchange_details.regulated_name.clone())
+        }),
+        prepaid: pagos_card_details.prepaid,
+        reloadable: pagos_card_details.reloadable,
+        pan_or_token,
+        // Card bin length will be present for a successful Pagos response
+        // If the Pagos response does not provide bin_length, default to 0
+        // Setting bin_length to 0 is safe as it will not be used in the domain logic
+        card_bin_length: pagos_card_details.bin_length.unwrap_or(0),
+
+        // Bin provider bin length will be present for a successful Pagos response
+        // If the Pagos response does not provide pagos_bin_length, default to 0
+        // Setting pagos_bin_length to 0 is safe as it will not be used in the domain logic
+        bin_provider_bin_length: pagos_card_details.pagos_bin_length.unwrap_or(0),
+
+        card_brand_is_additional,
+        domestic_only: pagos_card_details.domestic_only,
+    })
+}
+
+async fn fetch_co_badged_info_from_db(
+    app_state: &app::TenantAppState,
+    parsed_card_number: i64,
+) -> CustomResult<Vec<types::CoBadgedCardInfoDomainData>, error::ApiError> {
+    let co_badged_card_infos_record =
+        co_badged_card_info::find_co_badged_cards_info_by_card_bin(app_state, parsed_card_number)
+            .await;
+
+    match co_badged_card_infos_record {
+        Err(error) => {
+            logger::error!(
+                "Error while fetching co-badged card info record from DB: {:?}",
+                error
+            );
+            Err(error::ApiError::UnknownError)
+                .attach_printable("Error while fetching co-badged card info record from DB")
+        }
+        Ok(co_badged_card_infos) => {
+            logger::debug!("Co-badged card info record retrieved successfully from DB");
+
+            let parsed_cards: Vec<types::CoBadgedCardInfoDomainData> = co_badged_card_infos
+                .into_iter()
+                .filter_map(|raw_co_badged_card_info| {
+                    match raw_co_badged_card_info.clone().try_into() {
+                        Ok(parsed) => Some(parsed),
+                        Err(error) => {
+                            logger::warn!(
+                                "Skipping co-badged card from DB with card_network = {:?} due to error: {}",
+                                raw_co_badged_card_info.card_network,
+                                error
+                            );
+                            None
+                        }
+                    }
+                })
+                .collect();
+            Ok(parsed_cards)
+        }
+    }
+}
+
+async fn fetch_co_badged_info_from_pagos_api(
+    app_state: &app::TenantAppState,
+    card_isin: &str,
+) -> CustomResult<Vec<types::CoBadgedCardInfoDomainData>, error::ApiError> {
+    match pagos_client::fetch_pan_details_internal(app_state, card_isin).await {
+        Ok(pagos_response) => {
+            logger::debug!(
+                ?pagos_response,
+                "Pagos PAN details fetched successfully internally"
+            );
+            let mut domain_data_list = Vec::new();
+
+            if let Some(primary_card_brand_str) = &pagos_response.card.card_brand {
+                match try_convert_pagos_card_to_domain_data(
+                    &pagos_response.card,
+                    None,
+                    primary_card_brand_str,
+                ) {
+                    Ok(primary_data) => domain_data_list.push(primary_data),
+                    Err(error) => {
+                        logger::error!("Error converting primary Pagos card details: {:?}", error);
+                        return Err(error);
+                    }
+                }
+            }
+
+            if let Some(additional_brands) = &pagos_response.card.additional_card_brands {
+                for brand_info in additional_brands {
+                    if let Some(additional_card_brand_str) = &brand_info.card_brand {
+                        match try_convert_pagos_card_to_domain_data(
+                            &pagos_response.card,
+                            Some(brand_info),
+                            additional_card_brand_str,
+                        ) {
+                            Ok(additional_data) => domain_data_list.push(additional_data),
+                            Err(error) => {
+                                logger::error!("Error converting additional Pagos card details for brand {}: {:?}", additional_card_brand_str, error);
+                                return Err(error);
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(domain_data_list)
+        }
+        Err(error) => Err(error),
+    }
+}
 
 pub struct CoBadgedCardInfoList(Vec<types::CoBadgedCardInfoDomainData>);
 
@@ -130,79 +343,54 @@ impl CoBadgedCardInfoList {
 pub async fn get_co_badged_cards_info(
     app_state: &app::TenantAppState,
     card_isin: String,
-    acquirer_country: &types::CountryAlpha2,
 ) -> CustomResult<Option<types::CoBadgedCardInfoResponse>, error::ApiError> {
-    // pad the card number to 19 digits to match the co-badged card bin length
-    let card_number_str = CoBadgedCardInfoList::pad_card_number_to_19_digit(card_isin);
+    let use_api_lookup = app_state
+        .config
+        .pagos_api
+        .as_ref()
+        .map_or(false, |pc| pc.use_api_for_co_badged_lookup);
 
-    let parsed_number: i64 = card_number_str
-        .parse::<i64>()
-        .change_context(error::ApiError::UnknownError)
-        .attach_printable(
-            "Failed to convert card number to integer in co-badged cards info flow",
-        )?;
+    let co_badged_cards_data_result = if use_api_lookup {
+        logger::debug!("Fetching co-badged card info from Pagos API");
+        fetch_co_badged_info_from_pagos_api(app_state, &card_isin).await
+    } else {
+        logger::debug!("Fetching co-badged card info from DB");
+        let card_number_str = CoBadgedCardInfoList::pad_card_number_to_19_digit(card_isin.clone());
+        let parsed_number: i64 = card_number_str
+            .parse::<i64>()
+            .change_context(error::ApiError::UnknownError)
+            .attach_printable(
+                "Failed to convert card number to integer in co-badged cards info flow (DB path)",
+            )?;
+        fetch_co_badged_info_from_db(app_state, parsed_number).await
+    };
 
-    let co_badged_card_infos_record =
-        co_badged_card_info::find_co_badged_cards_info_by_card_bin(app_state, parsed_number).await;
-
-    let filtered_co_badged_card_info_list_optional = match co_badged_card_infos_record {
+    let co_badged_cards_data = match co_badged_cards_data_result {
+        Ok(data) => data,
         Err(error) => {
-            logger::error!(
-                "Error while fetching co-badged card info record: {:?}",
-                error
-            );
-            Err(error::ApiError::UnknownError)
-                .attach_printable("Error while fetching co-badged card info record")
+            logger::error!("Failed to fetch co-badged card info: {:?}", error);
+            return Err(error);
         }
-        Ok(co_badged_card_infos) => {
-            logger::debug!("Co-badged card info record retrieved successfully");
+    };
 
-            // Parse the co-badged card info records into domain data
-            let parsed_cards: Vec<types::CoBadgedCardInfoDomainData> = co_badged_card_infos
-                .into_iter()
-                .filter_map(|raw_co_badged_card_info| {
-                    match raw_co_badged_card_info.clone().try_into() {
-                        Ok(parsed) => Some(parsed),
-                        Err(error) => {
-                            logger::warn!(
-                                "Skipping co-badged card with card_network = {:?} due to error: {}",
-                                raw_co_badged_card_info.card_network,
-                                error
-                            );
-                            None
-                        }
-                    }
-                })
-                .collect();
+    if co_badged_cards_data.is_empty() {
+        logger::debug!("No co-badged card data found from the selected source.");
+        return Ok(None);
+    }
 
-            let co_badged_card_infos_list = CoBadgedCardInfoList(parsed_cards);
+    let co_badged_card_infos_list = CoBadgedCardInfoList(co_badged_cards_data);
 
-            let filtered_list_optional = co_badged_card_infos_list
-                .is_valid_length()
-                .then(|| {
-                    co_badged_card_infos_list
-                        .is_only_one_global_network_present()
-                        .then_some(co_badged_card_infos_list.filter_cards())
-                })
-                .flatten()
-                .and_then(|filtered_list| filtered_list.is_valid_length().then_some(filtered_list));
+    let filtered_list_optional = co_badged_card_infos_list
+        .is_valid_length()
+        .then(|| {
+            co_badged_card_infos_list
+                .is_only_one_global_network_present()
+                .then_some(co_badged_card_infos_list.filter_cards())
+        })
+        .flatten()
+        .and_then(|filtered_list| filtered_list.is_valid_length().then_some(filtered_list));
 
-            filtered_list_optional
-                .and_then(|filtered_list| {
-                    filtered_list
-                        .is_local_transaction(acquirer_country)
-                        .change_context(error::ApiError::UnknownError)
-                        .attach_printable(
-                            "Failed to check if the transaction is local or international",
-                        )
-                        .map(|is_local_transaction| is_local_transaction.then_some(filtered_list))
-                        .transpose()
-                })
-                .transpose()
-        }
-    }?;
-
-    let co_badged_cards_info_response = filtered_co_badged_card_info_list_optional
+    let co_badged_cards_info_response = filtered_list_optional
         .map(|filtered_list| filtered_list.get_co_badged_cards_info_response())
         .transpose()
         .attach_printable("Failed to construct co-badged card info response")?;

--- a/src/decider/network_decider/helpers.rs
+++ b/src/decider/network_decider/helpers.rs
@@ -107,7 +107,7 @@ impl types::CoBadgedCardRequest {
         }
 
         let card_isin = card_isin_optional?;
-        co_badged_card_info::get_co_badged_cards_info(app_state, card_isin, &self.acquirer_country)
+        co_badged_card_info::get_co_badged_cards_info(app_state, card_isin)
             .await
             .map_err(|error| {
                 logger::warn!(?error, "Failed to fetch co-badged card info");

--- a/src/decider/network_decider/types.rs
+++ b/src/decider/network_decider/types.rs
@@ -106,7 +106,6 @@ pub enum RegulatedName {
 
 #[derive(Debug, Clone)]
 pub struct CoBadgedCardInfoDomainData {
-    pub id: String,
     pub card_bin_min: i64,
     pub card_bin_max: i64,
     pub issuing_bank_name: Option<String>,
@@ -122,9 +121,6 @@ pub struct CoBadgedCardInfoDomainData {
     pub bin_provider_bin_length: i16,
     pub card_brand_is_additional: bool,
     pub domestic_only: Option<bool>,
-    pub created_at: time::PrimitiveDateTime,
-    pub modified_at: time::PrimitiveDateTime,
-    pub last_updated_provider: Option<String>,
 }
 
 impl CoBadgedCardInfoDomainData {
@@ -156,7 +152,6 @@ impl TryFrom<storage_types::CoBadgedCardInfo> for CoBadgedCardInfoDomainData {
         let parsed_network = db_co_badged_cards_info_record.get_parsed_card_network()?;
 
         Ok(Self {
-            id: db_co_badged_cards_info_record.id,
             card_bin_min: db_co_badged_cards_info_record.card_bin_min,
             card_bin_max: db_co_badged_cards_info_record.card_bin_max,
             issuing_bank_name: db_co_badged_cards_info_record.issuing_bank_name,
@@ -172,9 +167,6 @@ impl TryFrom<storage_types::CoBadgedCardInfo> for CoBadgedCardInfoDomainData {
             bin_provider_bin_length: db_co_badged_cards_info_record.bin_provider_bin_length,
             card_brand_is_additional: db_co_badged_cards_info_record.card_brand_is_additional,
             domestic_only: db_co_badged_cards_info_record.domestic_only,
-            created_at: db_co_badged_cards_info_record.created_at,
-            modified_at: db_co_badged_cards_info_record.modified_at,
-            last_updated_provider: db_co_badged_cards_info_record.last_updated_provider,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod logger;
 pub mod merchant_config_util;
 #[cfg(feature = "middleware")]
 pub mod middleware;
+pub mod pagos_client;
 pub mod redis;
 pub mod routes;
 pub mod storage;

--- a/src/pagos_client.rs
+++ b/src/pagos_client.rs
@@ -1,0 +1,127 @@
+use error_stack::ResultExt;
+use masking::ExposeInterface;
+use reqwest::header;
+
+use crate::{
+    app::TenantAppState,
+    error::ApiError,
+    logger,
+    types::pagos::PagosPanDetailsResponse,
+    utils::CustomResult,
+};
+
+type PagosClientResult<T> = Result<T, error_stack::Report<PagosClientError>>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PagosClientError {
+    #[error("HTTP request failed")]
+    NetworkError(#[from] reqwest::Error),
+    #[error("Failed to deserialize Pagos API response")]
+    DeserializationError(#[from] serde_json::Error),
+    #[error("Pagos API returned an error: {status} - {body}")]
+    ApiError {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+}
+
+#[derive(Clone)]
+pub struct PagosApiClient {
+    client: reqwest::Client,
+    base_url: String,
+    api_key: String,
+}
+
+impl PagosApiClient {
+    pub fn new(base_url: String, api_key: String) -> PagosClientResult<Self> {
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(PagosClientError::NetworkError)?;
+        Ok(Self {
+            client,
+            base_url,
+            api_key,
+        })
+    }
+
+    pub async fn get_pan_details(
+        &self,
+        bin_number: &str,
+    ) -> PagosClientResult<PagosPanDetailsResponse> {
+        let url = format!("{}/bins?enhanced=true&bin={}", self.base_url, bin_number);
+
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            "x-api-key",
+            header::HeaderValue::from_str(&self.api_key).map_err(|_| {
+                error_stack::Report::new(PagosClientError::ConfigError(
+                    "Invalid Pagos API key format".to_string(),
+                ))
+            })?,
+        );
+        headers.insert(
+            header::ACCEPT,
+            header::HeaderValue::from_static("application/json"),
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(PagosClientError::NetworkError)?;
+
+        if response.status().is_success() {
+            let body_text = response
+                .text()
+                .await
+                .map_err(PagosClientError::NetworkError)?;
+            logger::debug!(pagos_api_response_body = %body_text, "Pagos API successful response");
+            Ok(serde_json::from_str::<PagosPanDetailsResponse>(&body_text)
+                .map_err(PagosClientError::DeserializationError)?)
+        } else {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Failed to read error body".to_string());
+            logger::error!(pagos_api_error_status = %status, pagos_api_error_body = %body, "Pagos API error");
+            Err(error_stack::Report::new(PagosClientError::ApiError {
+                status,
+                body,
+            }))
+        }
+    }
+}
+
+pub async fn fetch_pan_details_internal(
+    app_state: &TenantAppState,
+    card_isin: &str,
+) -> CustomResult<PagosPanDetailsResponse, ApiError> {
+    let pagos_config = app_state
+        .config
+        .pagos_api
+        .as_ref()
+        .ok_or(error_stack::Report::new(
+            ApiError::ParsingError("Pagos API configuration not found"),
+        ))
+        .attach_printable(
+            "Pagos API configuration not found for tenant when fetching PAN details internally",
+        )?;
+
+    let pagos_client = PagosApiClient::new(
+        pagos_config.base_url.clone(),
+        pagos_config.api_key.clone().expose().clone(),
+    )
+    .change_context(ApiError::UnknownError)
+    .attach_printable("Failed to initialize Pagos API client during internal fetch")?;
+
+    pagos_client.get_pan_details(card_isin).await.map_err(|e| {
+        logger::error!(error = %e, card_isin = %card_isin, "Failed to fetch PAN details from Pagos internally");
+        error_stack::Report::new(ApiError::UnknownError)
+            .attach_printable(format!("Pagos client error: {:?}", e))
+    })
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@ pub mod bank_code;
 pub mod card;
 pub mod country;
 pub mod currency;
+pub mod pagos;
 pub mod customer;
 pub mod emi_bank_code;
 pub mod feature;

--- a/src/types/pagos.rs
+++ b/src/types/pagos.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+
+use crate::decider::network_decider::types::{CountryAlpha2, PanOrToken, RegulatedName};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PagosInterchangeDetails {
+    pub regulated: Option<bool>,
+    pub regulated_name: Option<RegulatedName>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PagosCostDetails {
+    pub interchange: Option<PagosInterchangeDetails>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub enum PagosCardType {
+    Credit,
+    Debit,
+    Prepaid,
+    Charge,
+    DeferredDebit,
+    #[serde(other)]
+    Unknown,
+}
+
+impl PagosCardType {
+    pub fn to_domain_card_type(&self) -> Option<crate::decider::network_decider::types::CardType> {
+        match self {
+            PagosCardType::Credit => Some(crate::decider::network_decider::types::CardType::Credit),
+            PagosCardType::Debit => Some(crate::decider::network_decider::types::CardType::Debit),
+            _ => None,
+        }
+    }
+}
+
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PagosCardDetails {
+    pub card_brand: Option<String>,
+    #[serde(rename = "type")]
+    pub card_type: Option<PagosCardType>,
+    pub card_level: Option<String>,
+    pub bank: Option<PagosBankDetails>,
+    pub country: Option<PagosCountryDetails>,
+    pub domestic_only: Option<bool>,
+    pub prepaid: Option<bool>,
+    pub additional_card_brands: Option<Vec<PagosAdditionalCardBrand>>,
+    pub correlation_id: Option<String>,
+    pub number: Option<PagosCardNumberDetails>,
+    pub bin_length: Option<i16>,
+    pub pagos_bin_length: Option<i16>,
+    pub bin_max: Option<String>,
+    pub bin_min: Option<String>,
+    pub pan_or_token: Option<PanOrToken>,
+    pub reloadable: Option<bool>,
+    pub shared_bin: Option<bool>,
+    pub cost: Option<PagosCostDetails>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PagosCardNumberDetails {
+    pub length: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PagosAdditionalCardBrand {
+    pub card_brand: Option<String>,
+    pub bin_max: Option<String>,
+    pub bin_min: Option<String>,
+    pub card_brand_product: Option<String>,
+    pub card_brand_bank_name: Option<String>,
+    pub ecom_enabled: Option<bool>,
+    pub billpay_enabled: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PagosBankDetails {
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PagosCountryDetails {
+    pub alpha2: Option<CountryAlpha2>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PagosPanDetailsResponse {
+    pub card: PagosCardDetails,
+}


### PR DESCRIPTION
Refactor: Enhance Co-Badged Card Info Lookup with Pagos API Option and Code Cleanup__

This PR introduces a configurable mechanism to fetch co-badged card information, allowing a switch between the existing database lookup and a new Pagos API integration. It also includes several code quality improvements and stricter error handling.
