### PR TITLE
feat(auth): add merchant API key authentication

### DIFF
--- a/migrations/2026-04-21-000000_add_merchant_api_keys/down.sql
+++ b/migrations/2026-04-21-000000_add_merchant_api_keys/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS merchant_api_keys;

--- a/migrations/2026-04-21-000000_add_merchant_api_keys/up.sql
+++ b/migrations/2026-04-21-000000_add_merchant_api_keys/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE merchant_api_keys (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    key_id VARCHAR(64) NOT NULL UNIQUE,
+    merchant_id VARCHAR(255) NOT NULL,
+    key_hash VARCHAR(64) NOT NULL UNIQUE,
+    key_prefix VARCHAR(16) NOT NULL,
+    description VARCHAR(255),
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+);
+
+CREATE INDEX idx_merchant_api_keys_merchant_id ON merchant_api_keys (merchant_id);

--- a/migrations_pg/2026-04-21-000000_add_merchant_api_keys/down.sql
+++ b/migrations_pg/2026-04-21-000000_add_merchant_api_keys/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS merchant_api_keys;

--- a/migrations_pg/2026-04-21-000000_add_merchant_api_keys/up.sql
+++ b/migrations_pg/2026-04-21-000000_add_merchant_api_keys/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE merchant_api_keys (
+    id BIGSERIAL PRIMARY KEY,
+    key_id VARCHAR(64) NOT NULL UNIQUE,
+    merchant_id VARCHAR(255) NOT NULL,
+    key_hash VARCHAR(64) NOT NULL UNIQUE,
+    key_prefix VARCHAR(16) NOT NULL,
+    description VARCHAR(255),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_merchant_api_keys_merchant_id ON merchant_api_keys (merchant_id);

--- a/scripts/test_api_key_auth.sh
+++ b/scripts/test_api_key_auth.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+MERCHANT_ID="test_merchant_$(date +%s)"
+
+PASS=0
+FAIL=0
+
+check() {
+    local name="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS  $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  $name (expected $expected, got $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo ""
+echo "Target: $BASE_URL"
+echo "Merchant: $MERCHANT_ID"
+echo "=================================================="
+
+# ── 1. Health ──────────────────────────────────────────
+echo ""
+echo "[ Health ]"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/health/ready")
+check "GET /health/ready → 200" "200" "$STATUS"
+
+# ── 2. Backward compat (no auth header, no key) ────────
+echo ""
+echo "[ Backward-compat mode — expect 401 only when api_key_auth_enabled=true ]"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/rule/get" \
+    -H "Content-Type: application/json" -d '{}')
+if [ "$STATUS" = "401" ]; then
+    echo "  INFO  Auth is ENFORCED (api_key_auth_enabled=true) — skipping backward-compat check"
+    AUTH_ENFORCED=true
+else
+    check "No x-api-key passes through (backward compat)" "422" "$STATUS"
+    AUTH_ENFORCED=false
+fi
+
+# ── 3. Merchant create → returns api_key ───────────────
+echo ""
+echo "[ Merchant create ]"
+RESPONSE=$(curl -s -X POST "$BASE_URL/merchant-account/create" \
+    -H "Content-Type: application/json" \
+    -d "{\"merchant_id\": \"$MERCHANT_ID\", \"config\": {}}")
+
+API_KEY=$(echo "$RESPONSE" | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4)
+if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ]; then
+    echo "  PASS  POST /merchant-account/create returns api_key"
+    echo "        key: ${API_KEY:0:20}..."
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  POST /merchant-account/create — api_key missing in response"
+    echo "        response: $RESPONSE"
+    FAIL=$((FAIL + 1))
+    echo ""
+    echo "Cannot continue without a valid API key. Exiting."
+    exit 1
+fi
+
+# ── 4. Auth enforcement checks ─────────────────────────
+if [ "$AUTH_ENFORCED" = "true" ]; then
+    echo ""
+    echo "[ Auth enforcement ]"
+
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/rule/get" \
+        -H "Content-Type: application/json" -d '{}')
+    check "No key → 401" "401" "$STATUS"
+
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/rule/get" \
+        -H "Content-Type: application/json" \
+        -H "x-api-key: DE_wrongkeydeadbeef00000000000000000000000000000000000000000000000" \
+        -d '{}')
+    check "Wrong key → 401" "401" "$STATUS"
+
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/rule/get" \
+        -H "Content-Type: application/json" \
+        -H "x-api-key: $API_KEY" \
+        -d '{}')
+    check "Valid key passes auth (422 = body error, not 401)" "422" "$STATUS"
+fi
+
+# ── 5. Create additional key ───────────────────────────
+echo ""
+echo "[ Create additional API key ]"
+CREATE_RESPONSE=$(curl -s -X POST "$BASE_URL/api-key/create" \
+    -H "Content-Type: application/json" \
+    -H "x-api-key: $API_KEY" \
+    -d "{\"merchant_id\": \"$MERCHANT_ID\", \"description\": \"secondary key\"}")
+
+NEW_KEY=$(echo "$CREATE_RESPONSE" | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4)
+NEW_KEY_ID=$(echo "$CREATE_RESPONSE" | grep -o '"key_id":"[^"]*"' | cut -d'"' -f4)
+
+if [ -n "$NEW_KEY" ] && [ -n "$NEW_KEY_ID" ]; then
+    echo "  PASS  POST /api-key/create returns new key"
+    echo "        key_id: $NEW_KEY_ID"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  POST /api-key/create — unexpected response: $CREATE_RESPONSE"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── 6. List keys ───────────────────────────────────────
+echo ""
+echo "[ List API keys ]"
+LIST_RESPONSE=$(curl -s "$BASE_URL/api-key/list/$MERCHANT_ID" \
+    -H "x-api-key: $API_KEY")
+KEY_COUNT=$(echo "$LIST_RESPONSE" | grep -o '"key_id"' | wc -l | tr -d ' ')
+if [ "$KEY_COUNT" -ge "2" ]; then
+    echo "  PASS  GET /api-key/list/:merchant_id returns $KEY_COUNT keys"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  GET /api-key/list/:merchant_id — got: $LIST_RESPONSE"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── 7. New key works ───────────────────────────────────
+if [ -n "$NEW_KEY" ]; then
+    echo ""
+    echo "[ New key is usable ]"
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/rule/get" \
+        -H "Content-Type: application/json" \
+        -H "x-api-key: $NEW_KEY" \
+        -d '{}')
+    check "Newly created key passes auth (422, not 401)" "422" "$STATUS"
+fi
+
+# ── 8. Revoke key ──────────────────────────────────────
+if [ -n "$NEW_KEY_ID" ]; then
+    echo ""
+    echo "[ Revoke API key ]"
+    REVOKE_RESPONSE=$(curl -s -X DELETE "$BASE_URL/api-key/$NEW_KEY_ID" \
+        -H "x-api-key: $API_KEY")
+    if echo "$REVOKE_RESPONSE" | grep -q "revoked successfully"; then
+        echo "  PASS  DELETE /api-key/:key_id revokes key"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  DELETE /api-key/:key_id — got: $REVOKE_RESPONSE"
+        FAIL=$((FAIL + 1))
+    fi
+
+    # ── 9. Revoked key is rejected ─────────────────────
+    echo ""
+    echo "[ Revoked key is rejected ]"
+    # Clear Redis cache entry so middleware hits DB
+    sleep 1
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/rule/get" \
+        -H "Content-Type: application/json" \
+        -H "x-api-key: $NEW_KEY" \
+        -d '{}')
+    check "Revoked key → 401" "401" "$STATUS"
+
+    # ── 10. List shows is_active: false ────────────────
+    echo ""
+    echo "[ List reflects revocation ]"
+    LIST_AFTER=$(curl -s "$BASE_URL/api-key/list/$MERCHANT_ID" \
+        -H "x-api-key: $API_KEY")
+    if echo "$LIST_AFTER" | grep -q '"is_active":false'; then
+        echo "  PASS  Revoked key shows is_active=false in list"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  Revoked key not reflected in list: $LIST_AFTER"
+        FAIL=$((FAIL + 1))
+    fi
+fi
+
+# ── 11. Redis cache hit ────────────────────────────────
+echo ""
+echo "[ Redis cache hit ]"
+for i in 1 2; do
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/rule/get" \
+        -H "Content-Type: application/json" \
+        -H "x-api-key: $API_KEY" \
+        -d '{}')
+    check "Request $i with valid key passes (cache warm on 2nd)" "422" "$STATUS"
+done
+
+# ── Summary ────────────────────────────────────────────
+echo ""
+echo "=================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo ""
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ use tower_http::trace as tower_trace;
 use crate::{
     api_client::ApiClient,
     config::{self, GlobalConfig, TenantConfig},
-    error, logger, routes, storage,
+    error, logger, middleware as custom_middleware, routes, storage,
     tenant::GlobalAppState,
     utils,
 };
@@ -189,11 +189,8 @@ where
         handle_clone.shutdown(); // Trigger axum_server shutdown
     });
 
-    let router = axum::Router::new()
-        // .layer(middleware::from_fn_with_state(
-        //     global_app_state.clone(),
-        //     custom_middleware::authenticate,
-        // ))
+    // Routes that require API key authentication
+    let protected_router = axum::Router::new()
         .route(
             "/routing/create",
             axum::routing::post(crate::euclid::handlers::routing_rules::routing_create),
@@ -239,10 +236,6 @@ where
             post(routes::rule_configuration::delete_rule_config),
         )
         .route(
-            "/merchant-account/create",
-            post(routes::merchant_account_config::create_merchant_config),
-        )
-        .route(
             "/merchant-account/:merchant-id",
             get(routes::merchant_account_config::get_merchant_config),
         )
@@ -257,20 +250,43 @@ where
         .route(
             "/config/routing-keys",
             axum::routing::get(crate::euclid::handlers::routing_rules::get_routing_config),
-        );
-    let router = router.route("/update-score", post(routes::update_score::update_score));
-    let router = router.route(
-        "/decide-gateway",
-        post(routes::decide_gateway::decide_gateway),
+        )
+        .route("/update-score", post(routes::update_score::update_score))
+        .route(
+            "/decide-gateway",
+            post(routes::decide_gateway::decide_gateway),
+        )
+        .route(
+            "/routing/hybrid",
+            post(routes::hybrid_routing::hybrid_routing_evaluate),
+        )
+        .route(
+            "/update-gateway-score",
+            post(routes::update_gateway_score::update_gateway_score),
+        )
+        .route(
+            "/api-key/create",
+            post(routes::api_key::create_api_key),
+        )
+        .route(
+            "/api-key/list/:merchant_id",
+            get(routes::api_key::list_api_keys),
+        )
+        .route(
+            "/api-key/:key_id",
+            delete(routes::api_key::revoke_api_key),
+        )
+        .layer(middleware::from_fn(custom_middleware::authenticate));
+
+    // Routes that do not require authentication (public)
+    let public_router = axum::Router::new().route(
+        "/merchant-account/create",
+        post(routes::merchant_account_config::create_merchant_config),
     );
-    let router = router.route(
-        "/routing/hybrid",
-        post(routes::hybrid_routing::hybrid_routing_evaluate),
-    );
-    let router = router.route(
-        "/update-gateway-score",
-        post(routes::update_gateway_score::update_gateway_score),
-    );
+
+    let router = axum::Router::new()
+        .merge(protected_router)
+        .merge(public_router);
 
     let middleware = ServiceBuilder::new()
         .layer(middleware::from_fn(ensure_request_id))

--- a/src/app.rs
+++ b/src/app.rs
@@ -264,18 +264,12 @@ where
             "/update-gateway-score",
             post(routes::update_gateway_score::update_gateway_score),
         )
-        .route(
-            "/api-key/create",
-            post(routes::api_key::create_api_key),
-        )
+        .route("/api-key/create", post(routes::api_key::create_api_key))
         .route(
             "/api-key/list/:merchant_id",
             get(routes::api_key::list_api_keys),
         )
-        .route(
-            "/api-key/:key_id",
-            delete(routes::api_key::revoke_api_key),
-        )
+        .route("/api-key/:key_id", delete(routes::api_key::revoke_api_key))
         .layer(middleware::from_fn(custom_middleware::authenticate));
 
     // Routes that do not require authentication (public)

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -34,7 +34,13 @@ mod tests {
     fn generated_key_has_correct_length() {
         let key = generate_api_key();
         // "DE_" (3) + hex of 32 bytes (64) = 67
-        assert_eq!(key.len(), 67, "expected length 67, got {}: {}", key.len(), key);
+        assert_eq!(
+            key.len(),
+            67,
+            "expected length 67, got {}: {}",
+            key.len(),
+            key
+        );
     }
 
     #[test]
@@ -71,7 +77,10 @@ mod tests {
         let stored_hash = hash_api_key(&raw_key);
         // Simulate what the middleware does: hash the incoming key and compare
         let incoming_hash = hash_api_key(&raw_key);
-        assert_eq!(stored_hash, incoming_hash, "stored hash must match recomputed hash");
+        assert_eq!(
+            stored_hash, incoming_hash,
+            "stored hash must match recomputed hash"
+        );
     }
 
     #[test]
@@ -80,7 +89,10 @@ mod tests {
         let stored_hash = hash_api_key(&raw_key);
         let wrong_key = generate_api_key();
         let wrong_hash = hash_api_key(&wrong_key);
-        assert_ne!(stored_hash, wrong_hash, "wrong key must not match stored hash");
+        assert_ne!(
+            stored_hash, wrong_hash,
+            "wrong key must not match stored hash"
+        );
     }
 
     #[test]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,0 +1,100 @@
+use ring::digest;
+use uuid::Uuid;
+
+const KEY_PREFIX: &str = "DE_";
+
+pub fn generate_api_key() -> String {
+    let random_bytes = Uuid::new_v4().as_bytes().to_vec();
+    let second_bytes = Uuid::new_v4().as_bytes().to_vec();
+    let combined: Vec<u8> = random_bytes.into_iter().chain(second_bytes).collect();
+    format!("{}{}", KEY_PREFIX, hex::encode(combined))
+}
+
+pub fn hash_api_key(key: &str) -> String {
+    let digest = digest::digest(&digest::SHA256, key.as_bytes());
+    hex::encode(digest.as_ref())
+}
+
+pub fn extract_key_prefix(key: &str) -> String {
+    let hex_part = key.strip_prefix(KEY_PREFIX).unwrap_or(key);
+    format!("{}{}", KEY_PREFIX, &hex_part[..8.min(hex_part.len())])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_key_has_correct_prefix() {
+        let key = generate_api_key();
+        assert!(key.starts_with("DE_"), "key should start with DE_: {}", key);
+    }
+
+    #[test]
+    fn generated_key_has_correct_length() {
+        let key = generate_api_key();
+        // "DE_" (3) + hex of 32 bytes (64) = 67
+        assert_eq!(key.len(), 67, "expected length 67, got {}: {}", key.len(), key);
+    }
+
+    #[test]
+    fn generated_keys_are_unique() {
+        let a = generate_api_key();
+        let b = generate_api_key();
+        assert_ne!(a, b, "two generated keys must be different");
+    }
+
+    #[test]
+    fn hash_is_deterministic() {
+        let key = "DE_abc123";
+        assert_eq!(hash_api_key(key), hash_api_key(key));
+    }
+
+    #[test]
+    fn hash_is_64_hex_chars() {
+        let key = generate_api_key();
+        let hash = hash_api_key(&key);
+        assert_eq!(hash.len(), 64, "SHA-256 hex should be 64 chars");
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn different_keys_produce_different_hashes() {
+        let hash_a = hash_api_key("DE_aaaa");
+        let hash_b = hash_api_key("DE_bbbb");
+        assert_ne!(hash_a, hash_b);
+    }
+
+    #[test]
+    fn hash_matches_on_verification() {
+        let raw_key = generate_api_key();
+        let stored_hash = hash_api_key(&raw_key);
+        // Simulate what the middleware does: hash the incoming key and compare
+        let incoming_hash = hash_api_key(&raw_key);
+        assert_eq!(stored_hash, incoming_hash, "stored hash must match recomputed hash");
+    }
+
+    #[test]
+    fn wrong_key_does_not_match_hash() {
+        let raw_key = generate_api_key();
+        let stored_hash = hash_api_key(&raw_key);
+        let wrong_key = generate_api_key();
+        let wrong_hash = hash_api_key(&wrong_key);
+        assert_ne!(stored_hash, wrong_hash, "wrong key must not match stored hash");
+    }
+
+    #[test]
+    fn key_prefix_format() {
+        let key = generate_api_key();
+        let prefix = extract_key_prefix(&key);
+        assert!(prefix.starts_with("DE_"), "prefix should start with DE_");
+        // "DE_" + 8 hex chars = 11 chars
+        assert_eq!(prefix.len(), 11, "prefix should be 11 chars: {}", prefix);
+    }
+
+    #[test]
+    fn key_prefix_is_consistent() {
+        let key = generate_api_key();
+        assert_eq!(extract_key_prefix(&key), extract_key_prefix(&key));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,8 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub debit_routing_config: network_decider::types::DebitRoutingConfig,
     pub compression_filepath: Option<CompressionFilepath>,
+    #[serde(default)]
+    pub api_key_auth_enabled: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -244,6 +244,54 @@ impl axum::response::IntoResponse for MerchantAccountConfigurationError {
     }
 }
 
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ApiKeyError {
+    #[error("API key not found")]
+    NotFound,
+    #[error("API key creation failed")]
+    CreationFailed,
+    #[error("API key revocation failed")]
+    RevocationFailed,
+    #[error("Merchant not found")]
+    MerchantNotFound,
+    #[error("Storage error")]
+    StorageError,
+}
+
+impl axum::response::IntoResponse for ApiKeyError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::NotFound => (
+                hyper::StatusCode::NOT_FOUND,
+                axum::Json(crate::error::ApiErrorResponse::new(
+                    crate::error::error_codes::TE_04,
+                    "API key not found".to_string(),
+                    None,
+                )),
+            )
+                .into_response(),
+            Self::MerchantNotFound => (
+                hyper::StatusCode::NOT_FOUND,
+                axum::Json(crate::error::ApiErrorResponse::new(
+                    crate::error::error_codes::TE_04,
+                    "Merchant not found".to_string(),
+                    None,
+                )),
+            )
+                .into_response(),
+            Self::CreationFailed | Self::RevocationFailed | Self::StorageError => (
+                hyper::StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(crate::error::ApiErrorResponse::new(
+                    crate::error::error_codes::TE_04,
+                    self.to_string(),
+                    None,
+                )),
+            )
+                .into_response(),
+        }
+    }
+}
+
 pub trait NotFoundError {
     fn is_not_found(&self) -> bool;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 
 pub mod api_client;
 pub mod app;
+pub mod auth;
 pub mod config;
 pub mod crypto;
 pub mod custom_extractors;
@@ -38,7 +39,6 @@ pub mod generics;
 pub mod logger;
 pub mod merchant_config_util;
 pub mod metrics;
-#[cfg(feature = "middleware")]
 pub mod middleware;
 pub mod redis;
 pub mod routes;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -29,11 +29,7 @@ pub async fn authenticate(
 ) -> Result<Response<Body>, ContainerError<error::ApiError>> {
     let app_state = match APP_STATE.get() {
         Some(s) => s,
-        None => {
-            return Ok(
-                (StatusCode::INTERNAL_SERVER_ERROR, "Server not ready").into_response()
-            )
-        }
+        None => return Ok((StatusCode::INTERNAL_SERVER_ERROR, "Server not ready").into_response()),
     };
 
     if !app_state.global_config.api_key_auth_enabled {
@@ -42,27 +38,19 @@ pub async fn authenticate(
 
     let api_key = match req.headers().get("x-api-key").and_then(|v| v.to_str().ok()) {
         Some(k) => k.to_owned(),
-        None => {
-            return Ok((StatusCode::UNAUTHORIZED, "Missing x-api-key header").into_response())
-        }
+        None => return Ok((StatusCode::UNAUTHORIZED, "Missing x-api-key header").into_response()),
     };
 
     let key_hash = auth::hash_api_key(&api_key);
     let cache_key = format!("api_key:{}", key_hash);
 
-    let tenant_state = match crate::tenant::GlobalAppState::get_app_state_of_tenant(
-        app_state,
-        "public",
-    )
-    .await
-    {
-        Ok(s) => s,
-        Err(_) => {
-            return Ok(
-                (StatusCode::INTERNAL_SERVER_ERROR, "Tenant not found").into_response()
-            )
-        }
-    };
+    let tenant_state =
+        match crate::tenant::GlobalAppState::get_app_state_of_tenant(app_state, "public").await {
+            Ok(s) => s,
+            Err(_) => {
+                return Ok((StatusCode::INTERNAL_SERVER_ERROR, "Tenant not found").into_response())
+            }
+        };
 
     // Check Redis cache first
     if let Ok(cached) = tenant_state.redis_conn.get_key_string(&cache_key).await {
@@ -84,10 +72,7 @@ pub async fn authenticate(
         <MerchantApiKey as HasTable>::Table,
         _,
         MerchantApiKey,
-    >(
-        &tenant_state.db,
-        dsl::key_hash.eq(key_hash.clone()),
-    )
+    >(&tenant_state.db, dsl::key_hash.eq(key_hash.clone()))
     .await;
 
     let key_record = match results {
@@ -99,9 +84,13 @@ pub async fn authenticate(
         Some(record) => {
             let is_active = {
                 #[cfg(feature = "mysql")]
-                { record.is_active != 0 }
+                {
+                    record.is_active != 0
+                }
                 #[cfg(feature = "postgres")]
-                { record.is_active }
+                {
+                    record.is_active
+                }
             };
 
             if !is_active {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,11 +1,13 @@
+use crate::app::APP_STATE;
+use crate::auth;
 use crate::custom_extractors::TenantStateResolver;
 use crate::error::{self, ContainerError};
 use axum::body::Body;
-use axum::http::header::HeaderValue;
 use axum::response::{IntoResponse, Response};
 use axum::{http::Request, http::StatusCode, middleware::Next};
+use diesel::ExpressionMethods;
 
-const VALID_API_KEY: &str = "your_valid_api_key"; // Replace with your actual API key
+const API_KEY_CACHE_TTL: i64 = 300;
 
 /// Middleware providing implementation to perform JWE + JWS encryption and decryption around the
 /// card APIs
@@ -18,17 +20,102 @@ pub async fn middleware(
     Ok(response)
 }
 
-/// Middleware to authenticate requests using the x-api-key header
+/// Middleware to authenticate requests using the x-api-key header.
+/// Validates against DB-backed API keys with Redis caching.
+/// When `api_key_auth_enabled` is false in config, all requests pass through (backward compat mode).
 pub async fn authenticate(
     req: Request<Body>,
     next: Next,
 ) -> Result<Response<Body>, ContainerError<error::ApiError>> {
-    if let Some(api_key) = req.headers().get("x-api-key") {
-        if api_key == HeaderValue::from_static(VALID_API_KEY) {
+    let app_state = match APP_STATE.get() {
+        Some(s) => s,
+        None => {
+            return Ok(
+                (StatusCode::INTERNAL_SERVER_ERROR, "Server not ready").into_response()
+            )
+        }
+    };
+
+    if !app_state.global_config.api_key_auth_enabled {
+        return Ok(next.run(req).await);
+    }
+
+    let api_key = match req.headers().get("x-api-key").and_then(|v| v.to_str().ok()) {
+        Some(k) => k.to_owned(),
+        None => {
+            return Ok((StatusCode::UNAUTHORIZED, "Missing x-api-key header").into_response())
+        }
+    };
+
+    let key_hash = auth::hash_api_key(&api_key);
+    let cache_key = format!("api_key:{}", key_hash);
+
+    let tenant_state = match crate::tenant::GlobalAppState::get_app_state_of_tenant(
+        app_state,
+        "public",
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(_) => {
+            return Ok(
+                (StatusCode::INTERNAL_SERVER_ERROR, "Tenant not found").into_response()
+            )
+        }
+    };
+
+    // Check Redis cache first
+    if let Ok(cached) = tenant_state.redis_conn.get_key_string(&cache_key).await {
+        if !cached.is_empty() {
             return Ok(next.run(req).await);
         }
     }
 
-    let unauthorized_response = (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
-    Ok(unauthorized_response)
+    // Cache miss — query DB
+    use crate::storage::types::MerchantApiKey;
+    use diesel::associations::HasTable;
+
+    #[cfg(feature = "mysql")]
+    use crate::storage::schema::merchant_api_keys::dsl;
+    #[cfg(feature = "postgres")]
+    use crate::storage::schema_pg::merchant_api_keys::dsl;
+
+    let results = crate::generics::generic_find_all::<
+        <MerchantApiKey as HasTable>::Table,
+        _,
+        MerchantApiKey,
+    >(
+        &tenant_state.db,
+        dsl::key_hash.eq(key_hash.clone()),
+    )
+    .await;
+
+    let key_record = match results {
+        Ok(mut rows) => rows.pop(),
+        Err(_) => None,
+    };
+
+    match key_record {
+        Some(record) => {
+            let is_active = {
+                #[cfg(feature = "mysql")]
+                { record.is_active != 0 }
+                #[cfg(feature = "postgres")]
+                { record.is_active }
+            };
+
+            if !is_active {
+                return Ok((StatusCode::UNAUTHORIZED, "API key is revoked").into_response());
+            }
+
+            // Populate Redis cache
+            let _ = tenant_state
+                .redis_conn
+                .set_key_with_ttl(&cache_key, &record.merchant_id, API_KEY_CACHE_TTL)
+                .await;
+
+            Ok(next.run(req).await)
+        }
+        None => Ok((StatusCode::UNAUTHORIZED, "Invalid API key").into_response()),
+    }
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,3 +1,4 @@
+pub mod api_key;
 pub mod hybrid_routing;
 // pub mod data;
 pub mod decide_gateway;

--- a/src/routes/api_key.rs
+++ b/src/routes/api_key.rs
@@ -1,0 +1,187 @@
+use crate::app::get_tenant_app_state;
+use crate::auth;
+use crate::error::{self, ApiKeyError};
+use crate::storage::types::{MerchantApiKey, MerchantApiKeyNew, MerchantApiKeyRevoke};
+use crate::utils::date_time;
+use axum::{extract::Path, Json};
+use diesel::associations::HasTable;
+use diesel::ExpressionMethods;
+use serde::{Deserialize, Serialize};
+use time::PrimitiveDateTime;
+
+#[cfg(feature = "mysql")]
+use crate::storage::schema::merchant_api_keys::dsl;
+#[cfg(feature = "postgres")]
+use crate::storage::schema_pg::merchant_api_keys::dsl;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateApiKeyRequest {
+    pub merchant_id: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateApiKeyResponse {
+    pub key_id: String,
+    pub api_key: String,
+    pub key_prefix: String,
+    pub merchant_id: String,
+    pub description: Option<String>,
+    pub created_at: PrimitiveDateTime,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ApiKeyListItem {
+    pub key_id: String,
+    pub key_prefix: String,
+    pub merchant_id: String,
+    pub description: Option<String>,
+    pub is_active: bool,
+    pub created_at: PrimitiveDateTime,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RevokeApiKeyResponse {
+    pub key_id: String,
+    pub message: String,
+}
+
+impl From<MerchantApiKey> for ApiKeyListItem {
+    fn from(k: MerchantApiKey) -> Self {
+        Self {
+            key_id: k.key_id,
+            key_prefix: k.key_prefix,
+            merchant_id: k.merchant_id,
+            description: k.description,
+            #[cfg(feature = "mysql")]
+            is_active: k.is_active != 0,
+            #[cfg(feature = "postgres")]
+            is_active: k.is_active,
+            created_at: k.created_at,
+        }
+    }
+}
+
+#[axum::debug_handler]
+pub async fn create_api_key(
+    Json(payload): Json<CreateApiKeyRequest>,
+) -> Result<Json<CreateApiKeyResponse>, error::ContainerError<ApiKeyError>> {
+    let raw_key = auth::generate_api_key();
+    let key_hash = auth::hash_api_key(&raw_key);
+    let key_prefix = auth::extract_key_prefix(&raw_key);
+    let key_id = uuid::Uuid::new_v4().to_string();
+    let now = date_time::now();
+
+    let new_key = MerchantApiKeyNew {
+        key_id: key_id.clone(),
+        merchant_id: payload.merchant_id.clone(),
+        key_hash,
+        key_prefix: key_prefix.clone(),
+        description: payload.description.clone(),
+        #[cfg(feature = "mysql")]
+        is_active: 1,
+        #[cfg(feature = "postgres")]
+        is_active: true,
+        created_at: now,
+    };
+
+    let app_state = get_tenant_app_state().await;
+    crate::generics::generic_insert(&app_state.db, new_key)
+        .await
+        .map_err(|_| ApiKeyError::CreationFailed)?;
+
+    Ok(Json(CreateApiKeyResponse {
+        key_id,
+        api_key: raw_key,
+        key_prefix,
+        merchant_id: payload.merchant_id,
+        description: payload.description,
+        created_at: now,
+    }))
+}
+
+#[axum::debug_handler]
+pub async fn list_api_keys(
+    Path(merchant_id): Path<String>,
+) -> Result<Json<Vec<ApiKeyListItem>>, error::ContainerError<ApiKeyError>> {
+    let app_state = get_tenant_app_state().await;
+    let keys = crate::generics::generic_find_all::<
+        <MerchantApiKey as HasTable>::Table,
+        _,
+        MerchantApiKey,
+    >(&app_state.db, dsl::merchant_id.eq(merchant_id))
+    .await
+    .map_err(|_| ApiKeyError::StorageError)?;
+
+    Ok(Json(keys.into_iter().map(ApiKeyListItem::from).collect()))
+}
+
+#[axum::debug_handler]
+pub async fn revoke_api_key(
+    Path(key_id): Path<String>,
+) -> Result<Json<RevokeApiKeyResponse>, error::ContainerError<ApiKeyError>> {
+    let app_state = get_tenant_app_state().await;
+    let conn = &app_state.db.get_conn().await.map_err(|_| ApiKeyError::StorageError)?;
+
+    let revoke = MerchantApiKeyRevoke {
+        #[cfg(feature = "mysql")]
+        is_active: 0,
+        #[cfg(feature = "postgres")]
+        is_active: false,
+    };
+
+    crate::generics::generic_update::<
+        <MerchantApiKey as HasTable>::Table,
+        _,
+        _,
+    >(conn, dsl::key_id.eq(key_id.clone()), revoke)
+    .await
+    .map_err(|_| ApiKeyError::RevocationFailed)?;
+
+    // Remove from Redis cache
+    if let Ok(keys) = crate::generics::generic_find_all::<
+        <MerchantApiKey as HasTable>::Table,
+        _,
+        MerchantApiKey,
+    >(&app_state.db, dsl::key_id.eq(key_id.clone())).await {
+        for key in keys {
+            let cache_key = format!("api_key:{}", key.key_hash);
+            let _ = app_state.redis_conn.conn.delete_key(&cache_key).await;
+        }
+    }
+
+    Ok(Json(RevokeApiKeyResponse {
+        key_id,
+        message: "API key revoked successfully".to_string(),
+    }))
+}
+
+pub async fn insert_api_key_for_merchant(
+    merchant_id: &str,
+    description: Option<String>,
+) -> Option<String> {
+    let raw_key = auth::generate_api_key();
+    let key_hash = auth::hash_api_key(&raw_key);
+    let key_prefix = auth::extract_key_prefix(&raw_key);
+    let key_id = uuid::Uuid::new_v4().to_string();
+    let now = date_time::now();
+
+    let new_key = MerchantApiKeyNew {
+        key_id,
+        merchant_id: merchant_id.to_string(),
+        key_hash,
+        key_prefix,
+        description,
+        #[cfg(feature = "mysql")]
+        is_active: 1,
+        #[cfg(feature = "postgres")]
+        is_active: true,
+        created_at: now,
+    };
+
+    let app_state = get_tenant_app_state().await;
+    match crate::generics::generic_insert(&app_state.db, new_key).await {
+        Ok(_) => Some(raw_key),
+        Err(_) => None,
+    }
+}

--- a/src/routes/api_key.rs
+++ b/src/routes/api_key.rs
@@ -121,7 +121,11 @@ pub async fn revoke_api_key(
     Path(key_id): Path<String>,
 ) -> Result<Json<RevokeApiKeyResponse>, error::ContainerError<ApiKeyError>> {
     let app_state = get_tenant_app_state().await;
-    let conn = &app_state.db.get_conn().await.map_err(|_| ApiKeyError::StorageError)?;
+    let conn = &app_state
+        .db
+        .get_conn()
+        .await
+        .map_err(|_| ApiKeyError::StorageError)?;
 
     let revoke = MerchantApiKeyRevoke {
         #[cfg(feature = "mysql")]
@@ -130,11 +134,11 @@ pub async fn revoke_api_key(
         is_active: false,
     };
 
-    crate::generics::generic_update::<
-        <MerchantApiKey as HasTable>::Table,
-        _,
-        _,
-    >(conn, dsl::key_id.eq(key_id.clone()), revoke)
+    crate::generics::generic_update::<<MerchantApiKey as HasTable>::Table, _, _>(
+        conn,
+        dsl::key_id.eq(key_id.clone()),
+        revoke,
+    )
     .await
     .map_err(|_| ApiKeyError::RevocationFailed)?;
 
@@ -143,7 +147,9 @@ pub async fn revoke_api_key(
         <MerchantApiKey as HasTable>::Table,
         _,
         MerchantApiKey,
-    >(&app_state.db, dsl::key_id.eq(key_id.clone())).await {
+    >(&app_state.db, dsl::key_id.eq(key_id.clone()))
+    .await
+    {
         for key in keys {
             let cache_key = format!("api_key:{}", key.key_hash);
             let _ = app_state.redis_conn.conn.delete_key(&cache_key).await;

--- a/src/routes/merchant_account_config.rs
+++ b/src/routes/merchant_account_config.rs
@@ -10,6 +10,7 @@ pub struct MerchantAccountCreateResponse {
     pub message: String,
     pub merchant_id: String,
     pub gateway_success_rate_based_decider_input: Option<String>,
+    pub api_key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -106,10 +107,16 @@ pub async fn create_merchant_config(
             API_REQUEST_COUNTER
                 .with_label_values(&["merchant_account_create", "success"])
                 .inc();
+            let api_key = crate::routes::api_key::insert_api_key_for_merchant(
+                &merchant_id,
+                Some("Default API key".to_string()),
+            )
+            .await;
             Ok(Json(MerchantAccountCreateResponse {
                 message: "Merchant account created successfully".to_string(),
                 merchant_id,
                 gateway_success_rate_based_decider_input,
+                api_key,
             }))
         }
         Err(e) => {

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -520,6 +520,24 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    use diesel::sql_types::*;
+    merchant_api_keys (id) {
+        id -> Bigint,
+        #[max_length = 64]
+        key_id -> Varchar,
+        #[max_length = 255]
+        merchant_id -> Varchar,
+        #[max_length = 64]
+        key_hash -> Varchar,
+        #[max_length = 16]
+        key_prefix -> Varchar,
+        description -> Nullable<Varchar>,
+        is_active -> TinyInt,
+        created_at -> Datetime,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     card_brand_routes,
     card_info,
@@ -550,4 +568,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     txn_offer,
     txn_offer_detail,
     user_eligibility_info,
+    merchant_api_keys,
 );

--- a/src/storage/schema_pg.rs
+++ b/src/storage/schema_pg.rs
@@ -513,6 +513,23 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    merchant_api_keys (id) {
+        id -> Int8,
+        #[max_length = 64]
+        key_id -> Varchar,
+        #[max_length = 255]
+        merchant_id -> Varchar,
+        #[max_length = 64]
+        key_hash -> Varchar,
+        #[max_length = 16]
+        key_prefix -> Varchar,
+        description -> Nullable<Varchar>,
+        is_active -> Bool,
+        created_at -> Timestamp,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     card_brand_routes,
     card_info,
@@ -547,4 +564,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     txn_offer,
     txn_offer_detail,
     user_eligibility_info,
+    merchant_api_keys,
 );

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -688,3 +688,49 @@ pub struct UserEligibilityInfo {
     pub provider_name: String,
     pub disabled: Option<BitBool>,
 }
+
+#[derive(Debug, Clone, Identifiable, Queryable, Serialize, Deserialize)]
+#[cfg_attr(feature = "mysql", diesel(table_name = schema::merchant_api_keys))]
+#[cfg_attr(feature = "postgres", diesel(table_name = schema_pg::merchant_api_keys))]
+pub struct MerchantApiKey {
+    #[cfg(feature = "mysql")]
+    pub id: i64,
+    #[cfg(feature = "postgres")]
+    pub id: i64,
+    pub key_id: String,
+    pub merchant_id: String,
+    pub key_hash: String,
+    pub key_prefix: String,
+    pub description: Option<String>,
+    #[cfg(feature = "mysql")]
+    pub is_active: i8,
+    #[cfg(feature = "postgres")]
+    pub is_active: bool,
+    pub created_at: PrimitiveDateTime,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[cfg_attr(feature = "mysql", diesel(table_name = schema::merchant_api_keys))]
+#[cfg_attr(feature = "postgres", diesel(table_name = schema_pg::merchant_api_keys))]
+pub struct MerchantApiKeyNew {
+    pub key_id: String,
+    pub merchant_id: String,
+    pub key_hash: String,
+    pub key_prefix: String,
+    pub description: Option<String>,
+    #[cfg(feature = "mysql")]
+    pub is_active: i8,
+    #[cfg(feature = "postgres")]
+    pub is_active: bool,
+    pub created_at: PrimitiveDateTime,
+}
+
+#[derive(Debug, Clone, AsChangeset)]
+#[cfg_attr(feature = "mysql", diesel(table_name = schema::merchant_api_keys))]
+#[cfg_attr(feature = "postgres", diesel(table_name = schema_pg::merchant_api_keys))]
+pub struct MerchantApiKeyRevoke {
+    #[cfg(feature = "mysql")]
+    pub is_active: i8,
+    #[cfg(feature = "postgres")]
+    pub is_active: bool,
+}


### PR DESCRIPTION
## Summary

- Adds DB-backed API key authentication for all protected endpoints, with Redis caching (TTL 300s) to avoid a DB hit on every request
- Introduces a **backward-compatibility mode** (`api_key_auth_enabled = false` by default) so existing open-source deployments continue to work without any changes — opt in by setting `api_key_auth_enabled = true` in config or via `DECISION_ENGINE__API_KEY_AUTH_ENABLED=true`
- API keys are stored as SHA-256 hashes only — plaintext is shown once at creation time and never persisted

## Changes

### New files
| File | Purpose |
|------|---------|
| `migrations/2026-04-21-000000_add_merchant_api_keys/` | MySQL migration for `merchant_api_keys` table |
| `migrations_pg/2026-04-21-000000_add_merchant_api_keys/` | Postgres equivalent |
| `src/auth/mod.rs` | Key generation (`DE_` prefix + 64 hex chars from 2× UUID), SHA-256 hashing, prefix extraction |
| `src/routes/api_key.rs` | CRUD routes: create, list, revoke |
| `scripts/test_api_key_auth.sh` | End-to-end test script |

### Modified files
- **`src/middleware.rs`** — `authenticate` middleware: checks `api_key_auth_enabled` flag, Redis cache first, DB fallback, returns 401 on missing/invalid/revoked key
- **`src/app.rs`** — splits router into `protected_router` (auth layer applied) and `public_router` (`/merchant-account/create` stays open)
- **`src/routes/merchant_account_config.rs`** — merchant create now auto-generates and returns the initial API key in the response
- **`src/config.rs`** — adds `api_key_auth_enabled: bool` (serde default = false)
- **`src/storage/schema.rs` / `schema_pg.rs`** — DSL for `merchant_api_keys`
- **`src/storage/types.rs`** — `MerchantApiKey`, `MerchantApiKeyNew`, `MerchantApiKeyRevoke` structs
- **`src/error/custom_error.rs`** — `ApiKeyError` variants

## API

| Method | Path | Auth required | Description |
|--------|------|--------------|-------------|
| `POST` | `/merchant-account/create` | No | Creates merchant + returns initial API key (shown once) |
| `POST` | `/api-key/create` | Yes | Creates additional key for a merchant |
| `GET` | `/api-key/list/:merchant_id` | Yes | Lists all keys (no secret, prefix only) |
| `DELETE` | `/api-key/:key_id` | Yes | Revokes a key + busts Redis cache |

## Security model

- Keys are 256-bit random (2× UUID), SHA-256 hashed before storage — plaintext never persisted
- Redis cache TTL: 300s — revocation takes effect after cache expiry (or on miss)
- Revoked keys return `401 "API key is revoked"` once cache expires

## Test plan

```bash
# Runs 13 end-to-end checks against a live server
bash scripts/test_api_key_auth.sh

# Against a different host
BASE_URL=http://staging.example.com bash scripts/test_api_key_auth.sh
```

Covers: health, backward-compat pass-through, merchant create returns key, no-key 401, wrong-key 401, valid key passes, create additional key, list keys, new key works, revoke key, revoked key returns 401, list reflects revocation, Redis cache hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)