### PR TITLE
refactor: add fallback output check for evaluate request

### DIFF
--- a/src/decider/gatewaydecider/flows.rs
+++ b/src/decider/gatewaydecider/flows.rs
@@ -657,7 +657,9 @@ pub async fn runDeciderFlow(
                             is_scheduled_outage: decider_flow.writer.isScheduledOutage,
                             is_dynamic_mga_enabled: decider_flow.writer.is_dynamic_mga_enabled,
                             gateway_mga_id_map: Some(gatewayMgaIdMap),
-                            is_rust_based_decider: deciderParams.dpShouldConsumeResult.unwrap_or(false),
+                            is_rust_based_decider: deciderParams
+                                .dpShouldConsumeResult
+                                .unwrap_or(false),
                         }),
                         None => Err((
                             decider_flow.writer.debugFilterList.clone(),


### PR DESCRIPTION
## Description
This change makes the fallback hierarchy as follows:
Don't check configs if fallback is present in the evaluate request, return it if rule fails.

--> if fallback present in both evaluate request and in rule:
------> output the evalue fallback output

