### PR TITLE
feat: Add local prometheus setup for metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,13 @@ init-local:
 	docker-compose run --rm db-migrator && docker-compose up --build open-router-local
 
 init-local-pg:
-	docker-compose run --rm db-migrator-postgres && docker-compose up --build open-router-local-pg 
+	docker-compose run --rm db-migrator-postgres && docker-compose up --build open-router-local-pg
+
+init-local-pg-monitor:
+	docker-compose run --rm db-migrator-postgres && docker-compose up --build -d prometheus && docker-compose up --build -d grafana && docker-compose up --build open-router-local-pg
+
+init-pg-monitor:
+	docker-compose run --rm db-migrator-postgres && docker-compose up --build -d prometheus && docker-compose up --build -d grafana && docker-compose up --build open-router-pg
 
 run-local:
 	docker-compose up open-router-local

--- a/config/development.toml
+++ b/config/development.toml
@@ -9,7 +9,7 @@ port = 8080
 
 [metrics]
 host = "127.0.0.1"
-port = 9090
+port = 9094
 
 [limit]
 request_count = 1

--- a/config/docker-configuration.toml
+++ b/config/docker-configuration.toml
@@ -9,7 +9,7 @@ port = 8080
 
 [metrics]
 host = "0.0.0.0"
-port = 9090
+port = 9094
 
 [limit]
 request_count = 1

--- a/config/grafana-datasource.yaml
+++ b/config/grafana-datasource.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Metrics
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090/
+    editable: true

--- a/config/prometheus.yaml
+++ b/config/prometheus.yaml
@@ -1,0 +1,30 @@
+# my global config
+global:
+  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# alter manager if required
+# Alertmanager configuration
+# alerting:
+#   alertmanagers:
+#     - static_configs:
+#         - targets:
+#         - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: "open-router"
+
+    metrics_path: /metrics
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["open-router-pg:9094"] # this can be replaced by open-router-local-pg for local setup

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,7 +73,7 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-      - "9090:9090"
+      - "9094:9094"
     depends_on:
       postgresql:
         condition: service_healthy
@@ -96,7 +96,7 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-      - "9090:9090"
+      - "9094:9094"
     depends_on:
       db-migrator-postgres: 
         condition: service_completed_successfully
@@ -108,6 +108,31 @@ services:
       - open-router-network
     environment:
       - GROOVY_RUNNER_HOST=host.docker.internal:8085
+
+  prometheus:
+    image: prom/prometheus:latest
+    networks:
+      - open-router-network
+    volumes:
+      - ./config/prometheus.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    networks:
+      - open-router-network
+    restart: unless-stopped
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    volumes:
+      # - ./config/grafana.ini:/etc/grafana/grafana.ini
+      - ./config/grafana-datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yml
 
   groovy-runner:
     image: ghcr.io/juspay/open-router/groovy-runner:main


### PR DESCRIPTION
Have added docker compose setup for metrics. This includes prometheus which scraps from the `/metrics` endpoint and grafana setup to query from prometheus. 

<img width="1414" height="896" alt="image" src="https://github.com/user-attachments/assets/0f7f414e-7093-4b22-a582-60fb00fbb0bf" />
