### PR TITLE
Changes for tenant_config parse error

### DIFF
--- a/src/merchant_config_util.rs
+++ b/src/merchant_config_util.rs
@@ -45,7 +45,7 @@ use crate::{
             },
         },
         payment_flow::{payment_flows_to_text, PaymentFlow},
-        tenant::tenant_config::{ConfigType, ModuleName},
+        tenant::tenant_config::{ConfigType, ModuleName, TenantConfigValueType, TenantConfigStatus},
         tenant_config::{
             get_arr_active_tenant_config_by_tenant_id_module_name_module_key_and_arr_type,
             get_arr_active_tenant_config_by_tenant_id_module_name_module_key_and_arr_type_and_country,
@@ -544,10 +544,11 @@ pub async fn isPaymentFlowEnabledWithHierarchyCheck(
 }
 
 fn checkIfEnabledByTenant(config_value: &str, error_tag: &str) -> bool {
-    let config_status = to_config_status(config_value);
-    match config_status {
-        Ok(ConfigStatus::ENABLED) => true,
-        Ok(ConfigStatus::DISABLED) => false,
+    let result: Result<TenantConfigValueType<Value>, _> = serde_json::from_str(config_value);
+    match result {
+        Ok(config) => {
+            config.status == TenantConfigStatus::ENABLED
+        },
         Err(e) => {
             logger::error!(action = error_tag, tag = error_tag, "Error: {}", e);
             false

--- a/src/types/tenant/tenant_config.rs
+++ b/src/types/tenant/tenant_config.rs
@@ -112,6 +112,22 @@ pub fn text_to_filter_dimension(filter_dimension: String) -> Result<FilterDimens
     }
 }
 
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TenantConfigStatus {
+    #[serde(rename = "ENABLED")]
+    ENABLED,
+    #[serde(rename = "DISABLED")]
+    DISABLED,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TenantConfigValueType<T> {
+    pub status: TenantConfigStatus,
+    #[serde(rename = "configValue")]
+    pub config_value: Option<T>,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ConfigStatus {
     #[serde(rename = "ACTIVE")]


### PR DESCRIPTION
Changes for tenant_config parse error that we were getting during fallback when merchant_config is not found.

"message": "Error: Parsing error: Invalid ConfigStatus",