### PR TITLE
feat(ci): add the install path for rdkafka on CI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -35,6 +35,14 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - name: Install native deps for rdkafka
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libcurl4-openssl-dev \
+            libsasl2-dev \
+            zlib1g-dev
       - uses: taiki-e/install-action@v2
         with:
           tool: just
@@ -57,6 +65,14 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+      - name: Install native deps for rdkafka
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libcurl4-openssl-dev \
+            libsasl2-dev \
+            zlib1g-dev
       - uses: taiki-e/install-action@v2
         with:
           tool: just

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -151,6 +151,15 @@ jobs:
           toolchain: stable 2 weeks ago
           components: clippy
 
+      - name: Install native deps for rdkafka
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libcurl4-openssl-dev \
+            libsasl2-dev \
+            zlib1g-dev
+
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2.41.10
         with:


### PR DESCRIPTION
This pull request updates the CI workflows to ensure that all necessary native dependencies for the `rdkafka` library are installed before running Rust jobs. This helps prevent build failures related to missing system libraries when working with Kafka integrations.

CI workflow improvements:

* Added a step to install native dependencies (`pkg-config`, `libcurl4-openssl-dev`, `libsasl2-dev`, `zlib1g-dev`) required by `rdkafka` in the `ci-pr.yml` workflow for both relevant jobs. [[1]](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9R38-R45) [[2]](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9R68-R75)
* Added the same dependency installation step to the `ci-push.yml` workflow to ensure consistency across all CI pipelines.