### PR TITLE
fixed three_ds_2 to three_ds

### DIFF
--- a/src/decider/gatewaydecider/gw_filter.rs
+++ b/src/decider/gatewaydecider/gw_filter.rs
@@ -1858,6 +1858,14 @@ pub async fn filterGatewaysCardInfo(
     m_validation_type: Option<ETGCI::ValidationType>,
 ) -> Result<Vec<GatewayCardInfo>, ErrorResponse> {
     let appState = this.state().clone();
+
+    fn normalize_auth_type(auth_type: &str) -> String {
+        match auth_type.to_uppercase().as_str() {
+            "THREE_DS_2" => "THREE_DS".to_string(),
+            other => other.to_string(),
+        }
+    }
+
     if !enabled_gateways.is_empty()
         && card_bins.iter().all(|bin| bin.is_some())
         && (m_auth_type.is_some() || m_validation_type.is_some())
@@ -1893,13 +1901,11 @@ pub async fn filterGatewaysCardInfo(
                         ci.gateway.is_some()
                             && merchant_wise_mandate_supported_gateway_prime.contains(&ci.gateway)
                             && ci.validationType == Some(ETGCI::ValidationType::CardMandate)
-                            && ci
-                                .authType
-                                .clone()
-                                .unwrap_or_else(|| "THREE_DS".to_string())
-                                == auth_type_to_text(
-                                    &m_auth_type.clone().unwrap_or(AuthType::THREE_DS),
-                                )
+                            && normalize_auth_type(
+                                &ci.authType.clone().unwrap_or_else(|| "THREE_DS".to_string()),
+                            ) == normalize_auth_type(&auth_type_to_text(
+                                &m_auth_type.clone().unwrap_or(AuthType::THREE_DS),
+                            ))
                     })
                     .collect::<Vec<_>>()
             } else {
@@ -1918,13 +1924,11 @@ pub async fn filterGatewaysCardInfo(
                     .into_iter()
                     .filter(|ci| {
                         (ci.validationType == Some(ETGCI::ValidationType::CardMandate)
-                            && ci
-                                .authType
-                                .clone()
-                                .unwrap_or_else(|| "THREE_DS".to_string())
-                                == auth_type_to_text(
-                                    &m_auth_type.clone().unwrap_or(AuthType::THREE_DS),
-                                ))
+                            && normalize_auth_type(
+                                &ci.authType.clone().unwrap_or_else(|| "THREE_DS".to_string()),
+                            ) == normalize_auth_type(&auth_type_to_text(
+                                &m_auth_type.clone().unwrap_or(AuthType::THREE_DS),
+                            )))
                     })
                     .collect::<Vec<GatewayCardInfo>>();
 


### PR DESCRIPTION
Modify the decider code to support both THREE_DS and THREE_DS2 during gateway selection for card mandates.