### PR TITLE
feat: Implement Diesel Migrations for PostgreSQL and Helm Job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ init-local:
 	docker-compose run --rm db-migrator && docker-compose up --build open-router-local
 
 init-local-pg:
-	docker-compose run --rm db-migrator-postgres && docker-compose up --build open-router-local
+	docker-compose run --rm db-migrator-postgres && docker-compose up --build open-router-local-pg 
 
 run-local:
 	docker-compose up open-router-local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -195,6 +195,7 @@ services:
         condition: service_healthy
     environment:
       - PGPASSWORD=db_pass
+      - DATABASE_URL=postgresql://db_user:db_pass@postgresql:5432/decision_engine_db
     volumes:
       - .:/app
     working_dir: /app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,8 +56,39 @@ services:
     environment:
       - GROOVY_RUNNER_HOST=host.docker.internal:8085
 
+  open-router-local-pg:
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres
+      cache_from:
+        - decision-engine-open-router-local-pg:latest
+      labels:
+        - "com.docker.compose.watchfile=Dockerfile.postgres"
+        - "com.docker.compose.watchfile=src/"
+        - "com.docker.compose.watchfile=Cargo.toml"
+        - "com.docker.compose.watchfile=Cargo.lock"
+    image: decision-engine-open-router-local-pg:latest
+    platform: linux/amd64
+    container_name: open-router
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      groovy-runner-local:
+        condition: service_healthy
+    volumes:
+      - ./config/docker-configuration.toml:/local/config/development.toml
+    networks:
+      - open-router-network
+    environment:
+      - GROOVY_RUNNER_HOST=host.docker.internal:8085
+
   open-router-pg:
-    image: ghcr.io/juspay/decision-engine/postgres:b5a8f22
+    image: ghcr.io/juspay/decision-engine/postgres:v1.0.0
     pull_policy: always
     platform: linux/amd64
     container_name: open-router-pg 
@@ -69,8 +100,6 @@ services:
         condition: service_completed_successfully
       groovy-runner-local: 
         condition: service_healthy
-      routing-config:
-        condition: service_completed_successfully
     volumes:
       - ./config/docker-configuration.toml:/local/config/development.toml
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       - GROOVY_RUNNER_HOST=host.docker.internal:8085
 
   open-router-pg:
-    image: ghcr.io/juspay/decision-engine/postgres:e78b96d
+    image: ghcr.io/juspay/decision-engine/postgres:b5a8f22
     pull_policy: always
     platform: linux/amd64
     container_name: open-router-pg 
@@ -188,17 +188,17 @@ services:
       - open-router-network
   
   db-migrator-postgres:
-    image: postgres:latest
-    container_name: db-migrator
+    image: rust:latest
+    container_name: db-migrator 
     depends_on:
       postgresql:
         condition: service_healthy
-    volumes:
-      - ./migrations_pg/00000000000000_diesel_postgresql_initial_setup/up.sql:/app/migrations_pg/up.sql
-    working_dir: /app
     environment:
       - PGPASSWORD=db_pass
-    entrypoint: ["/bin/sh", "-c", "psql -h postgresql -U db_user -d decision_engine_db -f /app/migrations_pg/up.sql"]
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: "bash -c 'cargo install diesel_cli --no-default-features --features postgres && cargo install just && just migrate-pg'"
     networks:
       - open-router-network
 

--- a/helm-charts/templates/postgresql-migration-job.yaml
+++ b/helm-charts/templates/postgresql-migration-job.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: 6
   template:
@@ -42,26 +42,45 @@ spec:
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.postgresqlHost" . }} 5432; do echo waiting for postgresql; sleep 2; done;']
       containers:
         - name: migration
-          image: "postgres:15-alpine"
+          image: rust:latest
           imagePullPolicy: {{ .Values.dbMigration.postgresql.image.pullPolicy }}
           env:
             - name: PGPASSWORD
               value: {{ .Values.postgresql.auth.password | quote }}
+            - name: DATABASE_URL
+              value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include "decision-engine.postgresqlHost" . }}:5432/{{ .Values.postgresql.database }}
           command:
             - /bin/sh
             - -c
-            - |
-              # Download the SQL script and execute it
-              apk add curl
-              version={{ .Values.image.version }}
-              url="https://raw.githubusercontent.com/juspay/decision-engine/$version/migrations_pg/00000000000000_diesel_postgresql_initial_setup/up.sql"
-              curl -sSL $url -o /tmp/init.sql
-              if [ -f /tmp/init.sql ]; then
-                psql -h {{ include "decision-engine.postgresqlHost" . }} -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -f /tmp/init.sql
-              else
-                echo "Error: /tmp/init.sql not found"
-                exit 1
-              fi
+            - |-
+             version={{ .Values.image.version }}
+             echo "INFO: Starting migration process for version: $version"
+
+             DOWNLOAD_URL="https://github.com/juspay/decision-engine/refs/tags/$version.tar.gz"
+
+             echo "INFO: Downloading source code from $DOWNLOAD_URL"
+             # -L: follow redirects
+             # -f: fail script if server returns an error (e.g., 404). Requires "set -e".
+             # -sS: silent mode, but still show errors.
+             curl -LfsS -o decision-engine.tar.gz "$DOWNLOAD_URL"
+
+
+             tar -xzvf decision-engine.tar.gz --transform 's|[^/]*/|decision-engine/|'
+
+             echo "INFO: Changing directory to ./decision-engine"
+             cd decision-engine
+
+             echo "INFO: Contents of ./decision-engine (current directory):"
+             ls -la
+
+             echo "INFO: Installing tools (diesel_cli, just)..."
+             cargo install diesel_cli --no-default-features --features postgres
+             cargo install just
+
+             echo "INFO: Running database migrations using 'just migrate-pg'..."
+             just migrate-pg
+
+             echo "INFO: Migration job completed successfully."
           volumeMounts:
             - name: migration-script
               mountPath: /app/config

--- a/justfile
+++ b/justfile
@@ -84,13 +84,13 @@ default_db_url := 'postgresql://' + db_user + ':' + db_password + '@' + db_host 
 database_url := env_var_or_default('DATABASE_URL', default_db_url)
 default_migration_params := ''
 
-v1_migration_dir := source_directory() / 'migrations_pg'
-v1_config_file_dir := source_directory() / 'diesel_pg.toml'
+pg_migration_dir := source_directory() / 'migrations_pg'
+pg_config_file_dir := source_directory() / 'diesel_pg.toml'
 
 default_operation := 'run'
 
 [private]
-run_migration operation=default_operation migration_dir=v1_migration_dir config_file_dir=v1_config_file_dir url=database_url *other_params=default_migration_params:
+run_migration operation=default_operation migration_dir=pg_migration_dir config_file_dir=pg_config_file_dir url=database_url *other_params=default_migration_params:
     diesel migration \
         --database-url '{{ url }}' \
         {{ operation }} \
@@ -99,7 +99,7 @@ run_migration operation=default_operation migration_dir=v1_migration_dir config_
         {{ other_params }}
 
 # Run database migrations for postgres
-migrate-pg operation=default_operation *args='': (run_migration operation v1_migration_dir v1_config_file_dir database_url args)
+migrate-pg operation=default_operation *args='': (run_migration operation pg_migration_dir pg_config_file_dir database_url args)
 
 # Drop database if exists and then create a new 'hyperswitch_db' Database
 resurrect database_name=db_name:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,32 @@
+# Use the env variables if present, or fallback to default values
+
+db_user := env_var_or_default('DB_USER', 'db_user')
+db_password := env_var_or_default('DB_PASSWORD', 'db_pass')
+db_host := env_var_or_default('DB_HOST', 'postgresql')
+db_port := env_var_or_default('DB_PORT', '5432')
+db_name := env_var_or_default('DB_NAME', 'decision_engine_db')
+default_db_url := 'postgresql://' + db_user + ':' + db_password + '@' + db_host + ':' + db_port + '/' + db_name
+database_url := env_var_or_default('DATABASE_URL', default_db_url)
+default_migration_params := ''
+
+v1_migration_dir := source_directory() / 'migrations_pg'
+v1_config_file_dir := source_directory() / 'diesel_pg.toml'
+
+default_operation := 'run'
+
+[private]
+run_migration operation=default_operation migration_dir=v1_migration_dir config_file_dir=v1_config_file_dir url=database_url *other_params=default_migration_params:
+    diesel migration \
+        --database-url '{{ url }}' \
+        {{ operation }} \
+        --migration-dir '{{ migration_dir }}' \
+        --config-file '{{ config_file_dir }}' \
+        {{ other_params }}
+
+# Run database migrations for postgres
+migrate-pg operation=default_operation *args='': (run_migration operation v1_migration_dir v1_config_file_dir database_url args)
+
+# Drop database if exists and then create a new 'hyperswitch_db' Database
+resurrect database_name=db_name:
+    psql -U postgres -c 'DROP DATABASE IF EXISTS  {{ database_name }}';
+    psql -U postgres -c 'CREATE DATABASE {{ database_name }}';

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 
 db_user := env_var_or_default('DB_USER', 'db_user')
 db_password := env_var_or_default('DB_PASSWORD', 'db_pass')
-db_host := env_var_or_default('DB_HOST', 'postgresql')
+db_host := env_var_or_default('DB_HOST', 'localhost')
 db_port := env_var_or_default('DB_PORT', '5432')
 db_name := env_var_or_default('DB_NAME', 'decision_engine_db')
 default_db_url := 'postgresql://' + db_user + ':' + db_password + '@' + db_host + ':' + db_port + '/' + db_name

--- a/migrations_pg/00000000000000_diesel_postgresql_initial_setup/up.sql
+++ b/migrations_pg/00000000000000_diesel_postgresql_initial_setup/up.sql
@@ -54,7 +54,7 @@ CREATE TABLE merchant_priority_logic (
 DROP TABLE IF EXISTS tenant_config;
 CREATE TABLE tenant_config (
     id VARCHAR(255) PRIMARY KEY,
-    type VARCHAR(255) NOT NULL,
+    tenant_type VARCHAR(255) NOT NULL,
     module_key VARCHAR(255) NOT NULL,
     module_name VARCHAR(255) NOT NULL,
     tenant_account_id VARCHAR(255) NOT NULL,
@@ -111,15 +111,15 @@ CREATE TABLE gateway_payment_method_flow (
     gateway_bank_code TEXT,
     currency_configs TEXT,
     gateway_dsl TEXT,
-    non_combinable_flows TEXT,
-    country_code_alpha_3 TEXT,
+    non_combination_flows TEXT,
+    country_code_alpha3 TEXT,
     disabled BOOLEAN NOT NULL,
     payment_method_type TEXT
 );
 
 DROP TABLE IF EXISTS merchant_iframe_preferences;
 CREATE TABLE merchant_iframe_preferences (
-    id SERIAL PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
     merchant_id TEXT NOT NULL,
     dynamic_switching_enabled BOOLEAN,
     isin_routing_enabled BOOLEAN,
@@ -130,7 +130,7 @@ CREATE TABLE merchant_iframe_preferences (
 
 DROP TABLE IF EXISTS token_bin_info;
 CREATE TABLE token_bin_info (
-    token_bin TEXT NOT NULL,
+    token_bin TEXT PRIMARY KEY,
     card_bin TEXT NOT NULL,
     provider TEXT NOT NULL,
     date_created TIMESTAMP,
@@ -404,7 +404,7 @@ CREATE TABLE routing_algorithm (
     id VARCHAR(255) PRIMARY KEY,
     created_by VARCHAR(255) NOT NULL,
     name VARCHAR(255) NOT NULL,
-    description TEXT,
+    description TEXT NOT NULL,
     algorithm_data TEXT NOT NULL,
     metadata JSONB,
     created_at TIMESTAMP NOT NULL,

--- a/src/storage/schema_pg.rs
+++ b/src/storage/schema_pg.rs
@@ -153,11 +153,8 @@ diesel::table! {
         juspay_bank_code_id -> Nullable<Int8>,
         gateway_bank_code -> Nullable<Text>,
         currency_configs -> Nullable<Text>,
-        #[sql_name = "dsl"]
         gateway_dsl -> Nullable<Text>,
-        #[sql_name = "non_combinable_flows"]
         non_combination_flows -> Nullable<Text>,
-        #[sql_name = "country_code_alpha_3"]
         country_code_alpha3 -> Nullable<Text>,
         disabled -> Bool,
         payment_method_type -> Nullable<Text>,
@@ -333,7 +330,6 @@ diesel::table! {
         display_name -> Nullable<Text>,
         nick_name -> Nullable<Text>,
         sub_type -> Nullable<Text>,
-        #[sql_name = "dsl"]
         payment_dsl -> Nullable<Text>,
     }
 }
@@ -378,7 +374,6 @@ diesel::table! {
     tenant_config (id) {
         #[max_length = 255]
         id -> Varchar,
-        #[sql_name = "type"]
         #[max_length = 255]
         tenant_type -> Varchar,
         #[max_length = 255]


### PR DESCRIPTION
### Description

This PR integrates the migration process into both local development workflows (via just migrate-pg) and Kubernetes deployments (via the Helm chart). The addition of the just migrate-pg command provides a consistent way to manage PostgreSQL migrations.

__Migration Execution with `just` (`Justfile`):__

- Added a new recipe `migrate-pg` to the `Justfile`.
- This recipe utilizes `diesel_cli` to run PostgreSQL migrations located in the `migrations_pg/` directory, using `diesel_pg.toml` for configuration.
- The command effectively executed is `diesel migration run --migration-dir ./migrations_pg --config-file ./diesel_pg.toml`.

__Helm Chart for PostgreSQL Migrations (`helm-charts/templates/postgresql-migration-job.yaml`):__

- Introduced/Updated a Kubernetes Job definition within the Helm chart specifically for handling PostgreSQL database migrations.

- __Key operations within the job:__

  - Uses a `rust:latest` image.
  - Downloads the application source code corresponding to the deployed image version.
  - Installs `diesel_cli` (with PostgreSQL features) and `just`.
  - Executes the `just migrate-pg` command to apply the database migrations to the PostgreSQL instance.
  
 __Other  Changes:__

1. __`docker-compose.yaml`:__

   - Added a new service `open-router-local-pg`.

     - Builds using `Dockerfile.postgres`.
     - Includes cache from `decision-engine-open-router-local-pg:latest`.
     - Sets up watchfiles for `Dockerfile.postgres`, `src/`, `Cargo.toml`, and `Cargo.lock` to trigger rebuilds on changes.
     - Maps port `8080` to `8080`.
     - Depends on `postgresql`, `redis`, and `groovy-runner-local` services.
     - Mounts `./config/docker-configuration.toml` to `/local/config/development.toml` in the container.
     - Connects to the `open-router-network`.
     - Sets the `GROOVY_RUNNER_HOST` environment variable to `host.docker.internal:8085`.


2. __`Makefile`:__

   - Added a new target `init-local-pg`.

     - This command first runs database migrations using `docker-compose run --rm db-migrator-postgres`.
     - Then, it starts the `open-router-local-pg` service with a build step: `docker-compose up --build open-router-local-pg`.

### How do I test it

__Helm:__

<img width="1029" alt="Screenshot 2025-06-13 at 2 12 20 PM" src="https://github.com/user-attachments/assets/c6fa006c-54c2-462e-af1f-e6a557acdbbf" />

__open-router-local-pg (For local changes on docker):__

<img width="1028" alt="Screenshot 2025-06-13 at 2 25 56 PM" src="https://github.com/user-attachments/assets/56feba9f-ba35-4fa8-b163-5d0e13c3c72a" />

__open-router-pg (For running pre build image):__
<img width="1277" alt="Screenshot 2025-06-13 at 2 30 31 PM" src="https://github.com/user-attachments/assets/ceb433f3-35d0-4743-b36b-18379b5450fd" />

__open-router-pg (For running local changes on local postgres):__
<img width="1285" alt="Screenshot 2025-06-13 at 2 32 23 PM" src="https://github.com/user-attachments/assets/795fa304-1fbb-4946-8998-9b81dcebfc82" />
