### PR TITLE
refactor: Add latency field to decision-gateway response

### DIFF
--- a/src/routes/decision_gateway.rs
+++ b/src/routes/decision_gateway.rs
@@ -36,6 +36,7 @@ impl IntoResponse for ErrorResponse {
 pub struct DecidedGatewayResponse {
     pub decided_gateway: DecidedGateway,
     pub filter_list: Vec<(String, Vec<String>)>,
+    pub latency: Option<u64>,
 }
 
 #[axum::debug_handler]
@@ -145,9 +146,11 @@ where
 
             let final_result = match result {
                 Ok((decided_gateway, filter_list)) => {
+                    let cpu_time = cpu_start.elapsed().as_millis() as u64;
                     let response = DecidedGatewayResponse {
                         decided_gateway,
                         filter_list,
+                        latency: Some(cpu_time),
                     };
 
                     // Serialize response body and headers for logging


### PR DESCRIPTION
This PR introduces a `latency` field to the `decision-engine` API response for improved production monitoring

API response
<img width="720" height="714" alt="image" src="https://github.com/user-attachments/assets/bc226c0f-a9d6-4b8c-953a-d6a639bcdd09" />
