### PR TITLE
feat: changes for cache_config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -11,10 +11,13 @@ port = 3001        # The port where the server should be hosted on
 request_count = 1 # The requests per duration
 duration = 60     # duration to rate limit the delete api (in sec)
 
-
 [cache]
 tti = 7200          # Idle time after a get/insert of a cache entry to free the cache (in secs)
 max_capacity = 5000 # Max capacity of a single table cache
+
+[cache_config]
+service_config_redis_prefix = "DE_service_config_"
+service_config_ttl = 300    # 5 minutes
 
 [database]
 username = "sam"   # username for the database
@@ -63,4 +66,3 @@ private_key = "key.pem"  # path to the private key file (`pem` format)
 client_idle_timeout = 90    # timeout for idle sockets being kept-alive
 pool_max_idle_per_host = 10 # maximum idle connection per host allowed in the pool.
 identity = ""               # identity to be used for client certificate authentication in mtls.
-

--- a/config/development.toml
+++ b/config/development.toml
@@ -45,9 +45,11 @@ default_command_timeout = 30
 unresponsive_timeout = 10
 max_feed_count = 200
 
-[cache_config]
+[cache]
 tti = 7200          # i.e. 2 hours
 max_capacity = 5000
+
+[cache_config]
 service_config_redis_prefix = "DE_service_config_"
 service_config_ttl = 300    # 5 minutes
 

--- a/config/docker-configuration.toml
+++ b/config/docker-configuration.toml
@@ -49,6 +49,10 @@ max_feed_count = 200
 tti = 7200          # i.e. 2 hours
 max_capacity = 5000
 
+[cache_config]
+service_config_redis_prefix = "DE_service_config_"
+service_config_ttl = 300    # 5 minutes
+
 [tenant_secrets]
 public = { schema = "public" }
 


### PR DESCRIPTION
This pull request updates the configuration files to add a new `[cache_config]` section for cache-related settings and improves consistency across environments. The most important changes are the addition of Redis prefix and TTL settings for service configuration caching.

**Configuration improvements:**

* Added a new `[cache_config]` section to `config.example.toml`, `config/development.toml`, and `config/docker-configuration.toml` with `service_config_redis_prefix` and `service_config_ttl` to support service configuration caching. [[1]](diffhunk://#diff-a3de6acaaaa3b6a4a52ede7d1f71503ff6c08008276e7254bf3bef49620cfec8L14-R21) [[2]](diffhunk://#diff-eeba5fd66f2753499ebdfe068ce07b9712c29d509dbd25e20eae2df0648c5c4eL48-R52) [[3]](diffhunk://#diff-b258bb4b0ba900066cf48ab880d0f175a7d474bf257ca6a7f011b9b2ecb275d9R52-R55)

**Consistency and cleanup:**

* Ensured that all configuration files now consistently include both `[cache]` and `[cache_config]` sections. [[1]](diffhunk://#diff-eeba5fd66f2753499ebdfe068ce07b9712c29d509dbd25e20eae2df0648c5c4eL48-R52) [[2]](diffhunk://#diff-b258bb4b0ba900066cf48ab880d0f175a7d474bf257ca6a7f011b9b2ecb275d9R52-R55)
* Removed an unnecessary blank line from the end of the `[client]` section in `config.example.toml` for formatting consistency.