### PR TITLE
refactor(debit_routing): add `saving_percentage` for each network

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -189,7 +189,7 @@ fraud_check_fee = 0.01
 
 [debit_routing_config.network_fee]
 visa = { percentage = 0.1375, fixed_amount = 0.020 }
-mastercard = { percentage = 0.15, fixed_amount = 0.40 }
+mastercard = { percentage = 0.15, fixed_amount = 0.040 }
 accel = { percentage = 0.0, fixed_amount = 0.040 }
 nyce = { percentage = 0.10, fixed_amount = 0.015 }
 pulse = { percentage = 0.10, fixed_amount = 0.03 }

--- a/config/docker-configuration.toml
+++ b/config/docker-configuration.toml
@@ -170,7 +170,7 @@ fraud_check_fee = 0.01
 
 [debit_routing_config.network_fee]
 visa = { percentage = 0.1375, fixed_amount = 0.020 }
-mastercard = { percentage = 0.15, fixed_amount = 0.40 }
+mastercard = { percentage = 0.15, fixed_amount = 0.040 }
 accel = { percentage = 0.0, fixed_amount = 0.040 }
 nyce = { percentage = 0.10, fixed_amount = 0.015 }
 pulse = { percentage = 0.10, fixed_amount = 0.03 }

--- a/src/decider/network_decider/debit_routing.rs
+++ b/src/decider/network_decider/debit_routing.rs
@@ -1,5 +1,3 @@
-use error_stack::ResultExt;
-
 use crate::app::get_tenant_app_state;
 use crate::decider::gatewaydecider::{
     types as gateway_decider_types, utils as gateway_decider_utils,

--- a/src/decider/network_decider/helpers.rs
+++ b/src/decider/network_decider/helpers.rs
@@ -86,8 +86,7 @@ impl types::CoBadgedCardRequest {
         logger::debug!("Total fees per debit network: {:?}", network_costs);
         network_costs.sort_by(|(_, fee1), (_, fee2)| fee1.total_cmp(fee2));
 
-        let network_saving_infos =
-            Self::calculate_network_saving_infos(network_costs, amount)?;
+        let network_saving_infos = Self::calculate_network_saving_infos(network_costs, amount)?;
 
         Some(types::DebitRoutingOutput {
             co_badged_card_networks_info: network_saving_infos,

--- a/src/decider/network_decider/helpers.rs
+++ b/src/decider/network_decider/helpers.rs
@@ -94,7 +94,7 @@ impl types::CoBadgedCardRequest {
         let network_saving_infos = Self::calculate_network_saving_infos(network_costs, amount);
 
         Some(types::DebitRoutingOutput {
-            co_badged_card_networks: network_saving_infos,
+            co_badged_card_networks_info: network_saving_infos,
             issuer_country: co_badged_card_info.issuer_country,
             is_regulated: co_badged_card_info.is_regulated,
             regulated_name: co_badged_card_info.regulated_name,

--- a/src/decider/network_decider/types.rs
+++ b/src/decider/network_decider/types.rs
@@ -253,7 +253,7 @@ pub struct NetworkSavingInfo {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct DebitRoutingOutput {
-    pub co_badged_card_networks: Vec<NetworkSavingInfo>,
+    pub co_badged_card_networks_info: Vec<NetworkSavingInfo>,
     pub issuer_country: CountryAlpha2,
     pub is_regulated: bool,
     pub regulated_name: Option<RegulatedName>,

--- a/src/decider/network_decider/types.rs
+++ b/src/decider/network_decider/types.rs
@@ -245,14 +245,19 @@ crate::impl_to_sql_from_sql_text_pg!(PanOrToken);
 #[cfg(feature = "postgres")]
 crate::impl_to_sql_from_sql_text_pg!(CountryAlpha2);
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct NetworkSavingInfo {
+    pub network: gatewaydecider::types::NETWORK,
+    pub saving_percentage: f64,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct DebitRoutingOutput {
-    pub co_badged_card_networks: Vec<gatewaydecider::types::NETWORK>,
+    pub co_badged_card_networks: Vec<NetworkSavingInfo>,
     pub issuer_country: CountryAlpha2,
     pub is_regulated: bool,
     pub regulated_name: Option<RegulatedName>,
     pub card_type: CardType,
-    pub saving_percentage: f64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]


### PR DESCRIPTION
This pull requests adds `saving_percentage` for each of the card network in the response.

# Api request:
```
curl --location 'http://localhost:3030/decide-gateway' \
--header 'Content-Type: application/json' \
--header 'x-merchantid: hyperswitchTest' \
--data '{           
        "merchantId": "pro_681OnbogtHJ2QG6B4WP1",
        "eligibleGatewayList": ["ADYEN"],
        "rankingAlgorithm": "NTW_BASED_ROUTING",
        "eliminationEnabled": true,
        "paymentInfo": {
            "paymentId": "PAY12402",
            "amount": 5,
            "currency": "USD",
            "customerId": "CUST12345",
            "udfs": null,
            "preferredGateway": null,
            "paymentType": "ORDER_PAYMENT",
            "metadata": "{\"merchant_category_code\":\"merchant_category_code_0001\",\"acquirer_country\":\"US\"}",
            "internalMetadata": null,
            "isEmi": false,
            "emiBank": null,
            "emiTenure": null,
            "paymentMethodType": "CARD",
            "paymentMethod": "VISA",
            "paymentSource": null,
            "authType": null,
            "cardIssuerBankName": null,
            "cardIsin": "500251",
            "cardType": null,
            "cardSwitchProvider": null
        }
}'
```
```
{
    "decided_gateway": "ADYEN",
    "gateway_priority_map": null,
    "filter_wise_gateways": null,
    "priority_logic_tag": null,
    "routing_approach": "NONE",
    "gateway_before_evaluation": null,
    "priority_logic_output": null,
    "debit_routing_output": {
        "co_badged_card_networks": [
            {
                "network": "ACCEL",
                "saving_percentage": 9.65
            },
            {
                "network": "STAR",
                "saving_percentage": 7.77
            },
            {
                "network": "MASTERCARD",
                "saving_percentage": 0.0
            }
        ],
        "issuer_country": "US",
        "is_regulated": false,
        "regulated_name": "GOVERNMENT EXEMPT INTERCHANGE FEE",
        "card_type": "debit"
    },
    "reset_approach": "NO_RESET",
    "routing_dimension": null,
    "routing_dimension_level": null,
    "is_scheduled_outage": false,
    "is_dynamic_mga_enabled": false,
    "gateway_mga_id_map": null
}
```