### PR TITLE
fix: change cpu_start time to Instant instead of ProcessTime

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -5,7 +5,7 @@ log_format = "default"
 
 [server]
 host = "127.0.0.1"
-port = 8000
+port = 8080
 
 [metrics]
 host = "127.0.0.1"


### PR DESCRIPTION
This PR will change the cpu_start time in decision_gateway function to `Instant::now()` instead of `ProcessTime::now()`