### PR TITLE
fix: multiple bound declarations

### DIFF
--- a/src/decider/gatewaydecider/gw_filter.rs
+++ b/src/decider/gatewaydecider/gw_filter.rs
@@ -117,10 +117,7 @@ pub fn catMaybes<T: Clone>(options: &[Option<T>]) -> Vec<T> {
     options.iter().filter_map(|opt| opt.clone()).collect()
 }
 
-pub fn intersect<T: Eq + std::hash::Hash>(a: &[T], b: &[T]) -> Vec<T>
-where
-    T: Clone,
-{
+pub fn intersect<T: Eq + std::hash::Hash + Clone>(a: &[T], b: &[T]) -> Vec<T> {
     let set_a: HashSet<_> = a.iter().collect();
     let set_b: HashSet<_> = b.iter().collect();
     set_a.intersection(&set_b).cloned().cloned().collect()

--- a/src/error/container.rs
+++ b/src/error/container.rs
@@ -37,8 +37,7 @@ pub trait ErrorTransform<From> {}
 impl<T, U> From<ContainerError<T>> for ContainerError<U>
 where
     T: error_stack::Context,
-    U: error_stack::Context,
-    for<'a> U: From<&'a T> + Sync + Send,
+    for<'a> U: error_stack::Context + From<&'a T> + Sync + Send,
     Self: ErrorTransform<ContainerError<T>>,
 {
     #[track_caller]


### PR DESCRIPTION
Fixes #146 

Fix all `clippy::type_repetition_in_bounds`

checked with:

`cargo clippy -- -A warnings -D clippy::type_repetition_in_bounds`