### PR TITLE
feat: implement graceful shutdown for metrics server on SIGTERM

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -109,8 +109,6 @@ where
         logger::error!("SIGTERM signal received, shutting down...");
         let app_state = APP_STATE.get().expect("GlobalAppState not set");
         app_state.set_not_ready(); // Set readiness flag to false
-                                   // Wait for 60 seconds before shutting down
-        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
         handle_clone.shutdown(); // Trigger axum_server shutdown
     });
 


### PR DESCRIPTION
## Problem Identified

- The main application server and metrics server had conflicting signal handlers
- The main server listened only for SIGTERM, the metrics server only for SIGINT (Ctrl+C)
- No coordination between servers during shutdown

## Solution

- Build metrics server with SIGTERM

##Current 

![image](https://github.com/user-attachments/assets/0e2b41c5-6af5-45e9-9a4f-f7c2c704b8fa)
Not able to close both the servers

## New
![image](https://github.com/user-attachments/assets/d3c5d92f-4812-48e0-9b41-34959a5d051f)


