### PR TITLE
chore(helm): update helm to v1.0.0

### DIFF
--- a/groovy.Dockerfile
+++ b/groovy.Dockerfile
@@ -1,23 +1,18 @@
 FROM ubuntu:focal
 
 RUN apt-get update \
-        && apt-get -y install tar cron zip software-properties-common curl
+        && apt-get -y install tar cron zip software-properties-common curl \
+        qemu-user-static binfmt-support
 
-RUN mkdir -p /usr/lib/jvm
+# Install OpenJDK 8 (works on both arm64 and amd64)
+RUN apt-get update && apt-get install -y openjdk-8-jdk
 
-RUN curl https://jp-build-packages-apsouth1.s3.ap-south-1.amazonaws.com/build-assets/jdk-7u71-linux-x64.tar.gz -o /usr/lib/jvm/jdk-7u71-linux-x64.tar.gz
-
-RUN cd /usr/lib/jvm \
-        && tar xfvz jdk-7u71-linux-x64.tar.gz \
-        && mv jdk1.7.0_71 java-7-oracle \
-        && rm jdk-7u71-linux-x64.tar.gz \
-        && mkdir -p /usr/java/ \
-        && ln -s /usr/lib/jvm/java-7-oracle /usr/java/jdk1.7.0 \
-        && ln -s /usr/java/jdk1.7.0 /usr/java/latest \
-        && ln -s /usr/java/jdk1.7.0 /usr/lib/jvm/default-java \
-        && ln -s /usr/java/jdk1.7.0/bin/java /usr/bin/java \
-        && ln -s /usr/java/jdk1.7.0 /usr/lib/java \
-        && apt clean
+# Set up Java environment
+RUN mkdir -p /usr/java/ \
+    && ln -s /usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture) /usr/java/jdk1.8.0 \
+    && ln -s /usr/java/jdk1.8.0 /usr/java/latest \
+    && ln -s /usr/java/jdk1.8.0 /usr/lib/jvm/default-java \
+    && apt clean
 
 ENV JAVA_HOME=/usr/java/latest
 

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -155,7 +155,7 @@ helm delete my-release
 | `dbMigration.enabled`                     | Enable database migration                                  | `true`          |
 | `dbMigration.postgresql.enabled`          | Enable PostgreSQL migration                                | `true`          |
 | `dbMigration.postgresql.image.repository` | PostgreSQL migration image repository                      | `"postgres"`    |
-| `dbMigration.postgresql.image.version`        | PostgreSQL migration image tag                             | `"latest"`      |
+| `dbMigration.postgresql.image.tag`        | PostgreSQL migration image tag                             | `"latest"`      |
 | `dbMigration.postgresql.image.pullPolicy` | PostgreSQL migration image pull policy                     | `"IfNotPresent"` |
 | `dbMigration.postgresql.migrations.path`  | PostgreSQL migrations path                                 | `"/app/migrations_pg"` |
 | `dbMigration.postgresql.initSqlScript`    | PostgreSQL initial SQL script                              | `"-- This will be the initial migration script"` |
@@ -167,7 +167,7 @@ helm delete my-release
 |------------------------------------------|------------------------------------------------------------|-----------------|
 | `routingConfig.enabled`                  | Enable routing config job                                  | `true`          |
 | `routingConfig.image.repository`         | Routing config image repository                            | `"python"`      |
-| `routingConfig.image.version`                | Routing config image tag                                   | `"3.10-slim"`   |
+| `routingConfig.image.tag`                | Routing config image tag                                   | `"3.10-slim"`   |
 | `routingConfig.image.pullPolicy`         | Routing config image pull policy                           | `"IfNotPresent"` |
 | `routingConfig.command`                  | Routing config command                                     | `["bash", "run_setup.sh"]` |
 | `routingConfig.configVolume.enabled`     | Enable routing config volume                               | `true`          |

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -78,7 +78,7 @@ helm delete my-release
 |---------------------|---------------------------------------------------------------------------------------|-----------------|
 | `replicaCount`      | Number of Decision Engine replicas                                                    | `1`             |
 | `image.repository`  | Decision Engine image repository                                                      | `decision-engine` |
-| `image.tag`         | Decision Engine image tag                                                             | `latest`        |
+| `image.version`         | Decision Engine image tag                                                             | `latest`        |
 | `image.pullPolicy`  | Decision Engine image pull policy                                                     | `Always`        |
 | `imagePullSecrets`  | Image pull secrets                                                                    | `[]`            |
 | `nameOverride`      | Override the name of the chart                                                        | `""`            |
@@ -137,7 +137,7 @@ helm delete my-release
 |-----------------------------------------|------------------------------------------------------------|-----------------|
 | `groovyRunner.enabled`                  | Deploy Groovy Runner                                       | `true`          |
 | `groovyRunner.image.repository`         | Groovy Runner image repository                             | `"groovy-runner"` |
-| `groovyRunner.image.tag`                | Groovy Runner image tag                                    | `"latest"`      |
+| `groovyRunner.image.version`                | Groovy Runner image tag                                    | `"latest"`      |
 | `groovyRunner.image.pullPolicy`         | Groovy Runner image pull policy                            | `"Always"`      |
 | `groovyRunner.service.port`             | Groovy Runner service port                                 | `8085`          |
 | `groovyRunner.resources`                | Groovy Runner resources                                    | `{}`            |
@@ -155,7 +155,7 @@ helm delete my-release
 | `dbMigration.enabled`                     | Enable database migration                                  | `true`          |
 | `dbMigration.postgresql.enabled`          | Enable PostgreSQL migration                                | `true`          |
 | `dbMigration.postgresql.image.repository` | PostgreSQL migration image repository                      | `"postgres"`    |
-| `dbMigration.postgresql.image.tag`        | PostgreSQL migration image tag                             | `"latest"`      |
+| `dbMigration.postgresql.image.version`        | PostgreSQL migration image tag                             | `"latest"`      |
 | `dbMigration.postgresql.image.pullPolicy` | PostgreSQL migration image pull policy                     | `"IfNotPresent"` |
 | `dbMigration.postgresql.migrations.path`  | PostgreSQL migrations path                                 | `"/app/migrations_pg"` |
 | `dbMigration.postgresql.initSqlScript`    | PostgreSQL initial SQL script                              | `"-- This will be the initial migration script"` |
@@ -167,7 +167,7 @@ helm delete my-release
 |------------------------------------------|------------------------------------------------------------|-----------------|
 | `routingConfig.enabled`                  | Enable routing config job                                  | `true`          |
 | `routingConfig.image.repository`         | Routing config image repository                            | `"python"`      |
-| `routingConfig.image.tag`                | Routing config image tag                                   | `"3.10-slim"`   |
+| `routingConfig.image.version`                | Routing config image tag                                   | `"3.10-slim"`   |
 | `routingConfig.image.pullPolicy`         | Routing config image pull policy                           | `"IfNotPresent"` |
 | `routingConfig.command`                  | Routing config command                                     | `["bash", "run_setup.sh"]` |
 | `routingConfig.configVolume.enabled`     | Enable routing config volume                               | `true`          |

--- a/helm-charts/templates/deployment.yaml
+++ b/helm-charts/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.version | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/helm-charts/templates/groovy-runner-deployment.yaml
+++ b/helm-charts/templates/groovy-runner-deployment.yaml
@@ -30,11 +30,8 @@ spec:
         - name: groovy-runner
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.groovyRunner.image.repository }}:{{ .Values.groovyRunner.image.tag | default "latest" }}"
+          image: "{{ .Values.groovyRunner.image.repository }}:{{ .Values.groovyRunner.image.version | default "latest" }}"
           imagePullPolicy: {{ .Values.groovyRunner.image.pullPolicy }}
-          {{- if .Values.groovyRunner.image.platform }}
-          platform: {{ .Values.groovyRunner.image.platform }}
-          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.groovyRunner.service.port }}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -5,8 +5,7 @@ image:
   # Updated to include the registry URL
   repository: ghcr.io/juspay/decision-engine/postgres
   pullPolicy: Always
-  version: "d35b018" 
-  tag: "d35b018-linux-arm64"
+  version: "v1.0.0"
 
 # Configure these if your images are in a private registry
 imagePullSecrets: 
@@ -151,9 +150,8 @@ groovyRunner:
   enabled: true
   image:
     repository: "ghcr.io/juspay/decision-engine/groovy-runner"
-    tag: "0a8cdc1"
+    version: "v1.0.0"
     pullPolicy: "Always"
-    platform: "linux/arm64"
   service:
     port: 8085
   resources: {}


### PR DESCRIPTION
This pull request introduces several changes to streamline Dockerfile configurations and Helm chart definitions. Key updates include replacing the `image.tag` field with `image.version` across Helm chart files for consistency and clarity, updating Dockerfile dependencies, and removing unused configurations.

### Dockerfile updates:
* [`groovy.Dockerfile`](diffhunk://#diff-b3c228b64b336d4f0bedd98ba46affa7441437803d3eab9d4e9bf72658759f34L4-R14): Added support for `arm64` architecture by installing `qemu-user-static` and `binfmt-support`. Removed outdated OpenJDK 7 installation steps and replaced them with OpenJDK 8 setup for better compatibility.

### Helm chart updates:
#### Field consistency:
* [`helm-charts/README.md`](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35L81-R81): Replaced `image.tag` with `image.version` in multiple sections (`Decision Engine`, `Groovy Runner`, `PostgreSQL migration`, and `Routing Config`) for clearer naming conventions. [[1]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35L81-R81) [[2]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35L140-R140) [[3]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35L158-R158) [[4]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35L170-R170)
* [`helm-charts/templates/deployment.yaml`](diffhunk://#diff-b6c344c351bbbd23ccfcc795720e7fb5a189770e68f1310623df4b69ca19acf2L51-R51): Updated the image reference to use `image.version` instead of `image.tag`.
* [`helm-charts/templates/groovy-runner-deployment.yaml`](diffhunk://#diff-4402b0733dff1270140ca8df5d9d30a08378818dd6bb76105a9b15fc07228ee0L33-L37): Updated the image reference to use `groovyRunner.image.version` and removed the `platform` field.

#### Version updates:
* [`helm-charts/values.yaml`](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fL8-R8): Updated `image.version` fields for `Decision Engine` and `Groovy Runner` to "v1.0.0" for better version management. Removed the `platform` field under `groovyRunner.image`. [[1]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fL8-R8) [[2]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fL154-L156)