### PR TITLE
fix: clippy

### DIFF
--- a/src/feedback/gateway_elimination_scoring/flow.rs
+++ b/src/feedback/gateway_elimination_scoring/flow.rs
@@ -161,7 +161,7 @@ pub async fn updateKeyScoreForKeysFromConsumer(
             let _encoded_json = serde_json::to_string(&updated_cached_gateway_score).unwrap();
             let elapsed_time =
                 timestamp.saturating_sub(updated_cached_gateway_score.timestamp as u128);
-            let remaining_ttl = (hard_key_ttl as u128).saturating_sub(elapsed_time);
+            let remaining_ttl = hard_key_ttl.saturating_sub(elapsed_time);
             let safe_remaining_ttl = if remaining_ttl < 1000 {
                 hard_key_ttl as i64
             } else {


### PR DESCRIPTION
This pull request makes a small but important fix to the calculation of `remaining_ttl` in the `updateKeyScoreForKeysFromConsumer` function. The change ensures that the types involved in the subtraction are consistent and prevents potential issues with type casting.

* Corrected the calculation of `remaining_ttl` by removing an unnecessary cast to `u128` on `hard_key_ttl`, which improves type safety and clarity in `src/feedback/gateway_elimination_scoring/flow.rs`.