### PR TITLE
fix: set default for optional udfs in PaymentInfo struct

### DIFF
--- a/src/decider/gatewaydecider/types.rs
+++ b/src/decider/gatewaydecider/types.rs
@@ -968,7 +968,7 @@ pub struct PaymentInfo {
     currency: Currency,
     country: Option<CountryISO2>,
     customer_id: Option<ETCu::CustomerId>,
-    #[serde(deserialize_with = "deserialize_optional_udfs_to_hashmap")]
+    #[serde(default, deserialize_with = "deserialize_optional_udfs_to_hashmap")]
     udfs: Option<UDFs>,
     preferred_gateway: Option<String>,
     payment_type: TxnObjectType,


### PR DESCRIPTION
This pull request makes a small adjustment to the `PaymentInfo` struct in `types.rs` to improve deserialization robustness.

- Added the `#[serde(default, deserialize_with = "deserialize_optional_udfs_to_hashmap")]` attribute to the `udfs` field in the `PaymentInfo` struct, ensuring that missing `udfs` fields are handled gracefully during deserialization.

Decide-gateway (call without udfs)
```
curl --location 'http://localhost:8083/decide-gateway' \
--header 'Content-Type: application/json' \
--data '{           
        "merchantId": "azharamin",
        "eligibleGatewayList": ["GatewayA","GatewayB","GatewayC"],
        "rankingAlgorithm": "SR_BASED_ROUTING",
        "eliminationEnabled": false,
        "paymentInfo": {
            "paymentId": "PAY12359",
            "amount": 100.50,
            "currency": "USD",
            "country": "NL",
            "customerId": "CUST12345",
            "preferredGateway": null,
            "paymentType": "ORDER_PAYMENT",
            "metadata": null,
            "internalMetadata": null,
            "isEmi": false,
            "emiBank": null,
            "emiTenure": null,
            "paymentMethodType": "UPI",
            "paymentMethod": "UPI_COLLECT",
            "paymentSource": null,
            "authType": "OTP",
            "cardIssuerBankName": null,
            "cardIsin": "424242",
            "cardType": null,
            "cardSwitchProvider": "mastercard"
        }
}'
```

Response
```
{"decided_gateway":"GatewayA","gateway_priority_map":{"GatewayC":1.0,"GatewayB":1.0,"GatewayA":1.0},"filter_wise_gateways":null,"priority_logic_tag":null,"routing_approach":"SR_SELECTION_V3_ROUTING","gateway_before_evaluation":"GatewayB","priority_logic_output":{"isEnforcement":false,"gws":["GatewayA","GatewayB","GatewayC"],"priorityLogicTag":null,"gatewayReferenceIds":{},"primaryLogic":null,"fallbackLogic":null},"debit_routing_output":null,"reset_approach":"NO_RESET","routing_dimension":"ORDER_PAYMENT, UPI, UPI_COLLECT","routing_dimension_level":"PM_LEVEL","is_scheduled_outage":false,"is_dynamic_mga_enabled":false,"gateway_mga_id_map":null,"is_rust_based_decider":true,"latency":221}
```