### PR TITLE
fix: update open-router image version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   open-router:
-    image: ghcr.io/juspay/decision-engine:v1.2.0
+    image: ghcr.io/juspay/decision-engine:v1.2.1
     pull_policy: always
     platform: linux/amd64
     container_name: open-router


### PR DESCRIPTION
This pull request updates the `open-router` service in the `docker-compose.yaml` file to use a newer version of the `decision-engine` image. This ensures the service runs with the latest improvements and fixes.

- Updated the `open-router` service to use the `decision-engine` image version `v1.2.1` instead of `v1.2.0` in `docker-compose.yaml`.

Screenshots

older version of image

<img width="740" height="421" alt="Screenshot 2025-10-27 at 12 00 12 PM" src="https://github.com/user-attachments/assets/6a460c95-0799-4714-8fe5-34872f2db271" />




newer version of image

<img width="1724" height="447" alt="Screenshot 2025-10-27 at 12 01 09 PM" src="https://github.com/user-attachments/assets/55aa4ab3-8aa3-4fd0-b891-651c7d95176f" />

