### PR TITLE
fix: remove all rustc dead_code warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -111,17 +111,6 @@ pub struct TenantSecrets {
     pub schema: String,
 }
 
-fn deserialize_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let deserialized_str: String = serde::Deserialize::deserialize(deserializer)?;
-
-    let deserialized_str = deserialized_str.into_bytes();
-
-    Ok(deserialized_str)
-}
-
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct TenantsSecrets(HashMap<String, TenantSecrets>);
 

--- a/src/decider/gatewaydecider/flow_new.rs
+++ b/src/decider/gatewaydecider/flow_new.rs
@@ -563,6 +563,7 @@ pub async fn runDeciderFlow(
     }
 }
 
+#[allow(dead_code)]
 fn getGatewayToMGAIdMapF(allMgas: &Vec<MerchantGatewayAccount>, gateways: &Vec<String>) -> AValue {
     json!(gateways
         .iter()
@@ -660,38 +661,6 @@ async fn filterFunctionalGatewaysWithEnforcment(
 //         Some(f) => f.to_lowercase().collect::<String>() + chars.as_str(),
 //     }
 // }
-
-fn defaultDecidedGateway(
-    gw: String,
-    gpm: Option<AValue>,
-    priorityLogicTag: Option<String>,
-    finalDeciderApproach: T::GatewayDeciderApproach,
-    topGatewayBeforeSRDowntimeEvaluation: Option<String>,
-    priorityLogicOutput: Option<T::GatewayPriorityLogicOutput>,
-    resetApproach: T::ResetApproach,
-    routingDimension: Option<String>,
-    routingDimensionLevel: Option<String>,
-    isScheduledOutage: bool,
-    isDynamicMGAEnabled: bool,
-) -> T::DecidedGateway {
-    T::DecidedGateway {
-        decided_gateway: gw,
-        gateway_priority_map: gpm,
-        filter_wise_gateways: None,
-        priority_logic_tag: priorityLogicTag,
-        routing_approach: finalDeciderApproach,
-        gateway_before_evaluation: topGatewayBeforeSRDowntimeEvaluation,
-        priority_logic_output: priorityLogicOutput,
-        debit_routing_output: None,
-        reset_approach: resetApproach,
-        routing_dimension: routingDimension,
-        routing_dimension_level: routingDimensionLevel,
-        is_scheduled_outage: isScheduledOutage,
-        is_dynamic_mga_enabled: isDynamicMGAEnabled,
-        gateway_mga_id_map: None,
-        is_rust_based_decider: true,
-    }
-}
 
 // async fn addMetricsToStream(
 //     decidedGateway: Option<&Gateway>,

--- a/src/decider/gatewaydecider/flows.rs
+++ b/src/decider/gatewaydecider/flows.rs
@@ -840,39 +840,6 @@ async fn filterFunctionalGatewaysWithEnforcment(
 //     }
 // }
 
-fn defaultDecidedGateway(
-    gw: String,
-    gpm: Option<AValue>,
-    priorityLogicTag: Option<String>,
-    finalDeciderApproach: T::GatewayDeciderApproach,
-    topGatewayBeforeSRDowntimeEvaluation: Option<String>,
-    priorityLogicOutput: Option<T::GatewayPriorityLogicOutput>,
-    resetApproach: T::ResetApproach,
-    routingDimension: Option<String>,
-    routingDimensionLevel: Option<String>,
-    isScheduledOutage: bool,
-    isDynamicMGAEnabled: bool,
-    gatewayMgaIdMap: Option<AValue>,
-) -> T::DecidedGateway {
-    T::DecidedGateway {
-        decided_gateway: gw,
-        gateway_priority_map: gpm,
-        filter_wise_gateways: None,
-        priority_logic_tag: priorityLogicTag,
-        routing_approach: finalDeciderApproach,
-        gateway_before_evaluation: topGatewayBeforeSRDowntimeEvaluation,
-        priority_logic_output: priorityLogicOutput,
-        debit_routing_output: None,
-        reset_approach: resetApproach,
-        routing_dimension: routingDimension,
-        routing_dimension_level: routingDimensionLevel,
-        is_scheduled_outage: isScheduledOutage,
-        is_dynamic_mga_enabled: isDynamicMGAEnabled,
-        gateway_mga_id_map: gatewayMgaIdMap,
-        is_rust_based_decider: true,
-    }
-}
-
 // async fn addMetricsToStream(
 //     decidedGateway: Option<&Gateway>,
 //     finalDeciderApproach: T::RoutingApproach,

--- a/src/decider/gatewaydecider/types.rs
+++ b/src/decider/gatewaydecider/types.rs
@@ -565,9 +565,11 @@ pub struct GatewayScoringData {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct MetricsStreamKeyShard(String, i32);
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct MetricsStreamKey(String);
 
 // # TODO - Implement RedisKey for MetricsStreamKeyShard

--- a/src/feedback/gateway_selection_scoring_v3/flow.rs
+++ b/src/feedback/gateway_selection_scoring_v3/flow.rs
@@ -292,28 +292,6 @@ pub async fn updateScoreAndQueue(
     }
 }
 
-fn debugBlock(
-    txn_detail: TxnDetail,
-    current_time: String,
-    date_created: String,
-    value: String,
-) -> SrV3DebugBlock {
-    SrV3DebugBlock {
-        txn_uuid: txn_detail.txnUuid,
-        order_id: txn_detail.orderId.0,
-        date_created,
-        current_time,
-        txn_status: value,
-    }
-}
-
-fn getStatus(maybe_popped_status_block: Option<SrV3DebugBlock>, popped_status: String) -> String {
-    match maybe_popped_status_block {
-        Some(popped_status_block) => popped_status_block.txn_status.clone(),
-        None => popped_status,
-    }
-}
-
 //Original Haskell function: getSrV3MerchantBucketSize
 pub async fn getSrV3MerchantBucketSize(txn_detail: TxnDetail, txn_card_info: TxnCardInfo) -> i32 {
     let merchant_sr_v3_input_config: Option<SrV3InputConfig> = findByNameFromRedis(

--- a/src/logger/formatter.rs
+++ b/src/logger/formatter.rs
@@ -31,7 +31,6 @@ use tracing_subscriber::{
 
 // Implicit keys
 
-const MESSAGE: &str = "message";
 const HOSTNAME: &str = "hostname";
 const PID: &str = "pid";
 const LEVEL: &str = "level";
@@ -91,6 +90,7 @@ impl fmt::Display for RecordType {
 /// `FormattingLayer` relies on the `tracing_bunyan_formatter::JsonStorageLayer` which is storage of entries.
 ///
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct FormattingLayer<W>
 where
     W: for<'a> MakeWriter<'a> + 'static,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -71,9 +71,6 @@ pub type MysqlPool = bb8::Pool<MysqlPooledConn>;
 #[cfg(feature = "postgres")]
 type DeadPoolConnType = Object<AsyncPgConnection>;
 
-#[cfg(feature = "mysql")]
-type DeadPoolConnType = Object<AsyncMysqlConnection>;
-
 #[cfg(feature = "postgres")]
 impl Storage {
     /// Create a new storage interface from configuration


### PR DESCRIPTION
Fix #150 

Fixed all rustc `dead_code` warnings.

Tested with:

`cargo rustc --lib -- -A warnings -D dead_code`