### PR TITLE
refactor(euclid): payment_id for better logging

### DIFF
--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -262,8 +262,9 @@ pub async fn routing_evaluate(
 
     let state = get_tenant_app_state().await;
     logger::debug!(
-        "Received routing evaluation request for ID: {}",
-        payload.created_by
+        payment_id = ?payload.payment_id,
+        created_by = %payload.created_by,
+        "Received routing evaluation request"
     );
 
     let update_failure_metrics = || {
@@ -490,6 +491,7 @@ pub async fn routing_evaluate(
     );
 
     let response = RoutingEvaluateResponse {
+        payment_id: payload.payment_id.clone(),
         status: match rule_name.as_deref() {
             Some("default_selection") | Some("default_fallback") => "default_selection".into(),
             Some(_) => "success".into(),

--- a/src/euclid/types.rs
+++ b/src/euclid/types.rs
@@ -59,6 +59,7 @@ pub enum AlgorithmType {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct RoutingRequest {
+    pub payment_id: Option<String>,
     pub created_by: String,
     pub fallback_output: Option<Vec<ConnectorInfo>>,
     pub parameters: HashMap<String, Option<ValueType>>,
@@ -117,6 +118,7 @@ pub const ELIGIBLE_DIMENSIONS: [&str; 5] = [
 ];
 #[derive(Debug, serde::Serialize)]
 pub struct RoutingEvaluateResponse {
+    pub payment_id: Option<String>,
     pub status: String,
     pub output: serde_json::Value,
     pub evaluated_output: Vec<ConnectorInfo>,


### PR DESCRIPTION
## Description
This pull request updates the routing evaluation logic to improve traceability and response consistency by adding the `payment_id` field to both request and response types, and by enhancing logging for better observability. The most important changes are:

**API and Data Model Changes:**

* Added an optional `payment_id` field to the `RoutingRequest` struct in `src/euclid/types.rs`, allowing requests to include a payment identifier.
* Added an optional `payment_id` field to the `RoutingEvaluateResponse` struct in `src/euclid/types.rs`, ensuring responses include the payment identifier when available.
* Updated the response construction in `routing_evaluate` to include the `payment_id` in the returned `RoutingEvaluateResponse`.

**Logging Improvements:**

* Enhanced the log statement in `routing_evaluate` to explicitly log both `payment_id` and `created_by` for better traceability of routing evaluation requests.