### PR TITLE
fix: crud error status

### DIFF
--- a/src/routes/rule_configuration.rs
+++ b/src/routes/rule_configuration.rs
@@ -328,7 +328,7 @@ pub async fn update_rule_config(
 
             let result = types::service_configuration::update_config(name, Some(serialized_config))
                 .await
-                .change_context(error::RuleConfigurationError::StorageError);
+                .change_context(error::RuleConfigurationError::ConfigurationNotFound);
 
             match result {
                 Ok(_) => {
@@ -359,7 +359,7 @@ pub async fn update_rule_config(
                 Some(serialized_config),
             )
             .await
-            .change_context(error::RuleConfigurationError::StorageError);
+            .change_context(error::RuleConfigurationError::ConfigurationNotFound);
 
             match result {
                 Ok(_) => {
@@ -387,7 +387,7 @@ pub async fn update_rule_config(
 
             let result = types::service_configuration::update_config(name, Some(serialized_config))
                 .await
-                .change_context(error::RuleConfigurationError::StorageError);
+                .change_context(error::RuleConfigurationError::ConfigurationNotFound);
 
             match result {
                 Ok(_) => {
@@ -436,7 +436,7 @@ pub async fn delete_rule_config(
             let config_name = format!("SR_V3_INPUT_CONFIG_{}", mid);
             let result = types::service_configuration::delete_config(config_name)
                 .await
-                .change_context(error::RuleConfigurationError::StorageError);
+                .change_context(error::RuleConfigurationError::ConfigurationNotFound);
 
             match result {
                 Ok(_) => {
@@ -496,7 +496,7 @@ pub async fn delete_rule_config(
             let config_name = format!("DEBIT_ROUTING_CONFIG_{}", mid);
             let result = types::service_configuration::delete_config(config_name)
                 .await
-                .change_context(error::RuleConfigurationError::StorageError);
+                .change_context(error::RuleConfigurationError::ConfigurationNotFound);
 
             match result {
                 Ok(_) => {


### PR DESCRIPTION
This pull request updates error handling in the `rule_configuration.rs` route handlers to improve the accuracy of error reporting when configuration updates or deletions fail. Instead of returning a generic storage error, the code now returns a more specific configuration-not-found error, making it easier to diagnose issues related to missing configurations.

Error handling improvements:

* Changed error context from `StorageError` to `ConfigurationNotFound` in `update_rule_config` for three different update operations, improving error specificity when a configuration is not found. [[1]](diffhunk://#diff-99a18a1423559b7d3a9aeb922d901592d60e733b714e3ff2eb7cbaa6d3f8b313L331-R331) [[2]](diffhunk://#diff-99a18a1423559b7d3a9aeb922d901592d60e733b714e3ff2eb7cbaa6d3f8b313L362-R362) [[3]](diffhunk://#diff-99a18a1423559b7d3a9aeb922d901592d60e733b714e3ff2eb7cbaa6d3f8b313L390-R390)
* Changed error context from `StorageError` to `ConfigurationNotFound` in `delete_rule_config` for two different delete operations, ensuring the error reflects missing configuration rather than a generic storage issue. [[1]](diffhunk://#diff-99a18a1423559b7d3a9aeb922d901592d60e733b714e3ff2eb7cbaa6d3f8b313L439-R439) [[2]](diffhunk://#diff-99a18a1423559b7d3a9aeb922d901592d60e733b714e3ff2eb7cbaa6d3f8b313L499-R499)


<details>
<summary>1. Create Success Rate Config</summary>

Request
```
curl --location 'http://localhost:8082/rule/create' \
--header 'Content-Type: application/json' \
--header 'Accept: */*' \
--data '{
  "merchant_id": "test_merchant_123423",
  "config": {
    "type": "successRate",
    "data": {
      "defaultLatencyThreshold": 90,
      "defaultSuccessRate": 0.5,
      "defaultBucketSize": 200,
      "defaultHedgingPercent": 5,
      "subLevelInputConfig": [
        {
          "paymentMethodType": "upi",
          "paymentMethod": "upi_collect",
          "bucketSize": 250,
          "hedgingPercent": 1
        }
      ]
    }
  }
}
'
```

Response
```
{
    "message": "Success Rate Configuration created successfully",
    "merchant_id": "test_merchant_123423",
    "config": {
        "type": "successRate",
        "data": {
            "defaultLatencyThreshold": 90,
            "defaultBucketSize": 200,
            "defaultHedgingPercent": 5,
            "defaultLowerResetFactor": null,
            "defaultUpperResetFactor": null,
            "defaultGatewayExtraScore": null,
            "subLevelInputConfig": [
                {
                    "paymentMethodType": "upi",
                    "paymentMethod": "upi_collect",
                    "latencyThreshold": null,
                    "bucketSize": 250,
                    "hedgingPercent": 1,
                    "lowerResetFactor": null,
                    "upperResetFactor": null,
                    "gatewayExtraScore": null
                }
            ]
        }
    }
}
```
</details>

<details>
<summary>2. Delete Success Rate Config</summary>

Request
```
curl --location 'http://localhost:8082/rule/delete' \
--header 'Content-Type: application/json' \
--header 'Accept: */*' \
--data '{
  "merchant_id": "test_merchant_123423",
  "algorithm": "successRate"
}
'
```

Response
```
{
    "message": "Success Rate Configuration deleted successfully",
    "merchant_id": "test_merchant_123423"
}
```
</details>

<details>
<summary>3. Update Success Rate Config</summary>

Request
```
curl --location 'http://localhost:8082/rule/update' \
--header 'Content-Type: application/json' \
--header 'Accept: */*' \
--data '{
  "merchant_id": "test_merchant_123423",
  "config": {
    "type": "successRate",
    "data": {
      "defaultLatencyThreshold": 90,
      "defaultSuccessRate": 0.5,
      "defaultBucketSize": 200,
      "defaultHedgingPercent": 5,
      "subLevelInputConfig": [
        {
          "paymentMethodType": "upi",
          "paymentMethod": "upi_collect",
          "bucketSize": 250,
          "hedgingPercent": 1
        }
      ]
    }
  }
}
'
```

Response
```
{
    "code": "TE_04",
    "message": "Rule configuration not found",
    "data": null
}
```
</details>

<details>
<summary>4. Delete Success Rate Config</summary>

Request
```
curl --location 'http://localhost:8082/rule/delete' \
--header 'Content-Type: application/json' \
--header 'Accept: */*' \
--data '{
  "merchant_id": "test_merchant_123423",
  "algorithm": "successRate"
}
'
```

Response
```
{
    "code": "TE_04",
    "message": "Rule configuration not found",
    "data": null
}
```
</details>

