### PR TITLE
refactor: rename mca_id to gateway id

### DIFF
--- a/src/euclid/ast.rs
+++ b/src/euclid/ast.rs
@@ -150,8 +150,8 @@ pub enum Output {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ConnectorInfo {
-    pub connector: String,
-    pub mca_id: Option<String>,
+    pub gateway_name: String,
+    pub gateway_id: Option<String>,
 }
 
 pub type Globals = HashMap<String, HashSet<ValueType>>;

--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -357,7 +357,7 @@ fn perform_eligibility_analysis(
         let clause = cgraph::Clause {
             key: "output".to_string(),
             comparison: ComparisonType::Equal,
-            value: ValueType::EnumVariant(out.connector.clone()),
+            value: ValueType::EnumVariant(out.gateway_name.clone()),
         };
 
         if let Ok(true) = constraint_graph.check_clause_validity(clause, &ctx) {


### PR DESCRIPTION
## Description

This PR renames the `mca_id` field to `gateway_id` and introduces a new required field `gateway_name` in the `ConnectorInfo` struct used across routing rules in the Euclid decision engine. This change aims to improve naming clarity and better align field semantics with gateway-level identification.

### Key updates:
- In `ConnectorInfo`:
  - Replaced `mca_id` with `gateway_id`.
  - Added `gateway_name` as a required field.
- Updated all constraint-check logic to use `gateway_name` instead of `connector`.

## Outcomes

- Clarifies field naming by distinguishing between merchant connector account (`mca_id`) and actual gateway (`gateway_id`).
- Enables cleaner constraint logic and future compatibility with gateway-specific configurations.
- Improves readability and intent of rule evaluation logic in `perform_eligibility_analysis`.

## Diff Hunk Explanation

### Modified files and changes:

- **`src/euclid/ast.rs`**
  - `ConnectorInfo` struct:
    - Removed: `mca_id: Option<String>`
    - Added: `gateway_id: Option<String>`
    - Added: `gateway_name: String`

- **`src/euclid/handlers/routing_rules.rs`**
  - Updated clause generation in `perform_eligibility_analysis` to match against `gateway_name` instead of `connector`.

> ✅ Total Changes:
- **+3 additions**, **−3 deletions**
- **Files changed**: 2
