### PR TITLE
chore: change extraEnvVars from list to map for proper values merging

### DIFF
--- a/helm-charts/templates/deployment.yaml
+++ b/helm-charts/templates/deployment.yaml
@@ -66,7 +66,12 @@ spec:
               value: "{{ include "decision-engine.groovyRunnerName" . }}:{{ .Values.groovyRunner.service.port }}"
           {{- range $name, $value := .Values.extraEnvVars }}
             - name: {{ $name }}
+            {{- if and (kindIs "map" $value) $value.valueFrom }}
+              valueFrom:
+                {{- toYaml $value.valueFrom | nindent 16 }}
+            {{- else }}
               value: {{ $value | quote }}
+            {{- end }}
           {{- end }}
 
           livenessProbe:

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -219,8 +219,23 @@ routingConfig:
     # Path to mount routing config files
     mountPath: "/app"
 
-# Additional environment variables to inject into the main container
+# Additional environment variables to inject into the main container (map format for proper merging)
+# Supports both simple values and valueFrom references for secrets/configmaps
 extraEnvVars: {}
+  # Simple value example:
+  # MY_VAR: "my-value"
+  # Secret reference example:
+  # DB_PASSWORD:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: decision-engine-secrets
+  #       key: LOCKER__PG_DATABASE__PG_PASSWORD
+  # ConfigMap reference example:
+  # APP_CONFIG:
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: app-config
+  #       key: config.json
 
 # Istio configuration (optional)
 istio:


### PR DESCRIPTION
## Summary
- Changed `extraEnvVars` from a list (`[]`) to a map (`{}`) format
- Updated deployment template to iterate over map key-value pairs
## Problem
When using multiple values files with Helm (e.g., `-f values.yaml -f custom-values.yaml`), lists are replaced entirely rather than merged. This meant `extraEnvVars` from the later file would completely overwrite any variables from earlier files.
## Solution
Using a map instead of a list allows Helm to merge the keys from multiple values files. Duplicate keys are overridden by the later file (expected behavior), while unique keys from all files are preserved.
## Example
```yaml
# values-base.yaml
extraEnvVars:
  LOG_LEVEL: "info"
  APP_NAME: "my-app"
# values-prod.yaml  
extraEnvVars:
  LOG_LEVEL: "warn"
  ENVIRONMENT: "production"
With map format, the result is:
- LOG_LEVEL: "warn" (overridden)
- APP_NAME: "my-app" (preserved)
- ENVIRONMENT: "production" (added)