### PR TITLE
feat: add mca_id support for euclid rules

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -5,7 +5,7 @@ log_format = "default"
 
 [server]
 host = "127.0.0.1"
-port = 8080
+port = 8082
 
 [limit]
 request_count = 1
@@ -59,7 +59,7 @@ metadata = {type = "udf"}
 pay_later = {type = "enum", values = "Affirm, Alma, AfterpayClearpay, Klarna, PayBright, Atome, Walley"}
 gift_card = {type = "enum", values = "Givex, PaySafeCard"}
 wallet = {type = "enum", values = "AmazonPay, ApplePay, GooglePay, Paypal, AliPay, AliPayHk, Dana, MbWay, MobilePay, SamsungPay, Twint, Vipps, TouchNGo, Swish, WeChatPay, GoPay, Gcash, Momo, KakaoPay, Cashapp, Mifinity, Paze"}
-upi = {type = "enum", values = "UpiCollect, UpiIntent"}
+upi = {type = "enum", values = "upi_collect, upi_intent"}
 voucher = {type = "enum", values = "Boleto, Efecty, PagoEfectivo, RedCompra, RedPagos, Indomaret, Alfamart, Oxxo, SevenEleven, Lawson, MiniStop, FamilyMart, Seicomart, PayEasy"}
 bank_transfer = {type = "enum", values = "Ach, SepaBankTransfer, Bacs, Multibanco, Pix, Pse, PermataBankTransfer, BcaBankTransfer, BniVa, BriVa, CimbVa, DanamonVa, MandiriVa, LocalBankTransfer, InstantBankTransfer"}
 bank_redirect = {type = "enum", values = "Giropay, Ideal, Sofort, Eft, Eps, BancontactCard, Blik, LocalBankRedirect, OnlineBankingThailand, OnlineBankingCzechRepublic, OnlineBankingFinland, OnlineBankingFpx, OnlineBankingPoland, OnlineBankingSlovakia, Przelewy24, Trustly, Bizum, Interac, OpenBankingUk, OpenBankingPIS"}

--- a/config/development.toml
+++ b/config/development.toml
@@ -5,7 +5,7 @@ log_format = "default"
 
 [server]
 host = "127.0.0.1"
-port = 8082
+port = 8080
 
 [limit]
 request_count = 1

--- a/src/euclid/ast.rs
+++ b/src/euclid/ast.rs
@@ -38,7 +38,7 @@ impl ValueType {
 
 /// Represents a number comparison for "NumberComparisonArrayValue"
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct NumberComparison {
     pub comparison_type: ComparisonType,
     pub number: u64,
@@ -58,7 +58,7 @@ pub enum ComparisonType {
 
 /// Represents a single comparison condition.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct Comparison {
     /// The left hand side which will always be a domain input identifier like "payment.method.cardtype"
     pub lhs: String,
@@ -91,7 +91,7 @@ pub type IfCondition = Vec<Comparison>;
 /// }
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct IfStatement {
     // #[schema(value_type=Vec<Comparison>)]
     pub condition: IfCondition,
@@ -113,7 +113,7 @@ pub struct IfStatement {
 /// }
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 // #[aliases(RuleConnectorSelection = Rule<ConnectorSelection>)]
 pub struct Rule {
     pub name: String,
@@ -133,18 +133,25 @@ pub enum RoutingType {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct VolumeSplit<T> {
     pub split: u8,
     pub output: T,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub enum Output {
-    Priority(Vec<String>),
-    VolumeSplit(Vec<VolumeSplit<String>>),
-    VolumeSplitPriority(Vec<VolumeSplit<Vec<String>>>),
+    Priority(Vec<ConnectorInfo>),
+    VolumeSplit(Vec<VolumeSplit<ConnectorInfo>>),
+    VolumeSplitPriority(Vec<VolumeSplit<Vec<ConnectorInfo>>>),
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ConnectorInfo {
+    pub connector: String,
+    pub mca_id: Option<String>,
 }
 
 pub type Globals = HashMap<String, HashSet<ValueType>>;
@@ -152,7 +159,7 @@ pub type Globals = HashMap<String, HashSet<ValueType>>;
 /// The program, having a default connector selection and
 /// a bunch of rules. Also can hold arbitrary metadata.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 // #[aliases(ProgramConnectorSelection = Program<ConnectorSelection>)]
 pub struct Program {
     pub globals: Globals,

--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -1,5 +1,5 @@
 use crate::euclid::{
-    ast::{self, ComparisonType, Output, ValueType},
+    ast::{self, ComparisonType, ConnectorInfo, Output, ValueType},
     cgraph,
     interpreter::InterpreterBackend,
     types::{
@@ -322,15 +322,15 @@ fn format_output(output: &Output) -> Value {
 fn perform_eligibility_analysis(
     constraint_graph: &cgraph::ConstraintGraph,
     ctx: cgraph::CheckCtx,
-    output: &[String],
-) -> Vec<String> {
-    let mut eligible_connectors = Vec::<String>::with_capacity(output.len());
+    output: &[ConnectorInfo],
+) -> Vec<ConnectorInfo> {
+    let mut eligible_connectors = Vec::<ConnectorInfo>::with_capacity(output.len());
 
     for out in output {
         let clause = cgraph::Clause {
             key: "output".to_string(),
             comparison: ComparisonType::Equal,
-            value: ValueType::EnumVariant(out.clone()),
+            value: ValueType::EnumVariant(out.connector.clone()),
         };
 
         if let Ok(true) = constraint_graph.check_clause_validity(clause, &ctx) {

--- a/src/euclid/interpreter.rs
+++ b/src/euclid/interpreter.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
+use super::ast::ConnectorInfo;
+
 pub struct InterpreterBackend {
     _program: ast::Program,
 }
@@ -174,7 +176,7 @@ impl fmt::Display for RoutingError {
 impl Error for RoutingError {}
 type RoutingResult<T> = Result<T, RoutingError>;
 
-pub fn perform_volume_split(splits: Vec<VolumeSplit<String>>) -> RoutingResult<String> {
+pub fn perform_volume_split(splits: Vec<VolumeSplit<ConnectorInfo>>) -> RoutingResult<ConnectorInfo> {
     let weights: Vec<u8> = splits.iter().map(|sp| sp.split).collect();
     let weighted_index =
         WeightedIndex::new(weights).map_err(|_| RoutingError::VolumeSplitFailed)?;
@@ -187,8 +189,8 @@ pub fn perform_volume_split(splits: Vec<VolumeSplit<String>>) -> RoutingResult<S
 }
 
 pub fn perform_volume_split_priority(
-    splits: Vec<VolumeSplit<Vec<String>>>,
-) -> RoutingResult<Vec<String>> {
+    splits: Vec<VolumeSplit<Vec<ConnectorInfo>>>,
+) -> RoutingResult<Vec<ConnectorInfo>> {
     let weights: Vec<u8> = splits.iter().map(|sp| sp.split).collect();
     let weighted_index =
         WeightedIndex::new(weights).map_err(|_| RoutingError::VolumeSplitFailed)?;
@@ -200,7 +202,7 @@ pub fn perform_volume_split_priority(
         .ok_or(RoutingError::VolumeSplitFailed)
 }
 
-pub fn evaluate_output(output: &Output) -> RoutingResult<(Vec<String>, Vec<String>)> {
+pub fn evaluate_output(output: &Output) -> RoutingResult<(Vec<ConnectorInfo>, Vec<ConnectorInfo>)> {
     match output {
         Output::Priority(connectors) => {
             let first_connector = connectors.first().cloned();

--- a/src/euclid/types.rs
+++ b/src/euclid/types.rs
@@ -10,6 +10,7 @@ use std::{collections::HashMap, fmt, ops::Deref};
 use crate::storage::schema;
 #[cfg(feature = "postgres")]
 use crate::storage::schema_pg;
+use super::ast::ConnectorInfo;
 use super::utils::generate_random_id;
 
 pub type Metadata = HashMap<String, serde_json::Value>;
@@ -46,7 +47,7 @@ pub struct RoutingRequest {
 pub struct BackendOutput {
     pub rule_name: Option<String>,
     pub output: Output,
-    pub evaluated_output: Vec<String>,
+    pub evaluated_output: Vec<ConnectorInfo>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -77,8 +78,8 @@ impl RoutingDictionaryRecord {
 pub struct RoutingEvaluateResponse {
     pub status: String,
     pub output: serde_json::Value,
-    pub evaluated_output: Vec<String>,
-    pub eligible_connectors: Vec<String>,
+    pub evaluated_output: Vec<ConnectorInfo>,
+    pub eligible_connectors: Vec<ConnectorInfo>,
 }
 
 // #[derive(AsChangeset, Debug, Clone, Identifiable, Insertable, Queryable, Selectable)]

--- a/src/euclid/types.rs
+++ b/src/euclid/types.rs
@@ -32,9 +32,20 @@ pub struct RoutingRule {
     pub name: String,
     pub description: String,
     pub created_by: String,
-    pub algorithm: Program,
+    pub algorithm: StaticRoutingAlgorithm,
     #[serde(default)]
     pub metadata: Option<serde_json::Value>,
+}
+
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(
+    tag = "type",
+    content = "data",
+    rename_all = "snake_case",
+)]
+pub enum StaticRoutingAlgorithm {
+    Advanced(Program),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]

--- a/src/euclid/types.rs
+++ b/src/euclid/types.rs
@@ -104,7 +104,7 @@ pub struct RoutingAlgorithm {
     pub description: String,
     // #[cfg(feature = "mysql")]
     pub algorithm_data: String,
-    // #[cfg(feature = "postgres")]  
+    // #[cfg(feature = "postgres")]
     // pub algorithm_data: serde_json::Value,
     #[cfg(feature = "postgres")]
     pub metadata: Option<serde_json::Value>,

--- a/src/euclid/utils.rs
+++ b/src/euclid/utils.rs
@@ -1,5 +1,6 @@
 use super::ast::{Comparison, ComparisonType, IfStatement, Rule, ValueType};
 use super::errors::EuclidErrors;
+use super::types::StaticRoutingAlgorithm;
 use crate::euclid::types::{KeyConfig, TomlConfig, RoutingRule};
 use crate::error::{ApiError, ContainerError};
 use std::collections::HashMap;
@@ -62,6 +63,27 @@ pub fn get_keys_by_type(config: &TomlConfig) -> HashMap<String, Vec<String>> {
     result
 }
 
+// pub fn validate_routing_rule(
+//     rule: &RoutingRule,
+//     config: &Option<TomlConfig>,
+// ) -> Result<(), ContainerError<EuclidErrors>> {
+//     let config = config
+//         .clone()
+//         .ok_or_else(|| error_stack::report!(EuclidErrors::GlobalRoutingConfigsUnavailable))?;
+//
+//     let mut errors = Vec::new();
+//
+//     for rule in &rule.algorithm {
+//         validate_rule(rule, &config, &mut errors);
+//     }
+//
+//     if errors.is_empty() {
+//         Ok(())
+//     } else {
+//         Err(EuclidErrors::FailedToValidateRoutingRule.into())
+//     }
+// }
+
 pub fn validate_routing_rule(
     rule: &RoutingRule,
     config: &Option<TomlConfig>,
@@ -70,9 +92,13 @@ pub fn validate_routing_rule(
         .clone()
         .ok_or_else(|| error_stack::report!(EuclidErrors::GlobalRoutingConfigsUnavailable))?;
 
+    let program = match &rule.algorithm {
+        StaticRoutingAlgorithm::Advanced(p) => p,
+    };
+
     let mut errors = Vec::new();
 
-    for rule in &rule.algorithm.rules {
+    for rule in &program.rules {
         validate_rule(rule, &config, &mut errors);
     }
 

--- a/src/euclid/utils.rs
+++ b/src/euclid/utils.rs
@@ -63,27 +63,6 @@ pub fn get_keys_by_type(config: &TomlConfig) -> HashMap<String, Vec<String>> {
     result
 }
 
-// pub fn validate_routing_rule(
-//     rule: &RoutingRule,
-//     config: &Option<TomlConfig>,
-// ) -> Result<(), ContainerError<EuclidErrors>> {
-//     let config = config
-//         .clone()
-//         .ok_or_else(|| error_stack::report!(EuclidErrors::GlobalRoutingConfigsUnavailable))?;
-//
-//     let mut errors = Vec::new();
-//
-//     for rule in &rule.algorithm {
-//         validate_rule(rule, &config, &mut errors);
-//     }
-//
-//     if errors.is_empty() {
-//         Ok(())
-//     } else {
-//         Err(EuclidErrors::FailedToValidateRoutingRule.into())
-//     }
-// }
-
 pub fn validate_routing_rule(
     rule: &RoutingRule,
     config: &Option<TomlConfig>,
@@ -105,7 +84,13 @@ pub fn validate_routing_rule(
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(EuclidErrors::FailedToValidateRoutingRule.into())
+        let detailed_message = errors.join("; ");
+        crate::logger::error!("Routing rule validation failed with errors: {detailed_message}");
+        Err(EuclidErrors::InvalidRequest(format!(
+            "Routing rule validation failed: {}",
+            detailed_message
+        ))
+        .into())
     }
 }
 


### PR DESCRIPTION
## Description

This PR introduces support for `mca_id` (Merchant Connector Account ID) in Euclid rule evaluation. It enriches the routing logic by allowing routing outputs (like connectors) to carry optional metadata such as `mca_id` alongside the connector name.

### Key enhancements:
- Introduced a new struct `ConnectorInfo` with fields:  
  - `connector: String`  
  - `mca_id: Option<String>`
- Replaced all usages of plain `String` for connectors in the `Output` enum with `ConnectorInfo`.
- Updated logic in routing evaluation functions to work with `ConnectorInfo` instead of raw connector strings.
- Aligned serialization strategy across AST structures to use `snake_case`.

## Outcomes

- Enables precise routing decisions based on both connector name and associated metadata (`mca_id`).
- Prepares the routing engine for fine-grained control per merchant account connector configuration.
- Ensures that volume split, priority, and fallback logic work consistently with rich connector metadata.
- Increases clarity and maintainability of routing logic through structured data.

## Diff Hunk Explanation

### Modified files and changes:

- **`src/euclid/ast.rs`**
  - Replaced connector strings in `Output` with `ConnectorInfo`.
  - Added `ConnectorInfo` struct.
  - Changed serde naming convention to `snake_case`.

- **`src/euclid/handlers/routing_rules.rs`**
  - Refactored `perform_eligibility_analysis` to use `ConnectorInfo`.
  - Logic now filters based on `connector` field inside `ConnectorInfo`.

- **`src/euclid/interpreter.rs`**
  - Updated `perform_volume_split`, `perform_volume_split_priority`, and `evaluate_output` to work with `ConnectorInfo`.

- **`src/euclid/types.rs`**
  - Updated `BackendOutput` and `RoutingEvaluateResponse` to return `Vec<ConnectorInfo>` instead of `Vec<String>`.

> 🔧 Total Changes:
- ~33 additions
- ~23 deletions
