### PR TITLE
feat(audit): add audit logging middleware, API, and dashboard

### DIFF
--- a/migrations_pg/2024_04_16_000000_create_audit_log/down.sql
+++ b/migrations_pg/2024_04_16_000000_create_audit_log/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS audit_log;

--- a/migrations_pg/2024_04_16_000000_create_audit_log/up.sql
+++ b/migrations_pg/2024_04_16_000000_create_audit_log/up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS audit_log (
+    id TEXT PRIMARY KEY,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    endpoint TEXT NOT NULL,
+    method TEXT NOT NULL,
+    request_headers JSONB,
+    request_body JSONB,
+    response_status INTEGER NOT NULL,
+    response_body JSONB,
+    latency_ms INTEGER NOT NULL,
+    merchant_id TEXT,
+    request_id TEXT NOT NULL
+);
+
+CREATE INDEX idx_audit_log_timestamp ON audit_log (timestamp DESC);
+CREATE INDEX idx_audit_log_endpoint_method ON audit_log (endpoint, method);
+CREATE INDEX idx_audit_log_request_id ON audit_log (request_id);
+CREATE INDEX idx_audit_log_merchant_id ON audit_log (merchant_id) WHERE merchant_id IS NOT NULL;

--- a/src/app.rs
+++ b/src/app.rs
@@ -271,9 +271,19 @@ where
         "/update-gateway-score",
         post(routes::update_gateway_score::update_gateway_score),
     );
+    let router = router
+        .route("/audit/stats", get(routes::audit::audit_stats))
+        .route("/audit/requests", get(routes::audit::audit_requests))
+        .route(
+            "/audit/request/:id",
+            get(routes::audit::audit_request_by_id),
+        );
 
     let middleware = ServiceBuilder::new()
         .layer(middleware::from_fn(ensure_request_id))
+        .layer(middleware::from_fn(
+            crate::middleware::audit::audit_middleware,
+        ))
         .layer(
             tower_trace::TraceLayer::new_for_http()
                 .make_span_with(|request: &Request<_>| utils::record_fields_from_header(request))

--- a/src/middleware/audit.rs
+++ b/src/middleware/audit.rs
@@ -1,0 +1,205 @@
+use axum::{
+    body::{to_bytes, Body},
+    extract::Request,
+    middleware::Next,
+    response::Response,
+};
+use diesel::prelude::*;
+use diesel::sql_types::Text;
+use diesel_async::RunQueryDsl;
+use std::time::Instant;
+
+use crate::app::APP_STATE;
+use crate::logger;
+use crate::storage::consts::X_REQUEST_ID;
+
+const MAX_RESPONSE_BODY_BYTES: usize = 10 * 1024; // 10KB
+
+const HEADERS_TO_SANITIZE: &[&str] = &[
+    "authorization",
+    "x-api-key",
+    "cookie",
+    "set-cookie",
+    "x-auth-token",
+];
+
+fn sanitize_headers(headers: &axum::http::HeaderMap) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for (name, value) in headers.iter() {
+        let key = name.as_str().to_lowercase();
+        if HEADERS_TO_SANITIZE.contains(&key.as_str()) {
+            map.insert(key, serde_json::Value::String("[REDACTED]".to_string()));
+        } else if let Ok(v) = value.to_str() {
+            map.insert(key, serde_json::Value::String(v.to_string()));
+        }
+    }
+    serde_json::Value::Object(map)
+}
+
+fn extract_merchant_id(body: &serde_json::Value) -> Option<String> {
+    body.get("merchant_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            body.get("merchantId")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+}
+
+pub async fn audit_middleware(request: Request<Body>, next: Next) -> Response {
+    let start = Instant::now();
+
+    let endpoint = request.uri().path().to_string();
+    let method = request.method().to_string();
+
+    // Skip audit endpoints to avoid infinite recursion
+    if endpoint.starts_with("/audit") || endpoint.starts_with("/health") {
+        return next.run(request).await;
+    }
+
+    let request_id = request
+        .headers()
+        .get(X_REQUEST_ID)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let sanitized_headers = sanitize_headers(request.headers());
+
+    // Extract the request body
+    let (parts, body) = request.into_parts();
+    let body_bytes = match to_bytes(body, 1024 * 1024).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            logger::error!("Failed to read request body for audit: {:?}", e);
+            let request = Request::from_parts(parts, Body::empty());
+            return next.run(request).await;
+        }
+    };
+
+    let request_body: Option<serde_json::Value> = if body_bytes.is_empty() {
+        None
+    } else {
+        serde_json::from_slice(&body_bytes).ok()
+    };
+
+    let merchant_id = request_body.as_ref().and_then(extract_merchant_id);
+
+    // Reconstruct the request with the body
+    let request = Request::from_parts(parts, Body::from(body_bytes));
+
+    // Run the actual handler
+    let response = next.run(request).await;
+
+    let latency_ms = start.elapsed().as_millis() as i32;
+    let response_status = response.status().as_u16() as i32;
+
+    // Extract response body
+    let (resp_parts, resp_body) = response.into_parts();
+    let resp_bytes = match to_bytes(resp_body, 1024 * 1024).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            logger::error!("Failed to read response body for audit: {:?}", e);
+            let response = Response::from_parts(resp_parts, Body::empty());
+            return response;
+        }
+    };
+
+    let response_body: Option<serde_json::Value> = if resp_bytes.is_empty() {
+        None
+    } else if resp_bytes.len() > MAX_RESPONSE_BODY_BYTES {
+        Some(serde_json::json!({
+            "_truncated": true,
+            "_original_size": resp_bytes.len()
+        }))
+    } else {
+        serde_json::from_slice(&resp_bytes).ok()
+    };
+
+    // Reconstruct the response
+    let response = Response::from_parts(resp_parts, Body::from(resp_bytes));
+
+    // Spawn a background task to insert the audit log
+    let req_headers_json = serde_json::to_string(&sanitized_headers).unwrap_or_default();
+    let req_body_json = request_body
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    let resp_body_json = response_body
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+
+    tokio::spawn(async move {
+        if let Err(e) = insert_audit_log(
+            &endpoint,
+            &method,
+            &req_headers_json,
+            req_body_json.as_deref(),
+            response_status,
+            resp_body_json.as_deref(),
+            latency_ms,
+            merchant_id.as_deref(),
+            &request_id,
+        )
+        .await
+        {
+            logger::error!("Failed to insert audit log: {:?}", e);
+        }
+    });
+
+    response
+}
+
+#[derive(Debug, QueryableByName)]
+struct InsertResult {
+    #[diesel(sql_type = Text)]
+    id: String,
+}
+
+async fn insert_audit_log(
+    endpoint: &str,
+    method: &str,
+    request_headers: &str,
+    request_body: Option<&str>,
+    response_status: i32,
+    response_body: Option<&str>,
+    latency_ms: i32,
+    merchant_id: Option<&str>,
+    request_id: &str,
+) -> Result<(), String> {
+    #[allow(clippy::expect_used)]
+    let app_state = APP_STATE.get().expect("GlobalAppState not set");
+    let tenant_state = app_state
+        .get_app_state_of_tenant("public")
+        .await
+        .map_err(|e| format!("Failed to get tenant state: {:?}", e))?;
+
+    let conn = tenant_state
+        .db
+        .get_conn()
+        .await
+        .map_err(|e| format!("Failed to get DB connection: {:?}", e))?;
+
+    let id = uuid::Uuid::new_v4().to_string();
+
+    diesel::sql_query(
+        "INSERT INTO audit_log (id, endpoint, method, request_headers, request_body, \
+         response_status, response_body, latency_ms, merchant_id, request_id) \
+         VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7::jsonb, $8, $9, $10)",
+    )
+    .bind::<Text, _>(&id)
+    .bind::<Text, _>(endpoint)
+    .bind::<Text, _>(method)
+    .bind::<Text, _>(request_headers)
+    .bind::<diesel::sql_types::Nullable<Text>, _>(request_body)
+    .bind::<diesel::sql_types::Integer, _>(response_status)
+    .bind::<diesel::sql_types::Nullable<Text>, _>(response_body)
+    .bind::<diesel::sql_types::Integer, _>(latency_ms)
+    .bind::<diesel::sql_types::Nullable<Text>, _>(merchant_id)
+    .bind::<Text, _>(request_id)
+    .execute(&*conn)
+    .await
+    .map_err(|e| format!("Failed to execute audit insert: {:?}", e))?;
+
+    Ok(())
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,3 +1,5 @@
+pub mod audit;
+
 use crate::custom_extractors::TenantStateResolver;
 use crate::error::{self, ContainerError};
 use axum::body::Body;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,3 +1,4 @@
+pub mod audit;
 pub mod hybrid_routing;
 // pub mod data;
 pub mod decide_gateway;

--- a/src/routes/audit.rs
+++ b/src/routes/audit.rs
@@ -1,0 +1,373 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Integer, Jsonb, Nullable, Text};
+use diesel_async::RunQueryDsl;
+use hyper::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use crate::logger;
+use crate::tenant::GlobalAppState;
+
+#[derive(Debug, Deserialize)]
+pub struct StatsQuery {
+    pub range: Option<String>,
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RequestsQuery {
+    pub endpoint: Option<String>,
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+    pub range: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EndpointStats {
+    pub endpoint: String,
+    pub method: String,
+    pub count: i64,
+    pub avg_latency_ms: i64,
+    pub error_count: i64,
+    pub last_hit: Option<String>,
+}
+
+#[derive(Debug, QueryableByName)]
+struct StatsRow {
+    #[diesel(sql_type = Text)]
+    endpoint: String,
+    #[diesel(sql_type = Text)]
+    method: String,
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+    #[diesel(sql_type = BigInt)]
+    avg_latency_ms: i64,
+    #[diesel(sql_type = BigInt)]
+    error_count: i64,
+    #[diesel(sql_type = Nullable<Text>)]
+    last_hit: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuditLogEntry {
+    pub id: String,
+    pub timestamp: String,
+    pub endpoint: String,
+    pub method: String,
+    pub request_headers: Option<serde_json::Value>,
+    pub request_body: Option<serde_json::Value>,
+    pub response_status: i32,
+    pub response_body: Option<serde_json::Value>,
+    pub latency_ms: i32,
+    pub merchant_id: Option<String>,
+    pub request_id: String,
+}
+
+#[derive(Debug, QueryableByName)]
+struct AuditRow {
+    #[diesel(sql_type = Text)]
+    id: String,
+    #[diesel(sql_type = Text)]
+    timestamp: String,
+    #[diesel(sql_type = Text)]
+    endpoint: String,
+    #[diesel(sql_type = Text)]
+    method: String,
+    #[diesel(sql_type = Nullable<Jsonb>)]
+    request_headers: Option<serde_json::Value>,
+    #[diesel(sql_type = Nullable<Jsonb>)]
+    request_body: Option<serde_json::Value>,
+    #[diesel(sql_type = Integer)]
+    response_status: i32,
+    #[diesel(sql_type = Nullable<Jsonb>)]
+    response_body: Option<serde_json::Value>,
+    #[diesel(sql_type = Integer)]
+    latency_ms: i32,
+    #[diesel(sql_type = Nullable<Text>)]
+    merchant_id: Option<String>,
+    #[diesel(sql_type = Text)]
+    request_id: String,
+}
+
+#[derive(Debug, QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaginatedRequests {
+    pub data: Vec<AuditLogEntry>,
+    pub page: i64,
+    pub per_page: i64,
+    pub total: i64,
+}
+
+fn range_to_interval(range: &str) -> &str {
+    match range {
+        "1h" => "1 hour",
+        "6h" => "6 hours",
+        "24h" => "24 hours",
+        "7d" => "7 days",
+        _ => "24 hours",
+    }
+}
+
+pub async fn audit_stats(
+    State(state): State<Arc<GlobalAppState>>,
+    Query(params): Query<StatsQuery>,
+) -> Result<Json<Vec<EndpointStats>>, (StatusCode, String)> {
+    let tenant_state = state.get_app_state_of_tenant("public").await.map_err(|e| {
+        logger::error!("Failed to get tenant state: {:?}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to get database connection".to_string(),
+        )
+    })?;
+
+    let conn = tenant_state.db.get_conn().await.map_err(|e| {
+        logger::error!("Failed to get DB connection: {:?}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to get database connection".to_string(),
+        )
+    })?;
+
+    let range = params.range.as_deref().unwrap_or("24h");
+    let interval = range_to_interval(range);
+
+    let rows: Vec<StatsRow> = if let Some(ref ep) = params.endpoint {
+        diesel::sql_query(format!(
+            "SELECT endpoint, method, \
+             COUNT(*)::bigint as count, \
+             COALESCE(AVG(latency_ms)::bigint, 0) as avg_latency_ms, \
+             COUNT(*) FILTER (WHERE response_status >= 400)::bigint as error_count, \
+             MAX(timestamp)::text as last_hit \
+             FROM audit_log \
+             WHERE timestamp > NOW() - INTERVAL '{}' AND endpoint LIKE $1 \
+             GROUP BY endpoint, method \
+             ORDER BY count DESC",
+            interval
+        ))
+        .bind::<Text, _>(format!("%{}%", ep))
+        .load(&*conn)
+        .await
+        .map_err(|e| {
+            logger::error!("Failed to query audit stats: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Database query failed: {}", e),
+            )
+        })?
+    } else {
+        diesel::sql_query(format!(
+            "SELECT endpoint, method, \
+             COUNT(*)::bigint as count, \
+             COALESCE(AVG(latency_ms)::bigint, 0) as avg_latency_ms, \
+             COUNT(*) FILTER (WHERE response_status >= 400)::bigint as error_count, \
+             MAX(timestamp)::text as last_hit \
+             FROM audit_log \
+             WHERE timestamp > NOW() - INTERVAL '{}' \
+             GROUP BY endpoint, method \
+             ORDER BY count DESC",
+            interval
+        ))
+        .load(&*conn)
+        .await
+        .map_err(|e| {
+            logger::error!("Failed to query audit stats: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Database query failed: {}", e),
+            )
+        })?
+    };
+
+    let stats = rows
+        .into_iter()
+        .map(|r| EndpointStats {
+            endpoint: r.endpoint,
+            method: r.method,
+            count: r.count,
+            avg_latency_ms: r.avg_latency_ms,
+            error_count: r.error_count,
+            last_hit: r.last_hit,
+        })
+        .collect();
+
+    Ok(Json(stats))
+}
+
+pub async fn audit_requests(
+    State(state): State<Arc<GlobalAppState>>,
+    Query(params): Query<RequestsQuery>,
+) -> Result<Json<PaginatedRequests>, (StatusCode, String)> {
+    let tenant_state = state.get_app_state_of_tenant("public").await.map_err(|e| {
+        logger::error!("Failed to get tenant state: {:?}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to get database connection".to_string(),
+        )
+    })?;
+
+    let conn = tenant_state.db.get_conn().await.map_err(|e| {
+        logger::error!("Failed to get DB connection: {:?}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to get database connection".to_string(),
+        )
+    })?;
+
+    let page = params.page.unwrap_or(1).max(1);
+    let per_page = params.per_page.unwrap_or(50).min(100);
+    let offset = (page - 1) * per_page;
+    let range = params.range.as_deref().unwrap_or("24h");
+    let interval = range_to_interval(range);
+
+    let (rows, total): (Vec<AuditRow>, i64) = if let Some(ref ep) = params.endpoint {
+        let count_row: CountRow = diesel::sql_query(format!(
+            "SELECT COUNT(*)::bigint as count FROM audit_log \
+             WHERE timestamp > NOW() - INTERVAL '{}' AND endpoint = $1",
+            interval
+        ))
+        .bind::<Text, _>(ep.clone())
+        .get_result(&*conn)
+        .await
+        .unwrap_or(CountRow { count: 0 });
+
+        let rows = diesel::sql_query(format!(
+            "SELECT id, timestamp::text as timestamp, endpoint, method, \
+             request_headers, request_body, response_status, response_body, \
+             latency_ms, merchant_id, request_id \
+             FROM audit_log \
+             WHERE timestamp > NOW() - INTERVAL '{}' AND endpoint = $1 \
+             ORDER BY timestamp DESC \
+             LIMIT {} OFFSET {}",
+            interval, per_page, offset
+        ))
+        .bind::<Text, _>(ep.clone())
+        .load(&*conn)
+        .await
+        .map_err(|e| {
+            logger::error!("Failed to query audit requests: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Database query failed: {}", e),
+            )
+        })?;
+
+        (rows, count_row.count)
+    } else {
+        let count_row: CountRow = diesel::sql_query(format!(
+            "SELECT COUNT(*)::bigint as count FROM audit_log \
+             WHERE timestamp > NOW() - INTERVAL '{}'",
+            interval
+        ))
+        .get_result(&*conn)
+        .await
+        .unwrap_or(CountRow { count: 0 });
+
+        let rows = diesel::sql_query(format!(
+            "SELECT id, timestamp::text as timestamp, endpoint, method, \
+             request_headers, request_body, response_status, response_body, \
+             latency_ms, merchant_id, request_id \
+             FROM audit_log \
+             WHERE timestamp > NOW() - INTERVAL '{}' \
+             ORDER BY timestamp DESC \
+             LIMIT {} OFFSET {}",
+            interval, per_page, offset
+        ))
+        .load(&*conn)
+        .await
+        .map_err(|e| {
+            logger::error!("Failed to query audit requests: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Database query failed: {}", e),
+            )
+        })?;
+
+        (rows, count_row.count)
+    };
+
+    let data = rows
+        .into_iter()
+        .map(|r| AuditLogEntry {
+            id: r.id,
+            timestamp: r.timestamp,
+            endpoint: r.endpoint,
+            method: r.method,
+            request_headers: r.request_headers,
+            request_body: r.request_body,
+            response_status: r.response_status,
+            response_body: r.response_body,
+            latency_ms: r.latency_ms,
+            merchant_id: r.merchant_id,
+            request_id: r.request_id,
+        })
+        .collect();
+
+    Ok(Json(PaginatedRequests {
+        data,
+        page,
+        per_page,
+        total,
+    }))
+}
+
+pub async fn audit_request_by_id(
+    State(state): State<Arc<GlobalAppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<AuditLogEntry>, (StatusCode, String)> {
+    let tenant_state = state.get_app_state_of_tenant("public").await.map_err(|e| {
+        logger::error!("Failed to get tenant state: {:?}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to get database connection".to_string(),
+        )
+    })?;
+
+    let conn = tenant_state.db.get_conn().await.map_err(|e| {
+        logger::error!("Failed to get DB connection: {:?}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to get database connection".to_string(),
+        )
+    })?;
+
+    let row: AuditRow = diesel::sql_query(
+        "SELECT id, timestamp::text as timestamp, endpoint, method, \
+         request_headers, request_body, response_status, response_body, \
+         latency_ms, merchant_id, request_id \
+         FROM audit_log WHERE id = $1",
+    )
+    .bind::<Text, _>(id)
+    .get_result(&*conn)
+    .await
+    .map_err(|e| {
+        logger::error!("Failed to query audit request: {:?}", e);
+        (
+            StatusCode::NOT_FOUND,
+            "Audit log entry not found".to_string(),
+        )
+    })?;
+
+    Ok(Json(AuditLogEntry {
+        id: row.id,
+        timestamp: row.timestamp,
+        endpoint: row.endpoint,
+        method: row.method,
+        request_headers: row.request_headers,
+        request_body: row.request_body,
+        response_status: row.response_status,
+        response_body: row.response_body,
+        latency_ms: row.latency_ms,
+        merchant_id: row.merchant_id,
+        request_id: row.request_id,
+    }))
+}

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -7,6 +7,7 @@ import { EuclidRulesPage } from './components/pages/EuclidRulesPage'
 import { VolumeSplitPage } from './components/pages/VolumeSplitPage'
 import { DebitRoutingPage } from './components/pages/DebitRoutingPage'
 import { DecisionExplorerPage } from './components/pages/DecisionExplorerPage'
+import { AuditPage } from './components/pages/AuditPage'
 
 export default function App() {
   return (
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="routing/volume" element={<VolumeSplitPage />} />
         <Route path="routing/debit" element={<DebitRoutingPage />} />
         <Route path="decisions" element={<DecisionExplorerPage />} />
+        <Route path="audit" element={<AuditPage />} />
         <Route path="*" element={<Navigate to="." replace />} />
       </Route>
     </Routes>

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   BookOpen,
   PieChart,
   Network,
+  ScrollText,
 } from 'lucide-react'
 
 export function Sidebar() {
@@ -44,6 +45,14 @@ export function Sidebar() {
         <SideLink to="/routing/rules" icon={BookOpen} indent>Rule-Based (Euclid)</SideLink>
         <SideLink to="/routing/volume" icon={PieChart} indent>Volume Split</SideLink>
         <SideLink to="/routing/debit" icon={Network} indent>Debit Routing</SideLink>
+
+        <div className="pt-8 pb-3 px-3 flex items-center gap-2">
+          <span className="text-[11px] font-bold uppercase tracking-widest text-slate-400 dark:text-[#66666e]">
+            Observability
+          </span>
+        </div>
+
+        <SideLink to="/audit" icon={ScrollText}>Audit Log</SideLink>
       </nav>
 
       {/* Footer */}

--- a/website/src/components/pages/AuditPage.tsx
+++ b/website/src/components/pages/AuditPage.tsx
@@ -1,0 +1,484 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Card, CardBody, CardHeader } from '../ui/Card'
+import { Badge } from '../ui/Badge'
+import { Spinner } from '../ui/Spinner'
+import { ErrorMessage } from '../ui/ErrorMessage'
+import { apiFetch } from '../../lib/api'
+import {
+  ScrollText,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  ArrowUpDown,
+  Search,
+  ChevronLeft,
+} from 'lucide-react'
+
+interface EndpointStats {
+  endpoint: string
+  method: string
+  count: number
+  avg_latency_ms: number
+  error_count: number
+  last_hit: string | null
+}
+
+interface AuditLogEntry {
+  id: string
+  timestamp: string
+  endpoint: string
+  method: string
+  request_headers: Record<string, string> | null
+  request_body: unknown | null
+  response_status: number
+  response_body: unknown | null
+  latency_ms: number
+  merchant_id: string | null
+  request_id: string
+}
+
+interface PaginatedRequests {
+  data: AuditLogEntry[]
+  page: number
+  per_page: number
+  total: number
+}
+
+type TimeRange = '1h' | '6h' | '24h' | '7d'
+type SortField = 'endpoint' | 'count' | 'avg_latency_ms' | 'error_count' | 'last_hit'
+type SortDir = 'asc' | 'desc'
+
+const METHOD_COLORS: Record<string, 'green' | 'blue' | 'red' | 'orange' | 'purple'> = {
+  GET: 'blue',
+  POST: 'green',
+  PUT: 'orange',
+  DELETE: 'red',
+  PATCH: 'purple',
+}
+
+function statusBadgeVariant(status: number): 'green' | 'red' | 'orange' | 'blue' {
+  if (status >= 200 && status < 300) return 'green'
+  if (status >= 400 && status < 500) return 'orange'
+  if (status >= 500) return 'red'
+  return 'blue'
+}
+
+function formatTimestamp(ts: string): string {
+  try {
+    const d = new Date(ts)
+    return d.toLocaleString()
+  } catch {
+    return ts
+  }
+}
+
+function JsonBlock({ data, label }: { data: unknown; label: string }) {
+  if (data === null || data === undefined) {
+    return (
+      <div className="mb-4">
+        <p className="text-xs font-semibold text-slate-400 dark:text-[#66666e] uppercase tracking-wider mb-2">{label}</p>
+        <p className="text-sm text-slate-500 dark:text-[#55555e] italic">Empty</p>
+      </div>
+    )
+  }
+  return (
+    <div className="mb-4">
+      <p className="text-xs font-semibold text-slate-400 dark:text-[#66666e] uppercase tracking-wider mb-2">{label}</p>
+      <pre className="bg-slate-100 dark:bg-[#0a0a0c] rounded-xl p-4 text-xs text-slate-700 dark:text-slate-300 overflow-x-auto max-h-80 overflow-y-auto border border-slate-200 dark:border-[#1c1c1f]">
+        {typeof data === 'string' ? data : JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  )
+}
+
+export function AuditPage() {
+  const [range, setRange] = useState<TimeRange>('24h')
+  const [searchTerm, setSearchTerm] = useState('')
+  const [stats, setStats] = useState<EndpointStats[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [sortField, setSortField] = useState<SortField>('count')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  // Expanded endpoint state
+  const [expandedEndpoint, setExpandedEndpoint] = useState<string | null>(null)
+  const [requests, setRequests] = useState<AuditLogEntry[]>([])
+  const [requestsLoading, setRequestsLoading] = useState(false)
+  const [requestsPage, setRequestsPage] = useState(1)
+  const [requestsTotal, setRequestsTotal] = useState(0)
+
+  // Expanded request detail
+  const [expandedRequest, setExpandedRequest] = useState<string | null>(null)
+
+  const fetchStats = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const params = new URLSearchParams({ range })
+      const data = await apiFetch<EndpointStats[]>(`/audit/stats?${params}`)
+      setStats(data ?? [])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch audit stats')
+      setStats([])
+    } finally {
+      setLoading(false)
+    }
+  }, [range])
+
+  useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  const fetchRequests = useCallback(async (endpoint: string, page: number) => {
+    setRequestsLoading(true)
+    try {
+      const params = new URLSearchParams({
+        endpoint,
+        range,
+        page: String(page),
+        per_page: '20',
+      })
+      const data = await apiFetch<PaginatedRequests>(`/audit/requests?${params}`)
+      if (data) {
+        setRequests(data.data)
+        setRequestsTotal(data.total)
+      }
+    } catch {
+      setRequests([])
+    } finally {
+      setRequestsLoading(false)
+    }
+  }, [range])
+
+  const handleEndpointClick = useCallback((key: string, endpoint: string) => {
+    if (expandedEndpoint === key) {
+      setExpandedEndpoint(null)
+      setRequests([])
+      setExpandedRequest(null)
+    } else {
+      setExpandedEndpoint(key)
+      setRequestsPage(1)
+      setExpandedRequest(null)
+      fetchRequests(endpoint, 1)
+    }
+  }, [expandedEndpoint, fetchRequests])
+
+  const handlePageChange = useCallback((endpoint: string, page: number) => {
+    setRequestsPage(page)
+    fetchRequests(endpoint, page)
+  }, [fetchRequests])
+
+  // Sort and filter
+  const filtered = stats.filter(s => {
+    if (!searchTerm) return true
+    const term = searchTerm.toLowerCase()
+    return s.endpoint.toLowerCase().includes(term) || s.method.toLowerCase().includes(term)
+  })
+
+  const sorted = [...filtered].sort((a, b) => {
+    let cmp = 0
+    switch (sortField) {
+      case 'endpoint': cmp = a.endpoint.localeCompare(b.endpoint); break
+      case 'count': cmp = a.count - b.count; break
+      case 'avg_latency_ms': cmp = a.avg_latency_ms - b.avg_latency_ms; break
+      case 'error_count': cmp = a.error_count - b.error_count; break
+      case 'last_hit': cmp = (a.last_hit ?? '').localeCompare(b.last_hit ?? ''); break
+    }
+    return sortDir === 'desc' ? -cmp : cmp
+  })
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortField(field)
+      setSortDir('desc')
+    }
+  }
+
+  const totalRequests = stats.reduce((sum, s) => sum + s.count, 0)
+  const totalErrors = stats.reduce((sum, s) => sum + s.error_count, 0)
+  const avgLatency = stats.length > 0
+    ? Math.round(stats.reduce((sum, s) => sum + s.avg_latency_ms, 0) / stats.length)
+    : 0
+
+  const totalPages = Math.ceil(requestsTotal / 20)
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 bg-brand-500/10 dark:bg-[#151518] rounded-2xl flex items-center justify-center">
+            <ScrollText size={20} className="text-brand-600 dark:text-white" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Audit Log</h1>
+            <p className="text-sm text-slate-500 dark:text-[#66666e]">API request monitoring and inspection</p>
+          </div>
+        </div>
+
+        {/* Time range selector */}
+        <div className="flex items-center gap-2 bg-slate-100 dark:bg-[#0c0c0e] rounded-xl p-1 border border-slate-200 dark:border-[#1c1c1f]">
+          {(['1h', '6h', '24h', '7d'] as TimeRange[]).map(r => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
+                range === r
+                  ? 'bg-white dark:bg-[#1c1c1f] text-brand-600 dark:text-white shadow-sm'
+                  : 'text-slate-500 dark:text-[#66666e] hover:text-slate-700 dark:hover:text-white'
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-4 gap-4">
+        <Card>
+          <CardBody>
+            <p className="text-xs font-semibold text-slate-400 dark:text-[#66666e] uppercase tracking-wider">Total Requests</p>
+            <p className="text-2xl font-bold text-slate-900 dark:text-white mt-1">{totalRequests.toLocaleString()}</p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody>
+            <p className="text-xs font-semibold text-slate-400 dark:text-[#66666e] uppercase tracking-wider">Endpoints</p>
+            <p className="text-2xl font-bold text-slate-900 dark:text-white mt-1">{stats.length}</p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody>
+            <p className="text-xs font-semibold text-slate-400 dark:text-[#66666e] uppercase tracking-wider">Errors</p>
+            <p className="text-2xl font-bold text-red-500 mt-1">{totalErrors.toLocaleString()}</p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody>
+            <p className="text-xs font-semibold text-slate-400 dark:text-[#66666e] uppercase tracking-wider">Avg Latency</p>
+            <p className="text-2xl font-bold text-slate-900 dark:text-white mt-1">{avgLatency}ms</p>
+          </CardBody>
+        </Card>
+      </div>
+
+      {/* Main table */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-bold text-slate-900 dark:text-white">API Endpoints</h2>
+            <div className="relative">
+              <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 dark:text-[#55555e]" />
+              <input
+                type="text"
+                placeholder="Filter endpoints..."
+                value={searchTerm}
+                onChange={e => setSearchTerm(e.target.value)}
+                className="pl-9 pr-4 py-2 text-sm rounded-xl bg-white dark:bg-[#0a0a0c] border border-slate-200 dark:border-[#1c1c1f] text-slate-900 dark:text-white placeholder:text-slate-400 dark:placeholder:text-[#55555e] focus:outline-none focus:ring-2 focus:ring-brand-500/30 w-64"
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardBody className="p-0">
+          {loading ? (
+            <div className="flex justify-center py-12"><Spinner /></div>
+          ) : error ? (
+            <div className="p-6"><ErrorMessage error={error} /></div>
+          ) : sorted.length === 0 ? (
+            <div className="text-center py-12 text-slate-500 dark:text-[#66666e]">
+              No audit data found for the selected time range
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-[#1c1c1f]">
+                    <th className="w-8 px-4 py-3"></th>
+                    <SortableHeader field="endpoint" label="Endpoint" current={sortField} dir={sortDir} onSort={handleSort} />
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-slate-400 dark:text-[#66666e] uppercase tracking-wider">Method</th>
+                    <SortableHeader field="count" label="Hits" current={sortField} dir={sortDir} onSort={handleSort} />
+                    <SortableHeader field="avg_latency_ms" label="Avg Latency" current={sortField} dir={sortDir} onSort={handleSort} />
+                    <SortableHeader field="error_count" label="Errors" current={sortField} dir={sortDir} onSort={handleSort} />
+                    <SortableHeader field="last_hit" label="Last Hit" current={sortField} dir={sortDir} onSort={handleSort} />
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map(s => {
+                    const key = `${s.endpoint}:${s.method}`
+                    const isExpanded = expandedEndpoint === key
+                    const errorRate = s.count > 0 ? ((s.error_count / s.count) * 100).toFixed(1) : '0.0'
+
+                    return (
+                      <EndpointRow
+                        key={key}
+                        stat={s}
+                        rowKey={key}
+                        isExpanded={isExpanded}
+                        errorRate={errorRate}
+                        onToggle={() => handleEndpointClick(key, s.endpoint)}
+                        requests={requests}
+                        requestsLoading={requestsLoading}
+                        requestsPage={requestsPage}
+                        totalPages={totalPages}
+                        requestsTotal={requestsTotal}
+                        expandedRequest={expandedRequest}
+                        onExpandRequest={setExpandedRequest}
+                        onPageChange={(p) => handlePageChange(s.endpoint, p)}
+                      />
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardBody>
+      </Card>
+    </div>
+  )
+}
+
+function SortableHeader({
+  field, label, current, dir: _dir, onSort
+}: {
+  field: SortField; label: string; current: SortField; dir: SortDir; onSort: (f: SortField) => void
+}) {
+  return (
+    <th
+      className="px-4 py-3 text-left text-xs font-semibold text-slate-400 dark:text-[#66666e] uppercase tracking-wider cursor-pointer hover:text-slate-600 dark:hover:text-white select-none"
+      onClick={() => onSort(field)}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <ArrowUpDown size={12} className={current === field ? 'text-brand-500' : 'opacity-30'} />
+      </span>
+    </th>
+  )
+}
+
+function EndpointRow({
+  stat, rowKey: _rowKey, isExpanded, errorRate, onToggle,
+  requests, requestsLoading, requestsPage, totalPages, requestsTotal,
+  expandedRequest, onExpandRequest, onPageChange,
+}: {
+  stat: EndpointStats
+  rowKey: string
+  isExpanded: boolean
+  errorRate: string
+  onToggle: () => void
+  requests: AuditLogEntry[]
+  requestsLoading: boolean
+  requestsPage: number
+  totalPages: number
+  requestsTotal: number
+  expandedRequest: string | null
+  onExpandRequest: (id: string | null) => void
+  onPageChange: (page: number) => void
+}) {
+  return (
+    <>
+      <tr
+        className="border-b border-slate-100 dark:border-[#151518] hover:bg-slate-50 dark:hover:bg-[#0c0c0e] cursor-pointer transition-colors"
+        onClick={onToggle}
+      >
+        <td className="px-4 py-3">
+          {isExpanded
+            ? <ChevronDown size={14} className="text-slate-400" />
+            : <ChevronRight size={14} className="text-slate-400" />}
+        </td>
+        <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">{stat.endpoint}</td>
+        <td className="px-4 py-3"><Badge variant={METHOD_COLORS[stat.method] ?? 'gray'}>{stat.method}</Badge></td>
+        <td className="px-4 py-3 font-semibold text-slate-900 dark:text-white">{stat.count.toLocaleString()}</td>
+        <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{stat.avg_latency_ms}ms</td>
+        <td className="px-4 py-3">
+          <span className={stat.error_count > 0 ? 'text-red-500 font-semibold' : 'text-slate-500 dark:text-[#66666e]'}>
+            {stat.error_count.toLocaleString()} ({errorRate}%)
+          </span>
+        </td>
+        <td className="px-4 py-3 text-slate-500 dark:text-[#66666e] text-xs">
+          {stat.last_hit ? (
+            <span className="inline-flex items-center gap-1">
+              <Clock size={12} />
+              {formatTimestamp(stat.last_hit)}
+            </span>
+          ) : '—'}
+        </td>
+      </tr>
+
+      {isExpanded && (
+        <tr>
+          <td colSpan={7} className="bg-slate-50 dark:bg-[#0a0a0c] border-b border-slate-200 dark:border-[#1c1c1f]">
+            <div className="px-6 py-4">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-bold text-slate-700 dark:text-slate-300">
+                  Recent Requests ({requestsTotal.toLocaleString()} total)
+                </h3>
+                {totalPages > 1 && (
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onPageChange(requestsPage - 1) }}
+                      disabled={requestsPage <= 1}
+                      className="p-1 rounded-lg text-slate-400 hover:text-slate-700 dark:hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
+                    >
+                      <ChevronLeft size={16} />
+                    </button>
+                    <span className="text-xs text-slate-500 dark:text-[#66666e]">
+                      Page {requestsPage} of {totalPages}
+                    </span>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onPageChange(requestsPage + 1) }}
+                      disabled={requestsPage >= totalPages}
+                      className="p-1 rounded-lg text-slate-400 hover:text-slate-700 dark:hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
+                    >
+                      <ChevronRight size={16} />
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {requestsLoading ? (
+                <div className="flex justify-center py-6"><Spinner /></div>
+              ) : requests.length === 0 ? (
+                <p className="text-sm text-slate-500 dark:text-[#66666e] py-4">No requests found</p>
+              ) : (
+                <div className="space-y-1">
+                  {requests.map(req => {
+                    const isReqExpanded = expandedRequest === req.id
+                    return (
+                      <div key={req.id}>
+                        <div
+                          className="flex items-center gap-4 px-4 py-2.5 rounded-xl hover:bg-white dark:hover:bg-[#151518] cursor-pointer transition-colors"
+                          onClick={(e) => { e.stopPropagation(); onExpandRequest(isReqExpanded ? null : req.id) }}
+                        >
+                          {isReqExpanded
+                            ? <ChevronDown size={12} className="text-slate-400 shrink-0" />
+                            : <ChevronRight size={12} className="text-slate-400 shrink-0" />}
+                          <span className="text-xs text-slate-500 dark:text-[#66666e] w-40 shrink-0">{formatTimestamp(req.timestamp)}</span>
+                          <span className="text-xs font-mono text-slate-600 dark:text-slate-400 w-48 shrink-0 truncate">{req.request_id}</span>
+                          <Badge variant={statusBadgeVariant(req.response_status)}>{req.response_status}</Badge>
+                          <span className="text-xs text-slate-500 dark:text-[#66666e]">{req.latency_ms}ms</span>
+                          {req.merchant_id && (
+                            <span className="text-xs text-slate-400 dark:text-[#55555e] ml-auto">merchant: {req.merchant_id}</span>
+                          )}
+                        </div>
+
+                        {isReqExpanded && (
+                          <div className="ml-10 mr-4 mt-2 mb-4 p-4 bg-white dark:bg-[#0c0c0e] rounded-xl border border-slate-200 dark:border-[#1c1c1f]" onClick={e => e.stopPropagation()}>
+                            <JsonBlock data={req.request_headers} label="Request Headers" />
+                            <JsonBlock data={req.request_body} label="Request Body" />
+                            <JsonBlock data={req.response_body} label="Response Body" />
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -125,6 +125,23 @@ export default defineConfig({
           })
         },
       },
+      '/audit': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq, req) => {
+            console.log(`\n[PROXY] ${new Date().toISOString()}`)
+            console.log(`Forwarding: ${req.method} ${req.url} -> http://localhost:8080${req.url}`)
+          })
+          proxy.on('proxyRes', (proxyRes, req) => {
+            console.log(`[PROXY] Response: ${proxyRes.statusCode} ${proxyRes.statusMessage} for ${req.url}`)
+          })
+          proxy.on('error', (err, req) => {
+            console.log(`\n[PROXY ERROR] ${new Date().toISOString()}`)
+            console.log(`Error forwarding ${req.url}:`, err.message)
+          })
+        },
+      },
       '/update-gateway-score': {
         target: 'http://localhost:8080',
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- Add Postgres `audit_log` table migration with indexes on timestamp, endpoint, request_id, and merchant_id
- Add Axum middleware that captures every API request/response (sanitizes auth headers, truncates large response bodies, extracts merchant_id, logs latency) and writes to `audit_log` asynchronously via `tokio::spawn`
- Add 3 audit API endpoints: `GET /audit/stats` (per-endpoint hit counts with avg latency and error rates), `GET /audit/requests` (paginated request list), `GET /audit/request/:id` (single entry detail)
- Add React `AuditPage` dashboard with sortable endpoint stats table, time range filter (1h/6h/24h/7d), search, expandable request explorer with full JSON request/response inspection, and pagination
- Add "Observability" section to sidebar with Audit Log entry

## Test plan
- [ ] Run the Postgres migration (`up.sql`) against a test database
- [ ] Start the backend and verify `/audit/stats`, `/audit/requests`, and `/audit/request/:id` return valid JSON
- [ ] Make API calls (e.g., `/decide-gateway`) and verify they appear in the audit log
- [ ] Verify auth headers are redacted in stored `request_headers`
- [ ] Verify response bodies > 10KB are truncated
- [ ] Open the frontend `/audit` page and verify the dashboard renders
- [ ] Test time range filter switching, endpoint search, and pagination
- [ ] Click an endpoint row to expand and see individual requests
- [ ] Click a request to expand and see full headers/body JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)