### PR TITLE
feat(helm): make busybox init containers configurable and optional

### DIFF
--- a/helm-charts/templates/deployment.yaml
+++ b/helm-charts/templates/deployment.yaml
@@ -32,20 +32,24 @@ spec:
       initContainers:
         {{- if .Values.decisionEngine.usePostgreSQL }}
         - name: wait-for-postgresql
-          image: busybox:1.28
+          image: "{{ .Values.initContainers.busybox.repository }}:{{ .Values.initContainers.busybox.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.busybox.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.postgresqlHost" . }} 5432; do echo waiting for postgresql; sleep 2; done;']
         {{- end }}
         {{- if .Values.decisionEngine.useRedis }}
         - name: wait-for-redis
-          image: busybox:1.28
+          image: "{{ .Values.initContainers.busybox.repository }}:{{ .Values.initContainers.busybox.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.busybox.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.redisHost" . }} 6379; do echo waiting for redis; sleep 2; done;']
         {{- end }}
         - name: wait-for-groovy-runner
-          image: busybox:1.28
+          image: "{{ .Values.initContainers.busybox.repository }}:{{ .Values.initContainers.busybox.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.busybox.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.groovyRunnerName" . }} {{ .Values.groovyRunner.service.port }}; do echo waiting for groovy-runner; sleep 2; done;']
         {{- if .Values.decisionEngine.useMySQL }}
         - name: wait-for-mysql
-          image: busybox:1.28
+          image: "{{ .Values.initContainers.busybox.repository }}:{{ .Values.initContainers.busybox.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.busybox.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.mysqlHost" . }} 3306; do echo waiting for mysql; sleep 2; done;']
         {{- end }}
       {{- end }}

--- a/helm-charts/templates/mysql-migration-job.yaml
+++ b/helm-charts/templates/mysql-migration-job.yaml
@@ -26,10 +26,13 @@ spec:
       serviceAccountName: {{ include "decision-engine.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers.enabled }}
       initContainers:
         - name: wait-for-mysql
-          image: busybox:1.28
+          image: "{{ .Values.initContainers.busybox.repository }}:{{ .Values.initContainers.busybox.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.busybox.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.mysqlHost" . }} 3306; do echo waiting for mysql; sleep 2; done;']
+      {{- end }}
       containers:
         - name: migration
           image: "debian:stable-slim"

--- a/helm-charts/templates/postgresql-migration-job.yaml
+++ b/helm-charts/templates/postgresql-migration-job.yaml
@@ -36,10 +36,13 @@ spec:
       serviceAccountName: {{ include "decision-engine.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers.enabled }}
       initContainers:
         - name: wait-for-postgresql
-          image: busybox:1.28
+          image: "{{ .Values.initContainers.busybox.repository }}:{{ .Values.initContainers.busybox.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.busybox.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.postgresqlHost" . }} 5432; do echo waiting for postgresql; sleep 2; done;']
+      {{- end }}
       containers:
         - name: migration
           image: rust:latest

--- a/helm-charts/templates/routing-config-job.yaml
+++ b/helm-charts/templates/routing-config-job.yaml
@@ -26,17 +26,21 @@ spec:
       serviceAccountName: {{ include "decision-engine.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers.enabled }}
       initContainers:
         {{- if .Values.decisionEngine.usePostgreSQL }}
         - name: wait-for-postgresql
-          image: busybox:1.28
+          image: "{{ .Values.initContainers.busybox.repository }}:{{ .Values.initContainers.busybox.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.busybox.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.postgresqlHost" . }} 5432; do echo waiting for postgresql; sleep 2; done;']
         {{- end }}
         {{- if .Values.decisionEngine.useMySQL }}
         - name: wait-for-mysql
-          image: busybox:1.28
+          image: "{{ .Values.initContainers.busybox.repository }}:{{ .Values.initContainers.busybox.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.busybox.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "decision-engine.mysqlHost" . }} 3306; do echo waiting for mysql; sleep 2; done;']
         {{- end }}
+      {{- end }}
       containers:
         - name: routing-config
           image: "{{ .Values.routingConfig.image.repository }}:{{ .Values.routingConfig.image.tag }}"

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -30,6 +30,10 @@ podSecurityContext: {}
 initContainers:
   # Set to false to disable all init containers
   enabled: true
+  busybox:
+    repository: public.ecr.aws/docker/library/busybox
+    tag: "1.28"
+    pullPolicy: IfNotPresent
 
 securityContext: {}
   # capabilities:


### PR DESCRIPTION
- Add initContainers.enabled toggle to disable all init containers

- Make busybox image configurable via initContainers.busybox.repository, tag, pullPolicy

- Default to Amazon ECR Public: public.ecr.aws/docker/library/busybox:1.28