### PR TITLE
fix: all rustc warnings elided_lifetimes_in_path

### DIFF
--- a/src/decider/gatewaydecider/gw_filter.rs
+++ b/src/decider/gatewaydecider/gw_filter.rs
@@ -66,7 +66,7 @@ where
     v_mut
 }
 
-pub fn getGws(this: &mut DeciderFlow) -> Vec<String> {
+pub fn getGws(this: &mut DeciderFlow<'_>) -> Vec<String> {
     this.writer.functionalGateways.clone()
 }
 
@@ -80,7 +80,7 @@ fn makeFirstLetterSmall(s: String) -> String {
 }
 
 pub fn returnGwListWithLog(
-    this: &mut DeciderFlow,
+    this: &mut DeciderFlow<'_>,
     fName: DeciderFilterName,
     doOrNot: bool,
 ) -> Vec<String> {
@@ -127,7 +127,7 @@ where
 }
 
 pub fn setGwsAndMgas(
-    this: &mut DeciderFlow,
+    this: &mut DeciderFlow<'_>,
     filteredMgas: Vec<ETM::merchant_gateway_account::MerchantGatewayAccount>,
 ) {
     Utils::set_mgas(this, filteredMgas.clone());
@@ -136,7 +136,7 @@ pub fn setGwsAndMgas(
 }
 
 /// Sets the functional gateways in the DeciderFlow and updates related merchant gateway accounts
-pub fn setGws(this: &mut DeciderFlow, gws: Vec<String>) {
+pub fn setGws(this: &mut DeciderFlow<'_>, gws: Vec<String>) {
     // Get the merchant gateway accounts
     let m_mgas = Utils::get_mgas(this);
 
@@ -406,7 +406,7 @@ pub async fn getFunctionalGateways(this: &mut DeciderFlow<'_>) -> GatewayList {
 }
 
 fn validateAndSetDynamicMGAFlag(
-    this: &mut DeciderFlow,
+    this: &mut DeciderFlow<'_>,
     proceed_with_all_mgas: bool,
     mgas: &Vec<ETM::merchant_gateway_account::MerchantGatewayAccount>,
 ) {
@@ -424,7 +424,7 @@ fn validateAndSetDynamicMGAFlag(
 }
 
 pub fn filterMGAsByEnforcedPaymentFlows(
-    this: &mut DeciderFlow,
+    this: &mut DeciderFlow<'_>,
     initial_mgas: Vec<ETM::merchant_gateway_account::MerchantGatewayAccount>,
 ) -> Vec<ETM::merchant_gateway_account::MerchantGatewayAccount> {
     // Extract unique gateways from the merchant gateway accounts
@@ -1793,7 +1793,7 @@ where
 /// Determines if a merchant gateway account matches the provided gateway reference ID
 /// Used for gateway reference ID based routing
 pub fn predicate(
-    this: &mut DeciderFlow,
+    this: &mut DeciderFlow<'_>,
     mga: ETM::merchant_gateway_account::MerchantGatewayAccount,
     gw: String,
     metadata: HashMap<String, String>,
@@ -2809,7 +2809,7 @@ pub fn validate_only_one_mga(
 
 /// Filters gateways for EMI tenure-specific merchant gateway accounts
 /// Keeps only gateways that support the specific EMI tenure requested in the transaction
-pub fn filterForEMITenureSpecificMGAs(this: &mut DeciderFlow) -> Vec<String> {
+pub fn filterForEMITenureSpecificMGAs(this: &mut DeciderFlow<'_>) -> Vec<String> {
     // Get transaction details from context
     let txn_detail = this.get().dpTxnDetail.clone();
 
@@ -3082,7 +3082,7 @@ fn getTxnTypeSupportedGateways(
 /// Filters gateways and merchant gateway accounts based on UPI payment flow support
 /// Checks both V2 integration and UPI intent capabilities
 pub fn filterGatewaysForUpiPayBasedOnSupportedFlow(
-    this: &mut DeciderFlow,
+    this: &mut DeciderFlow<'_>,
     gws: Vec<String>,
     mgas: Vec<MerchantGatewayAccount>,
     v2_integration_not_supported_gateways: Vec<String>,

--- a/src/decider/gatewaydecider/types.rs
+++ b/src/decider/gatewaydecider/types.rs
@@ -297,7 +297,7 @@ struct GatewayScoringTypeLogVisitor;
 impl<'de> serde::de::Visitor<'de> for GatewayScoringTypeLogVisitor {
     type Value = AValue;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("struct GatewayScoringTypeLog")
     }
 

--- a/src/decider/network_decider/utils.rs
+++ b/src/decider/network_decider/utils.rs
@@ -22,7 +22,9 @@ macro_rules! impl_to_sql_from_sql_text_mysql {
         impl ::diesel::deserialize::FromSql<::diesel::sql_types::Text, ::diesel::mysql::Mysql>
             for $type
         {
-            fn from_sql(value: ::diesel::mysql::MysqlValue) -> ::diesel::deserialize::Result<Self> {
+            fn from_sql(
+                value: ::diesel::mysql::MysqlValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
                 use ::core::str::FromStr;
                 let s = ::core::str::from_utf8(value.as_bytes())?;
                 <$type>::from_str(s).map_err(|_| "Unrecognized enum variant".into())

--- a/src/types/card/txn_card_info.rs
+++ b/src/types/card/txn_card_info.rs
@@ -39,7 +39,7 @@ pub enum AuthType {
 }
 
 impl std::fmt::Display for AuthType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ATMPIN => write!(f, "ATMPIN"),
             Self::THREE_DS => write!(f, "THREE_DS"),


### PR DESCRIPTION
Fixes #145 

Added `<'_>` where it was needed to fix rustc "elided-lifetimes-in-paths" warnings.

Its not a clippy warning.

Checked by calling:
`cargo rustc --lib -- -A warnings -D elided_lifetimes_in_paths`

-A warnings → disable all warnings (allow)

-D elided_lifetimes_in_paths → treat this lint as an error