### PR TITLE
feat(member): invite member for the merchant account

### DIFF
--- a/scripts/test_auth.sh
+++ b/scripts/test_auth.sh
@@ -418,7 +418,85 @@ if [ -n "$JWT_TOKEN" ]; then
     fi
 fi
 
-# ── 21. Redis cache hit (API key) ──────────────────────
+# ── 21. Invite member (new user) ──────────────────────
+INVITE_EMAIL="invitee_$(date +%s)@example.com"
+echo ""
+echo "[ Invite new user to merchant ]"
+INVITE_RESPONSE=$(curl -s -X POST "$BASE_URL/merchant/members/invite" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $ONBOARD_TOKEN" \
+    -d "{\"email\": \"$INVITE_EMAIL\", \"role\": \"member\"}")
+
+IS_NEW=$(echo "$INVITE_RESPONSE" | grep -o '"is_new_user":true')
+INVITE_PASSWORD=$(echo "$INVITE_RESPONSE" | grep -o '"password":"[^"]*"' | cut -d'"' -f4)
+
+if [ -n "$IS_NEW" ] && [ -n "$INVITE_PASSWORD" ]; then
+    echo "  PASS  POST /merchant/members/invite creates new user and returns credentials"
+    echo "        generated password: ${INVITE_PASSWORD:0:6}..."
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  POST /merchant/members/invite — unexpected: $INVITE_RESPONSE"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── 22. Invited user can login ─────────────────────────
+echo ""
+echo "[ Invited user can login ]"
+INVITEE_LOGIN=$(curl -s -X POST "$BASE_URL/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\": \"$INVITE_EMAIL\", \"password\": \"$INVITE_PASSWORD\"}")
+
+INVITEE_TOKEN=$(echo "$INVITEE_LOGIN" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+if [ -n "$INVITEE_TOKEN" ]; then
+    echo "  PASS  Invited user can login with generated credentials"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  Invited user login failed: $INVITEE_LOGIN"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── 23. Invite same user again → 409 ──────────────────
+echo ""
+echo "[ Invite already-member user → 409 ]"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/merchant/members/invite" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $ONBOARD_TOKEN" \
+    -d "{\"email\": \"$INVITE_EMAIL\"}")
+check "Invite existing member → 409" "409" "$STATUS"
+
+# ── 24. Invite existing user to a different merchant ───
+echo ""
+echo "[ Invite existing user to second merchant ]"
+INVITE2_RESPONSE=$(curl -s -X POST "$BASE_URL/merchant/members/invite" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $ONBOARD2_TOKEN" \
+    -d "{\"email\": \"$INVITE_EMAIL\", \"role\": \"admin\"}")
+
+IS_NEW2=$(echo "$INVITE2_RESPONSE" | grep -o '"is_new_user":false')
+if [ -n "$IS_NEW2" ]; then
+    echo "  PASS  Existing user added to second merchant (is_new_user=false)"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  Expected is_new_user=false: $INVITE2_RESPONSE"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── 25. List members ───────────────────────────────────
+echo ""
+echo "[ List merchant members ]"
+MEMBERS_RESPONSE=$(curl -s "$BASE_URL/merchant/members" \
+    -H "Authorization: Bearer $ONBOARD_TOKEN")
+
+MEMBER_COUNT=$(echo "$MEMBERS_RESPONSE" | grep -o '"user_id"' | wc -l | tr -d ' ')
+if [ "$MEMBER_COUNT" -ge "2" ]; then
+    echo "  PASS  GET /merchant/members returns $MEMBER_COUNT members"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  GET /merchant/members — got: $MEMBERS_RESPONSE"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── 26. Redis cache hit (API key) ──────────────────────
 echo ""
 echo "[ Redis cache hit ]"
 for i in 1 2; do

--- a/src/app.rs
+++ b/src/app.rs
@@ -445,10 +445,7 @@ where
             "/onboarding/merchant",
             post(routes::user_auth::create_merchant),
         )
-        .route(
-            "/merchant/members",
-            get(routes::user_auth::list_members),
-        )
+        .route("/merchant/members", get(routes::user_auth::list_members))
         .route(
             "/merchant/members/invite",
             post(routes::user_auth::invite_member),

--- a/src/app.rs
+++ b/src/app.rs
@@ -444,6 +444,14 @@ where
         .route(
             "/onboarding/merchant",
             post(routes::user_auth::create_merchant),
+        )
+        .route(
+            "/merchant/members",
+            get(routes::user_auth::list_members),
+        )
+        .route(
+            "/merchant/members/invite",
+            post(routes::user_auth::invite_member),
         );
 
     let router = axum::Router::new()

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -338,6 +338,8 @@ pub enum UserAuthError {
     PasswordHashingFailed,
     #[error("Merchant not found")]
     MerchantNotFound,
+    #[error("User is already a member of this merchant")]
+    AlreadyMember,
 }
 
 impl axum::response::IntoResponse for UserAuthError {
@@ -353,6 +355,7 @@ impl axum::response::IntoResponse for UserAuthError {
             Self::EmailNotVerified => (hyper::StatusCode::FORBIDDEN, self.to_string()),
             Self::InvalidToken => (hyper::StatusCode::UNAUTHORIZED, self.to_string()),
             Self::MerchantNotFound => (hyper::StatusCode::NOT_FOUND, self.to_string()),
+            Self::AlreadyMember => (hyper::StatusCode::CONFLICT, self.to_string()),
             Self::StorageError | Self::TokenGenerationFailed | Self::PasswordHashingFailed => {
                 (hyper::StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -340,6 +340,8 @@ pub enum UserAuthError {
     MerchantNotFound,
     #[error("User is already a member of this merchant")]
     AlreadyMember,
+    #[error("Insufficient permissions")]
+    Forbidden,
 }
 
 impl axum::response::IntoResponse for UserAuthError {
@@ -356,6 +358,7 @@ impl axum::response::IntoResponse for UserAuthError {
             Self::InvalidToken => (hyper::StatusCode::UNAUTHORIZED, self.to_string()),
             Self::MerchantNotFound => (hyper::StatusCode::NOT_FOUND, self.to_string()),
             Self::AlreadyMember => (hyper::StatusCode::CONFLICT, self.to_string()),
+            Self::Forbidden => (hyper::StatusCode::FORBIDDEN, self.to_string()),
             Self::StorageError | Self::TokenGenerationFailed | Self::PasswordHashingFailed => {
                 (hyper::StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -467,9 +467,17 @@ pub async fn invite_member(
         .ok_or(UserAuthError::StorageError)?;
 
     let claims = verify_jwt_not_revoked(token, &global_config.user_auth.jwt_secret).await?;
-    let app_state = get_tenant_app_state().await;
 
-    let role = payload.role.unwrap_or_else(|| "member".to_string());
+    if claims.role != "admin" {
+        return Err(error::ContainerError::from(UserAuthError::Forbidden));
+    }
+
+    let role = match payload.role.as_deref().unwrap_or("member") {
+        "admin" => "admin".to_string(),
+        _ => "member".to_string(),
+    };
+
+    let app_state = get_tenant_app_state().await;
 
     let existing_users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
         &app_state.db,
@@ -520,9 +528,6 @@ pub async fn invite_member(
         // Create new user with generated password
         let generated_password = generate_random_password();
 
-        auth::validate_password_strength(&generated_password)
-            .map_err(|_| UserAuthError::PasswordHashingFailed)?;
-
         let password_hash = auth::hash_password(&generated_password)
             .map_err(|_| UserAuthError::PasswordHashingFailed)?;
 
@@ -556,9 +561,21 @@ pub async fn invite_member(
             created_at: now,
         };
 
-        crate::generics::generic_insert(&app_state.db, new_user_merchant)
+        if crate::generics::generic_insert(&app_state.db, new_user_merchant)
             .await
-            .map_err(|_| UserAuthError::StorageError)?;
+            .is_err()
+        {
+            // Compensating delete: remove orphaned user if membership insert fails
+            let conn = app_state.db.get_conn().await.ok();
+            if let Some(conn) = conn {
+                let _ = crate::generics::generic_delete::<
+                    <User as diesel::associations::HasTable>::Table,
+                    _,
+                >(&conn, dsl::user_id.eq(user_id.clone()))
+                .await;
+            }
+            return Err(error::ContainerError::from(UserAuthError::StorageError));
+        }
 
         Ok(Json(InviteMemberResponse {
             email: payload.email,
@@ -590,23 +607,32 @@ pub async fn list_members(
         .await
         .map_err(|_| UserAuthError::StorageError)?;
 
-    let mut members = Vec::new();
-    for membership in memberships {
-        let mut users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+    let user_ids: Vec<String> = memberships.iter().map(|m| m.user_id.clone()).collect();
+
+    let users = if user_ids.is_empty() {
+        Vec::new()
+    } else {
+        crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
             &app_state.db,
-            dsl::user_id.eq(membership.user_id.clone()),
+            dsl::user_id.eq_any(user_ids),
         )
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .map_err(|_| UserAuthError::StorageError)?
+    };
 
-        if let Some(user) = users.pop() {
-            members.push(MemberInfo {
-                user_id: user.user_id,
-                email: user.email,
+    let users_by_id: std::collections::HashMap<String, User> =
+        users.into_iter().map(|u| (u.user_id.clone(), u)).collect();
+
+    let members = memberships
+        .into_iter()
+        .filter_map(|membership| {
+            users_by_id.get(&membership.user_id).map(|user| MemberInfo {
+                user_id: user.user_id.clone(),
+                email: user.email.clone(),
                 role: membership.role,
-            });
-        }
-    }
+            })
+        })
+        .collect();
 
     Ok(Json(members))
 }

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -8,7 +8,7 @@ use crate::utils::date_time;
 use axum::http::HeaderMap;
 use axum::Json;
 use diesel::associations::HasTable;
-use diesel::ExpressionMethods;
+use diesel::{BoolExpressionMethods, ExpressionMethods};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "mysql")]
@@ -431,6 +431,214 @@ pub async fn switch_merchant(
         role: target.role.clone(),
         merchants,
     }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InviteMemberRequest {
+    pub email: String,
+    pub role: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InviteMemberResponse {
+    pub email: String,
+    pub is_new_user: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    pub role: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MemberInfo {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+}
+
+#[axum::debug_handler]
+pub async fn invite_member(
+    headers: HeaderMap,
+    Json(payload): Json<InviteMemberRequest>,
+) -> Result<Json<InviteMemberResponse>, error::ContainerError<UserAuthError>> {
+    let token = extract_bearer_token(&headers)?;
+    let global_config = APP_STATE
+        .get()
+        .map(|s| s.global_config.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    let claims = verify_jwt_not_revoked(token, &global_config.user_auth.jwt_secret).await?;
+    let app_state = get_tenant_app_state().await;
+
+    let role = payload.role.unwrap_or_else(|| "member".to_string());
+
+    let existing_users =
+        crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+            &app_state.db,
+            dsl::email.eq(payload.email.clone()),
+        )
+        .await
+        .map_err(|_| UserAuthError::StorageError)?;
+
+    let now = date_time::now();
+
+    if let Some(existing_user) = existing_users.into_iter().next() {
+        // Check if already a member
+        let existing_membership = crate::generics::generic_find_all::<
+            <UserMerchant as HasTable>::Table,
+            _,
+            UserMerchant,
+        >(
+            &app_state.db,
+            um_dsl::user_id
+                .eq(existing_user.user_id.clone())
+                .and(um_dsl::merchant_id.eq(claims.merchant_id.clone())),
+        )
+        .await
+        .map_err(|_| UserAuthError::StorageError)?;
+
+        if !existing_membership.is_empty() {
+            return Err(error::ContainerError::from(UserAuthError::AlreadyMember));
+        }
+
+        let new_user_merchant = NewUserMerchant {
+            user_id: existing_user.user_id.clone(),
+            merchant_id: claims.merchant_id.clone(),
+            role: role.clone(),
+            created_at: now,
+        };
+
+        crate::generics::generic_insert(&app_state.db, new_user_merchant)
+            .await
+            .map_err(|_| UserAuthError::StorageError)?;
+
+        Ok(Json(InviteMemberResponse {
+            email: existing_user.email,
+            is_new_user: false,
+            password: None,
+            role,
+        }))
+    } else {
+        // Create new user with generated password
+        let generated_password = generate_random_password();
+
+        auth::validate_password_strength(&generated_password)
+            .map_err(|_| UserAuthError::PasswordHashingFailed)?;
+
+        let password_hash = auth::hash_password(&generated_password)
+            .map_err(|_| UserAuthError::PasswordHashingFailed)?;
+
+        let user_id = uuid::Uuid::new_v4().to_string();
+
+        let new_user = NewUser {
+            user_id: user_id.clone(),
+            email: payload.email.clone(),
+            password_hash,
+            merchant_id: None,
+            role: role.clone(),
+            #[cfg(feature = "mysql")]
+            is_active: 1,
+            #[cfg(feature = "postgres")]
+            is_active: true,
+            #[cfg(feature = "mysql")]
+            email_verified: 1,
+            #[cfg(feature = "postgres")]
+            email_verified: true,
+            created_at: now,
+        };
+
+        crate::generics::generic_insert(&app_state.db, new_user)
+            .await
+            .map_err(|_| UserAuthError::StorageError)?;
+
+        let new_user_merchant = NewUserMerchant {
+            user_id: user_id.clone(),
+            merchant_id: claims.merchant_id.clone(),
+            role: role.clone(),
+            created_at: now,
+        };
+
+        crate::generics::generic_insert(&app_state.db, new_user_merchant)
+            .await
+            .map_err(|_| UserAuthError::StorageError)?;
+
+        Ok(Json(InviteMemberResponse {
+            email: payload.email,
+            is_new_user: true,
+            password: Some(generated_password),
+            role,
+        }))
+    }
+}
+
+#[axum::debug_handler]
+pub async fn list_members(
+    headers: HeaderMap,
+) -> Result<Json<Vec<MemberInfo>>, error::ContainerError<UserAuthError>> {
+    let token = extract_bearer_token(&headers)?;
+    let global_config = APP_STATE
+        .get()
+        .map(|s| s.global_config.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    let claims = verify_jwt_not_revoked(token, &global_config.user_auth.jwt_secret).await?;
+    let app_state = get_tenant_app_state().await;
+
+    let memberships = crate::generics::generic_find_all::<
+        <UserMerchant as HasTable>::Table,
+        _,
+        UserMerchant,
+    >(
+        &app_state.db,
+        um_dsl::merchant_id.eq(claims.merchant_id.clone()),
+    )
+    .await
+    .map_err(|_| UserAuthError::StorageError)?;
+
+    let mut members = Vec::new();
+    for membership in memberships {
+        let mut users =
+            crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+                &app_state.db,
+                dsl::user_id.eq(membership.user_id.clone()),
+            )
+            .await
+            .map_err(|_| UserAuthError::StorageError)?;
+
+        if let Some(user) = users.pop() {
+            members.push(MemberInfo {
+                user_id: user.user_id,
+                email: user.email,
+                role: membership.role,
+            });
+        }
+    }
+
+    Ok(Json(members))
+}
+
+fn generate_random_password() -> String {
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    let uppercase = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let lowercase = b"abcdefghijklmnopqrstuvwxyz";
+    let digits = b"0123456789";
+    let special = b"!@#$%^&*";
+
+    let mut password = vec![
+        uppercase[rng.gen_range(0..uppercase.len())] as char,
+        lowercase[rng.gen_range(0..lowercase.len())] as char,
+        digits[rng.gen_range(0..digits.len())] as char,
+        special[rng.gen_range(0..special.len())] as char,
+    ];
+
+    let all: Vec<u8> = [uppercase.as_ref(), lowercase.as_ref(), digits.as_ref(), special.as_ref()].concat();
+    for _ in 0..12 {
+        password.push(all[rng.gen_range(0..all.len())] as char);
+    }
+
+    use rand::seq::SliceRandom;
+    password.shuffle(&mut rng);
+    password.into_iter().collect()
 }
 
 #[axum::debug_handler]

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -471,13 +471,12 @@ pub async fn invite_member(
 
     let role = payload.role.unwrap_or_else(|| "member".to_string());
 
-    let existing_users =
-        crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
-            &app_state.db,
-            dsl::email.eq(payload.email.clone()),
-        )
-        .await
-        .map_err(|_| UserAuthError::StorageError)?;
+    let existing_users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+        &app_state.db,
+        dsl::email.eq(payload.email.clone()),
+    )
+    .await
+    .map_err(|_| UserAuthError::StorageError)?;
 
     let now = date_time::now();
 
@@ -583,26 +582,22 @@ pub async fn list_members(
     let claims = verify_jwt_not_revoked(token, &global_config.user_auth.jwt_secret).await?;
     let app_state = get_tenant_app_state().await;
 
-    let memberships = crate::generics::generic_find_all::<
-        <UserMerchant as HasTable>::Table,
-        _,
-        UserMerchant,
-    >(
-        &app_state.db,
-        um_dsl::merchant_id.eq(claims.merchant_id.clone()),
-    )
-    .await
-    .map_err(|_| UserAuthError::StorageError)?;
+    let memberships =
+        crate::generics::generic_find_all::<<UserMerchant as HasTable>::Table, _, UserMerchant>(
+            &app_state.db,
+            um_dsl::merchant_id.eq(claims.merchant_id.clone()),
+        )
+        .await
+        .map_err(|_| UserAuthError::StorageError)?;
 
     let mut members = Vec::new();
     for membership in memberships {
-        let mut users =
-            crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
-                &app_state.db,
-                dsl::user_id.eq(membership.user_id.clone()),
-            )
-            .await
-            .map_err(|_| UserAuthError::StorageError)?;
+        let mut users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+            &app_state.db,
+            dsl::user_id.eq(membership.user_id.clone()),
+        )
+        .await
+        .map_err(|_| UserAuthError::StorageError)?;
 
         if let Some(user) = users.pop() {
             members.push(MemberInfo {
@@ -631,7 +626,13 @@ fn generate_random_password() -> String {
         special[rng.gen_range(0..special.len())] as char,
     ];
 
-    let all: Vec<u8> = [uppercase.as_ref(), lowercase.as_ref(), digits.as_ref(), special.as_ref()].concat();
+    let all: Vec<u8> = [
+        uppercase.as_ref(),
+        lowercase.as_ref(),
+        digits.as_ref(),
+        special.as_ref(),
+    ]
+    .concat();
     for _ in 0..12 {
         password.push(all[rng.gen_range(0..all.len())] as char);
     }

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -12,6 +12,7 @@ import { AppShell } from './components/layout/AppShell'
 import { AuthGuard } from './components/layout/AuthGuard'
 import { AuthPage } from './pages/AuthPage'
 import { OnboardingPage } from './pages/OnboardingPage'
+import { MembersPage } from './pages/MembersPage'
 
 export default function App() {
   return (
@@ -30,6 +31,7 @@ export default function App() {
           <Route path="decisions" element={<DecisionExplorerPage />} />
           <Route path="analytics" element={<AnalyticsPage />} />
           <Route path="audit" element={<PaymentAuditPage />} />
+          <Route path="members" element={<MembersPage />} />
           <Route path="*" element={<Navigate to="." replace />} />
         </Route>
       </Route>

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Activity,
   Moon,
   Sun,
+  Users,
 } from 'lucide-react'
 
 export function Sidebar() {
@@ -89,6 +90,14 @@ export function Sidebar() {
         </div>
 
         <SideLink to="/decisions" icon={Search} selectedPath={selectedPath} onNavigate={setPendingPath}>Decision Explorer</SideLink>
+
+        <div className="flex items-center gap-2 px-3 pb-3 pt-8">
+          <span className="text-[11px] font-bold uppercase tracking-widest text-slate-400 dark:text-[#6d768a]">
+            Settings
+          </span>
+        </div>
+
+        <SideLink to="/members" icon={Users} selectedPath={selectedPath} onNavigate={setPendingPath}>Members</SideLink>
       </nav>
 
       {/* Footer */}

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -625,6 +625,7 @@ export function DecisionExplorerPage() {
   const [form, setForm] = useState<FormState>(initialState.form)
 
   const [simulationConfig, setSimulationConfig] = useState<SimulationConfig>(initialState.simulationConfig)
+  const [successRate, setSuccessRate] = useState(70)
 
   const [debitForm, setDebitForm] = useState<DebitRoutingFormState>(initialState.debitForm)
 
@@ -1380,6 +1381,7 @@ export function DecisionExplorerPage() {
     } else if (activeTab === 'batch') {
       setForm(defaults.form)
       setSimulationConfig(defaults.simulationConfig)
+      setSuccessRate(70)
       setSimulationResults(defaults.simulationResults)
       setIsSimulating(false)
     } else if (activeTab === 'rule') {
@@ -1874,42 +1876,51 @@ export function DecisionExplorerPage() {
 
                 {activeTab === 'batch' && (
                   <div className="border-t border-slate-200 dark:border-[#1c1c24] pt-4 mt-4 space-y-3">
-                    <h3 className="text-sm font-medium text-slate-800 flex items-center gap-2">
+                    <h3 className="text-sm font-medium text-slate-800 dark:text-slate-200 flex items-center gap-2">
                       <Activity size={14} />
-                      Simulation Configuration
+                      Simulation
                     </h3>
-                    <div className="grid grid-cols-3 gap-3">
-                      <div>
-                        <label className="block text-xs font-medium text-slate-600 mb-1">Total Payments</label>
+                    <div className="flex items-end gap-3">
+                      <div className="w-28">
+                        <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Payments</label>
                         <input
-                          type="text"
+                          type="number"
+                          min={1}
+                          max={1000}
                           value={simulationConfig.totalPayments}
-                          onChange={e => setSimulationConfig(s => ({ ...s, totalPayments: e.target.value }))}
+                          onChange={e => {
+                            const total = Math.max(1, parseInt(e.target.value) || 1)
+                            const s = Math.round(total * successRate / 100)
+                            setSimulationConfig({ totalPayments: String(total), successCount: String(s), failureCount: String(total - s) })
+                          }}
                           className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
                         />
                       </div>
-                      <div>
-                        <label className="block text-xs font-medium text-slate-600 mb-1">Success Count</label>
+                      <div className="flex-1">
+                        <div className="flex justify-between mb-1">
+                          <label className="text-xs font-medium text-slate-600 dark:text-slate-400">Success Rate</label>
+                          <span className="text-xs font-semibold text-brand-600 dark:text-sky-400">{successRate}%</span>
+                        </div>
                         <input
-                          type="text"
-                          value={simulationConfig.successCount}
-                          onChange={e => setSimulationConfig(s => ({ ...s, successCount: e.target.value }))}
-                          className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                          type="range"
+                          min={0}
+                          max={100}
+                          value={successRate}
+                          onChange={e => {
+                            const rate = parseInt(e.target.value)
+                            const total = parseInt(simulationConfig.totalPayments) || 10
+                            const s = Math.round(total * rate / 100)
+                            setSuccessRate(rate)
+                            setSimulationConfig({ totalPayments: String(total), successCount: String(s), failureCount: String(total - s) })
+                          }}
+                          className="w-full accent-brand-600"
                         />
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-slate-600 mb-1">Failure Count</label>
-                        <input
-                          type="text"
-                          value={simulationConfig.failureCount}
-                          onChange={e => setSimulationConfig(s => ({ ...s, failureCount: e.target.value }))}
-                          className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
-                        />
+                        <div className="flex justify-between mt-1 text-[10px] text-slate-400">
+                          <span>{simulationConfig.successCount} success</span>
+                          <span>{simulationConfig.failureCount} failure</span>
+                        </div>
                       </div>
                     </div>
-                    <p className="text-xs text-slate-500">
-                      Will run {simulationConfig.totalPayments || 0} payments: {simulationConfig.successCount || 0} SUCCESS, {simulationConfig.failureCount || 0} FAILURE
-                    </p>
                   </div>
                 )}
               </>

--- a/website/src/pages/MembersPage.tsx
+++ b/website/src/pages/MembersPage.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect } from 'react'
+import { UserPlus, Users, Copy, Check, Loader2, Eye, EyeOff } from 'lucide-react'
+import { apiFetch } from '../lib/api'
+import { ErrorMessage } from '../components/ui/ErrorMessage'
+
+interface MemberInfo {
+  user_id: string
+  email: string
+  role: string
+}
+
+interface InviteResponse {
+  email: string
+  is_new_user: boolean
+  password?: string
+  role: string
+}
+
+function RoleBadge({ role }: { role: string }) {
+  const colors =
+    role === 'admin'
+      ? 'bg-violet-50 text-violet-700 dark:bg-violet-950/40 dark:text-violet-300'
+      : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300'
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold capitalize ${colors}`}>
+      {role}
+    </span>
+  )
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+  function copy() {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1800)
+    })
+  }
+  return (
+    <button
+      onClick={copy}
+      className="ml-1.5 inline-flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+      title="Copy"
+    >
+      {copied ? <Check size={13} className="text-green-500" /> : <Copy size={13} />}
+    </button>
+  )
+}
+
+export function MembersPage() {
+  const [members, setMembers] = useState<MemberInfo[]>([])
+  const [loadingMembers, setLoadingMembers] = useState(true)
+  const [membersError, setMembersError] = useState<string | null>(null)
+
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState('member')
+  const [inviting, setInviting] = useState(false)
+  const [inviteError, setInviteError] = useState<string | null>(null)
+  const [inviteResult, setInviteResult] = useState<InviteResponse | null>(null)
+  const [showPassword, setShowPassword] = useState(false)
+
+  async function loadMembers() {
+    setLoadingMembers(true)
+    setMembersError(null)
+    try {
+      const data = await apiFetch<MemberInfo[]>('/merchant/members')
+      setMembers(data)
+    } catch (err) {
+      setMembersError(err instanceof Error ? err.message : 'Failed to load members')
+    } finally {
+      setLoadingMembers(false)
+    }
+  }
+
+  useEffect(() => {
+    loadMembers()
+  }, [])
+
+  async function handleInvite(e: React.FormEvent) {
+    e.preventDefault()
+    setInviteError(null)
+    setInviteResult(null)
+    setInviting(true)
+    try {
+      const res = await apiFetch<InviteResponse>('/merchant/members/invite', {
+        method: 'POST',
+        body: JSON.stringify({ email, role }),
+      })
+      setInviteResult(res)
+      setEmail('')
+      loadMembers()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Something went wrong'
+      const match = msg.match(/API error \d+: (.+)/)
+      if (match) {
+        try {
+          const parsed = JSON.parse(match[1])
+          setInviteError(parsed.message ?? msg)
+        } catch {
+          setInviteError(match[1])
+        }
+      } else {
+        setInviteError(msg)
+      }
+    } finally {
+      setInviting(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 px-4 py-8">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white">
+          Members
+        </h1>
+        <p className="mt-1 text-sm text-slate-500 dark:text-[#8a94a7]">
+          Manage who has access to this merchant workspace.
+        </p>
+      </div>
+
+      {/* Invite form */}
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 dark:border-[#1d2029] dark:bg-[#0c0e14]">
+        <div className="flex items-center gap-2.5 mb-5">
+          <UserPlus size={18} className="text-brand-600 dark:text-sky-400" />
+          <h2 className="text-base font-semibold text-slate-900 dark:text-white">Invite member</h2>
+        </div>
+
+        <form onSubmit={handleInvite} className="space-y-4">
+          <div className="flex gap-3">
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="colleague@example.com"
+              className="h-10 flex-1 rounded-xl border border-slate-200 bg-white px-3.5 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-[#2a2d35] dark:bg-[#1a1d25] dark:text-white dark:placeholder:text-[#6e7684] dark:focus:border-blue-500"
+            />
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              className="h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-[#2a2d35] dark:bg-[#1a1d25] dark:text-slate-200"
+            >
+              <option value="member">Member</option>
+              <option value="admin">Admin</option>
+            </select>
+            <button
+              type="submit"
+              disabled={inviting}
+              className="inline-flex h-10 items-center gap-2 rounded-xl bg-brand-600 px-4 text-sm font-semibold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {inviting ? <Loader2 size={14} className="animate-spin" /> : <UserPlus size={14} />}
+              Invite
+            </button>
+          </div>
+
+          <ErrorMessage error={inviteError} />
+        </form>
+
+        {inviteResult && (
+          <div className={`mt-4 rounded-xl border p-4 ${inviteResult.is_new_user ? 'border-amber-200 bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/20' : 'border-green-200 bg-green-50 dark:border-green-900/40 dark:bg-green-950/20'}`}>
+            {inviteResult.is_new_user ? (
+              <>
+                <p className="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-2">
+                  New account created — share these credentials
+                </p>
+                <div className="space-y-1.5 text-sm">
+                  <div className="flex items-center">
+                    <span className="w-20 text-amber-700 dark:text-amber-400 font-medium">Email</span>
+                    <code className="text-amber-900 dark:text-amber-200">{inviteResult.email}</code>
+                    <CopyButton text={inviteResult.email} />
+                  </div>
+                  <div className="flex items-center">
+                    <span className="w-20 text-amber-700 dark:text-amber-400 font-medium">Password</span>
+                    <code className="text-amber-900 dark:text-amber-200">
+                      {showPassword ? inviteResult.password : '••••••••••••••••'}
+                    </code>
+                    <button
+                      onClick={() => setShowPassword((v) => !v)}
+                      className="ml-1.5 inline-flex items-center justify-center w-6 h-6 rounded text-amber-600 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200 transition-colors"
+                      title={showPassword ? 'Hide password' : 'Show password'}
+                    >
+                      {showPassword ? <EyeOff size={13} /> : <Eye size={13} />}
+                    </button>
+                    {inviteResult.password && <CopyButton text={inviteResult.password} />}
+                  </div>
+                </div>
+              </>
+            ) : (
+              <p className="text-sm text-green-800 dark:text-green-300">
+                <span className="font-semibold">{inviteResult.email}</span> has been added to this merchant.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Members list */}
+      <div className="rounded-2xl border border-slate-200 bg-white dark:border-[#1d2029] dark:bg-[#0c0e14]">
+        <div className="flex items-center gap-2.5 border-b border-slate-100 px-6 py-4 dark:border-[#1a1d25]">
+          <Users size={18} className="text-slate-400" />
+          <h2 className="text-base font-semibold text-slate-900 dark:text-white">Current members</h2>
+          {!loadingMembers && (
+            <span className="ml-auto text-xs text-slate-400">{members.length} member{members.length !== 1 ? 's' : ''}</span>
+          )}
+        </div>
+
+        {loadingMembers ? (
+          <div className="flex items-center justify-center py-12 text-slate-400">
+            <Loader2 size={20} className="animate-spin" />
+          </div>
+        ) : membersError ? (
+          <div className="px-6 py-8 text-center text-sm text-red-500">{membersError}</div>
+        ) : members.length === 0 ? (
+          <div className="px-6 py-8 text-center text-sm text-slate-400">No members yet</div>
+        ) : (
+          <ul className="divide-y divide-slate-100 dark:divide-[#1a1d25]">
+            {members.map((m) => (
+              <li key={m.user_id} className="flex items-center gap-4 px-6 py-3.5">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-600 text-[11px] font-semibold text-white">
+                  {m.email.slice(0, 2).toUpperCase()}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+                    {m.email}
+                  </p>
+                  <p className="truncate text-xs text-slate-400">{m.user_id}</p>
+                </div>
+                <RoleBadge role={m.role} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/website/src/pages/MembersPage.tsx
+++ b/website/src/pages/MembersPage.tsx
@@ -30,17 +30,22 @@ function RoleBadge({ role }: { role: string }) {
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
-  function copy() {
-    navigator.clipboard.writeText(text).then(() => {
+  async function copy() {
+    if (!navigator.clipboard) return
+    try {
+      await navigator.clipboard.writeText(text)
       setCopied(true)
       setTimeout(() => setCopied(false), 1800)
-    })
+    } catch {
+      // clipboard unavailable or denied — fail silently
+    }
   }
   return (
     <button
       onClick={copy}
       className="ml-1.5 inline-flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
-      title="Copy"
+      title={copied ? 'Copied' : 'Copy'}
+      aria-label={copied ? 'Copied' : 'Copy'}
     >
       {copied ? <Check size={13} className="text-green-500" /> : <Copy size={13} />}
     </button>
@@ -178,6 +183,7 @@ export function MembersPage() {
                       onClick={() => setShowPassword((v) => !v)}
                       className="ml-1.5 inline-flex items-center justify-center w-6 h-6 rounded text-amber-600 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200 transition-colors"
                       title={showPassword ? 'Hide password' : 'Show password'}
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
                     >
                       {showPassword ? <EyeOff size={13} /> : <Eye size={13} />}
                     </button>

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(({ command }) => {
         '^/onboarding(?:/.*)?$': createApiProxy(),
         '^/auth(?:/.*)?$': createApiProxy(),
         '^/api-key(?:/.*)?$': createApiProxy(),
+        '^/merchant(?:/.*)?$': createApiProxy(),
       },
       fs: {
         strict: false,


### PR DESCRIPTION
This pull request introduces a complete implementation for merchant member management, including backend API endpoints for inviting and listing members, error handling for duplicate invites, and a new frontend page for managing members. The UI allows admins to invite new users (with auto-generated credentials for new accounts), see current members, and copy credentials for sharing. The navigation and API proxy are also updated to support these new features.

**Backend: Member Management APIs**
- Added new endpoints: `POST /merchant/members/invite` to invite a member (creating a user if needed) and `GET /merchant/members` to list all members for a merchant. These endpoints handle both new and existing users, assign roles, and return appropriate responses. 
- Added a random password generator for new users, and ensured password strength and hashing.
- Added error handling for inviting an already-member user, returning HTTP 409 Conflict, with a new `AlreadyMember` error type. 

**Backend: Test Coverage**
- Extended `test_auth.sh` to test all invite and member scenarios: inviting new and existing users, login with generated credentials, duplicate invites, and listing members.

**Frontend: Member Management UI**
- Added a new route `/members` and `MembersPage` UI for inviting and viewing merchant members, including role selection, credential copying, and error handling. 

**Frontend: API Proxy**
- Updated Vite config to proxy `/merchant` API routes to the backend.

**Other**
- Minor import fixes for diesel expression methods to support new queries.