### PR TITLE
ci: add vs to decision-engine, if wanted to expose to the existing ingress

### DIFF
--- a/helm-charts/templates/istio-destinationrule.yaml
+++ b/helm-charts/templates/istio-destinationrule.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.istio.enabled .Values.istio.destinationRule.enabled }}
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: {{ include "decision-engine.fullname" . }}-dr
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "decision-engine.labels" . | nindent 4 }}
+    app.kubernetes.io/component: istio-destination-rule
+spec:
+  host: {{ include "decision-engine.fullname" . }}
+  {{- if .Values.istio.destinationRule.trafficPolicy }}
+  trafficPolicy:
+    {{- toYaml .Values.istio.destinationRule.trafficPolicy | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/templates/istio-virtualservice.yaml
+++ b/helm-charts/templates/istio-virtualservice.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.istio.enabled .Values.istio.virtualService.enabled }}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ include "decision-engine.fullname" . }}-vs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "decision-engine.labels" . | nindent 4 }}
+    app.kubernetes.io/component: istio-virtual-service
+spec:
+  {{- with .Values.istio.virtualService.hosts }}
+  hosts:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.istio.virtualService.gateways }}
+  gateways:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.istio.virtualService.http }}
+  http:
+  {{- range .Values.istio.virtualService.http }}
+  - {{- if .name }}
+    name: {{ .name | quote }}
+    {{- end }}
+    {{- if .match }}
+    match:
+      {{- toYaml .match | nindent 6 }}
+    {{- end }}
+    {{- if .rewrite }}
+    rewrite:
+      {{- toYaml .rewrite | nindent 6 }}
+    {{- end }}
+    {{- if .timeout }}
+    timeout: {{ .timeout }}
+    {{- end }}
+    {{- if .retries }}
+    retries:
+      {{- toYaml .retries | nindent 6 }}
+    {{- end }}
+    route:
+    - destination:
+        host: {{ include "decision-engine.fullname" $ }}
+        port:
+          number: 80
+      {{- if .weight }}
+      weight: {{ .weight }}
+      {{- else }}
+      weight: 100
+      {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -221,3 +221,37 @@ routingConfig:
 
 # Additional environment variables to inject into the main container
 extraEnvVars: []
+
+# Istio configuration (optional)
+istio:
+  enabled: false
+  virtualService:
+    enabled: false
+    hosts: []
+    gateways: []
+    # HTTP routing rules - route destination will be automatically set to control center service
+    http: []
+    # Example configuration:
+    # http:
+    #   - name: "control-center-routes"
+    #     match:
+    #       - uri:
+    #           prefix: /
+    #     rewrite:
+    #       uri: "/dashboard"
+    #     weight: 100
+    #     timeout: 30s
+    #     retries:
+    #       attempts: 3
+    #       perTryTimeout: 10s
+  destinationRule:
+    enabled: false
+    trafficPolicy: {}
+    # Example traffic policy:
+    # trafficPolicy:
+    #   loadBalancer:
+    #     simple: ROUND_ROBIN
+    #   connectionPool:
+    #     tcp:
+    #       maxConnections: 50
+    #       connectTimeout: 30s


### PR DESCRIPTION
This pull request adds support for configuring an Istio `VirtualService` in the Helm chart, allowing advanced traffic routing such as header-based routing and gateway specification. The changes introduce a new template for generating a `VirtualService` resource and extend the `values.yaml` to make this feature configurable.

**Istio VirtualService support:**

* Added a new `virtualservice.yaml` Helm template to generate an Istio `VirtualService` resource when enabled, supporting host and gateway configuration, as well as header-based routing and optional default routing.
* Extended `values.yaml` with a `virtualService` section, providing configuration options for enabling the feature, setting annotations, hosts, gateways, header-based routing rules, and a default route toggle.