### PR TITLE
Debit routing/update config

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -206,7 +206,7 @@ regulated = { percentage = 0.05, fixed_amount = 0.21 }
 [debit_routing_config.interchange_fee.non_regulated]
 merchant_category_code_0001.visa = { percentage = 1.65, fixed_amount = 15.0 }
 merchant_category_code_0001.mastercard = { percentage = 1.65, fixed_amount = 15.0 }
-merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 4 }
+merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 4.0 }
 merchant_category_code_0001.nyce = { percentage = 1.30, fixed_amount = 21.3125 }
 merchant_category_code_0001.pulse = { percentage = 1.60, fixed_amount = 15.0 }
 merchant_category_code_0001.star = { percentage = 1.63, fixed_amount = 15.0 }

--- a/config/development.toml
+++ b/config/development.toml
@@ -190,23 +190,23 @@ pred = 1
 succ = 3
 
 [debit_routing_config]
-fraud_check_fee = 0.01
+fraud_check_fee = 1.0
 
 [debit_routing_config.network_fee]
-visa = { percentage = 0.1375, fixed_amount = 0.020 }
-mastercard = { percentage = 0.15, fixed_amount = 0.040 }
-accel = { percentage = 0.0, fixed_amount = 0.040 }
-nyce = { percentage = 0.10, fixed_amount = 0.015 }
-pulse = { percentage = 0.10, fixed_amount = 0.03 }
-star = { percentage = 0.10, fixed_amount = 0.015 }
+visa = { percentage = 0.1375, fixed_amount = 2.0 }
+mastercard = { percentage = 0.15, fixed_amount = 4.0 }
+accel = { percentage = 0.0, fixed_amount = 4.0 }
+nyce = { percentage = 0.10, fixed_amount = 1.5 }
+pulse = { percentage = 0.10, fixed_amount = 3.0 }
+star = { percentage = 0.10, fixed_amount = 1.5 }
 
 [debit_routing_config.interchange_fee]
 regulated = { percentage = 0.05, fixed_amount = 0.21 }
 
 [debit_routing_config.interchange_fee.non_regulated]
-merchant_category_code_0001.visa = { percentage = 1.65, fixed_amount = 0.15 }
-merchant_category_code_0001.mastercard = { percentage = 1.65, fixed_amount = 0.15 }
-merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 0.04 }
-merchant_category_code_0001.nyce = { percentage = 1.30, fixed_amount = 0.213125 }
-merchant_category_code_0001.pulse = { percentage = 1.60, fixed_amount = 0.15 }
-merchant_category_code_0001.star = { percentage = 1.63, fixed_amount = 0.15 }
+merchant_category_code_0001.visa = { percentage = 1.65, fixed_amount = 15.0 }
+merchant_category_code_0001.mastercard = { percentage = 1.65, fixed_amount = 15.0 }
+merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 4 }
+merchant_category_code_0001.nyce = { percentage = 1.30, fixed_amount = 21.3125 }
+merchant_category_code_0001.pulse = { percentage = 1.60, fixed_amount = 15.0 }
+merchant_category_code_0001.star = { percentage = 1.63, fixed_amount = 15.0 }

--- a/config/docker-configuration.toml
+++ b/config/docker-configuration.toml
@@ -183,7 +183,7 @@ regulated = { percentage = 0.05, fixed_amount = 0.21 }
 [debit_routing_config.interchange_fee.non_regulated]
 merchant_category_code_0001.visa = { percentage = 1.65, fixed_amount = 15.0 }
 merchant_category_code_0001.mastercard = { percentage = 1.65, fixed_amount = 15.0 }
-merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 4 }
+merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 4.0 }
 merchant_category_code_0001.nyce = { percentage = 1.30, fixed_amount = 21.3125 }
 merchant_category_code_0001.pulse = { percentage = 1.60, fixed_amount = 15.0 }
 merchant_category_code_0001.star = { percentage = 1.63, fixed_amount = 15.0 }

--- a/config/docker-configuration.toml
+++ b/config/docker-configuration.toml
@@ -167,23 +167,24 @@ pred = 1
 succ = 3
 
 [debit_routing_config]
-fraud_check_fee = 0.01
+fraud_check_fee = 1.0
 
 [debit_routing_config.network_fee]
-visa = { percentage = 0.1375, fixed_amount = 0.020 }
-mastercard = { percentage = 0.15, fixed_amount = 0.040 }
-accel = { percentage = 0.0, fixed_amount = 0.040 }
-nyce = { percentage = 0.10, fixed_amount = 0.015 }
-pulse = { percentage = 0.10, fixed_amount = 0.03 }
-star = { percentage = 0.10, fixed_amount = 0.015 }
+visa = { percentage = 0.1375, fixed_amount = 2.0 }
+mastercard = { percentage = 0.15, fixed_amount = 4.0 }
+accel = { percentage = 0.0, fixed_amount = 4.0 }
+nyce = { percentage = 0.10, fixed_amount = 1.5 }
+pulse = { percentage = 0.10, fixed_amount = 3.0 }
+star = { percentage = 0.10, fixed_amount = 1.5 }
 
 [debit_routing_config.interchange_fee]
 regulated = { percentage = 0.05, fixed_amount = 0.21 }
 
 [debit_routing_config.interchange_fee.non_regulated]
-merchant_category_code_0001.visa = { percentage = 1.65, fixed_amount = 0.15 }
-merchant_category_code_0001.mastercard = { percentage = 1.65, fixed_amount = 0.15 }
-merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 0.04 }
-merchant_category_code_0001.nyce = { percentage = 1.30, fixed_amount = 0.213125 }
-merchant_category_code_0001.pulse = { percentage = 1.60, fixed_amount = 0.15 }
-merchant_category_code_0001.star = { percentage = 1.63, fixed_amount = 0.15 }
+merchant_category_code_0001.visa = { percentage = 1.65, fixed_amount = 15.0 }
+merchant_category_code_0001.mastercard = { percentage = 1.65, fixed_amount = 15.0 }
+merchant_category_code_0001.accel = { percentage = 1.55, fixed_amount = 4 }
+merchant_category_code_0001.nyce = { percentage = 1.30, fixed_amount = 21.3125 }
+merchant_category_code_0001.pulse = { percentage = 1.60, fixed_amount = 15.0 }
+merchant_category_code_0001.star = { percentage = 1.63, fixed_amount = 15.0 }
+


### PR DESCRIPTION
This pull request updates debit routing fee configurations in both the `config/development.toml` and `config/docker-configuration.toml` files. The primary changes are significant increases to various fixed fee values for fraud checks, network fees, and interchange fees for different card networks and merchant categories.

Configuration changes to debit routing fees:

* Increased the `fraud_check_fee` from `0.01` to `1.0`. [[1]](diffhunk://#diff-eeba5fd66f2753499ebdfe068ce07b9712c29d509dbd25e20eae2df0648c5c4eL193-R212) [[2]](diffhunk://#diff-b258bb4b0ba900066cf48ab880d0f175a7d474bf257ca6a7f011b9b2ecb275d9L170-R190)
* Updated the `network_fee` fixed amounts for all card networks (Visa, Mastercard, Accel, Nyce, Pulse, Star), raising values from fractions of a dollar to whole dollar or higher amounts. [[1]](diffhunk://#diff-eeba5fd66f2753499ebdfe068ce07b9712c29d509dbd25e20eae2df0648c5c4eL193-R212) [[2]](diffhunk://#diff-b258bb4b0ba900066cf48ab880d0f175a7d474bf257ca6a7f011b9b2ecb275d9L170-R190)
* Increased the `interchange_fee.non_regulated` fixed amounts for merchant category code 0001 across all networks, changing values from cents to much higher dollar amounts. [[1]](diffhunk://#diff-eeba5fd66f2753499ebdfe068ce07b9712c29d509dbd25e20eae2df0648c5c4eL193-R212) [[2]](diffhunk://#diff-b258bb4b0ba900066cf48ab880d0f175a7d474bf257ca6a7f011b9b2ecb275d9L170-R190)