### PR TITLE
 fix: remove not needed parentheses to fix all rustc(unused_parens)

### DIFF
--- a/src/decider/gatewaydecider/flow_new.rs
+++ b/src/decider/gatewaydecider/flow_new.rs
@@ -42,7 +42,7 @@ use crate::types::txn_details::types as ETTD;
 
 pub async fn deciderFullPayloadHSFunction(
     dreq_: T::DomainDeciderRequestForApiCallV2,
-) -> Result<(T::DecidedGateway), T::ErrorResponse> {
+) -> Result<T::DecidedGateway, T::ErrorResponse> {
     let merchant_account =
         ETM::merchant_account::load_merchant_by_merchant_id(dreq_.merchantId.clone())
             .await
@@ -148,7 +148,7 @@ pub async fn runDeciderFlow(
     rankingAlgorithm: Option<RankingAlgorithm>,
     eliminationEnabled: Option<bool>,
     is_legacy_decider_flow: bool,
-) -> Result<(T::DecidedGateway), T::ErrorResponse> {
+) -> Result<T::DecidedGateway, T::ErrorResponse> {
     let txnCreationTime = deciderParams
         .dpTxnDetail
         .dateCreated
@@ -168,7 +168,7 @@ pub async fn runDeciderFlow(
         deciderParams.dpMerchantAccount.clone(),
     )
     .await;
-    let (functionalGateways) = deciderParams
+    let functionalGateways = deciderParams
         .dpEnforceGatewayList
         .clone()
         .unwrap_or_default();
@@ -536,7 +536,7 @@ pub async fn runDeciderFlow(
         .unwrap_or_default();
     updated_gateway_scoring_data;
     match dResult {
-        Ok(result) => Ok((result)),
+        Ok(result) => Ok(result),
         Err((
             debugFilterList,
             _,

--- a/src/decider/gatewaydecider/gw_filter.rs
+++ b/src/decider/gatewaydecider/gw_filter.rs
@@ -599,7 +599,7 @@ fn validateMga(
         Utils::is_seamless(mga)
     } else if isMandateRegister(mTxnObjType.clone()) {
         Utils::is_subscription(mga)
-    } else if (isEmandateRegister(mTxnObjType) && !is_otm_flow) {
+    } else if isEmandateRegister(mTxnObjType) && !is_otm_flow {
         Utils::is_emandate_enabled(mga)
     } else {
         !Utils::is_only_subscription(mga)
@@ -1871,14 +1871,14 @@ pub async fn filterGatewaysCardInfo(
                     .await
                     .into_iter()
                     .filter(|ci| {
-                        (ci.validationType == Some(ETGCI::ValidationType::CardMandate)
+                        ci.validationType == Some(ETGCI::ValidationType::CardMandate)
                             && ci
                                 .authType
                                 .clone()
                                 .unwrap_or_else(|| "THREE_DS".to_string())
                                 == auth_type_to_text(
                                     &m_auth_type.clone().unwrap_or(AuthType::ThreeDs),
-                                ))
+                                )
                     })
                     .collect::<Vec<GatewayCardInfo>>();
 

--- a/src/decider/gatewaydecider/gw_scoring.rs
+++ b/src/decider/gatewaydecider/gw_scoring.rs
@@ -2637,7 +2637,7 @@ pub async fn update_gateway_score_based_on_success_rate(
                 // };
 
                 let reset_gw_list = decider_flow.writer.resetGatewayList.clone();
-                if (!reset_gw_list.is_empty()) {
+                if !reset_gw_list.is_empty() {
                     trigger_reset_gateway_score(
                         decider_flow,
                         gateway_success_rate_inputs,

--- a/src/decider/gatewaydecider/utils.rs
+++ b/src/decider/gatewaydecider/utils.rs
@@ -1131,7 +1131,7 @@ pub async fn get_card_info_by_bin(card_bin: Option<String>) -> Option<ETCa::card
             let bin_list = if bin.len() > 6 {
                 (6..=9)
                     .filter(|&len| len <= bin.len())
-                    .map(|len| (ETCa::isin::to_isin(bin[..len].to_string())))
+                    .map(|len| ETCa::isin::to_isin(bin[..len].to_string()))
                     .collect()
             } else {
                 vec![(ETCa::isin::to_isin(bin))]
@@ -2864,7 +2864,7 @@ pub async fn get_penality_factor_(decider_flow: &mut DeciderFlow<'_>) -> f64 {
         let m_reward_factor =
             eliminationV2RewardFactor(&merchant_id, &txn_card_info, &txn_detail).await;
         match m_reward_factor {
-            Some(reward_factor) => return (1.0 - reward_factor),
+            Some(reward_factor) => return 1.0 - reward_factor,
             None => {
                 return getPenaltyFactor(ScoreKeyType::EliminationMerchantKey).await;
             }

--- a/src/feedback/gateway_elimination_scoring/flow.rs
+++ b/src/feedback/gateway_elimination_scoring/flow.rs
@@ -450,11 +450,11 @@ pub async fn getUpdatedMerchantDetailsForGlobalKey(
                 if filtered_merchant_details_array.is_empty() {
                     let arr_max_length = getMerchantArrMaxLength().await;
                     if merchant_details_array.len() as i32 >= arr_max_length {
-                        return (Some(merchant_details_array));
+                        return Some(merchant_details_array);
                     } else {
                         let merchant_detail =
                             getDefaultMerchantScoringDetailsArray(merchant_id, 1.0, 1, None);
-                        return (Some([merchant_details_array, vec![merchant_detail]].concat()));
+                        return Some([merchant_details_array, vec![merchant_detail]].concat());
                     }
                 } else {
                     let mut results = Vec::new();
@@ -475,11 +475,11 @@ pub async fn getUpdatedMerchantDetailsForGlobalKey(
             None => {
                 let merchant_scoring_details =
                     getDefaultMerchantScoringDetailsArray(merchant_id, 1.0, 1, None);
-                return (Some(vec![merchant_scoring_details]));
+                return Some(vec![merchant_scoring_details]);
             }
         }
     } else {
-        return (None);
+        return None;
     }
 }
 
@@ -506,13 +506,13 @@ pub async fn replaceTransactionCount(
         } else {
             merchant_scoring_details.transactionCount
         };
-        (MerchantScoringDetails {
+        MerchantScoringDetails {
             score: updated_score,
             transactionCount: new_count,
             ..merchant_scoring_details
-        })
+        }
     } else {
-        (merchant_scoring_details)
+        merchant_scoring_details
     }
 }
 

--- a/src/feedback/gateway_selection_scoring_v3/flow.rs
+++ b/src/feedback/gateway_selection_scoring_v3/flow.rs
@@ -75,15 +75,15 @@ pub async fn updateSrV3Score(
     gateway_reference_id: Option<String>,
 ) {
     // let is_merchant_enabled_globally = MC::isMerchantEnabledForPaymentFlows(merchant_acc.id, [PF::SrBasedRouting].to_vec()).await;
-    match (txn_detail.gateway.clone()) {
-        (None) => {
+    match txn_detail.gateway.clone() {
+        None => {
             logger::info!(
                 action = "gateway not found",
                 tag = "gateway not found",
                 "gateway not found for this transaction having id"
             );
         }
-        (Some(gateway)) => {
+        Some(gateway) => {
             let unified_sr_v3_key = getProducerKey(
                 txn_detail.clone(),
                 mb_gateway_scoring_data,


### PR DESCRIPTION
Fixes #144 and #147 

All `rustc(unused_parens)` warnings are removed.

No `clippy::double_parens` shown:

```
cargo clippy -- -A warnings -W clippy::double_parens
   Compiling open_router v0.1.3 (/home/andre/projects/decision-engine)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.05s
```

Btw there is no `clippy::unnecessary_parentheses`