### PR TITLE
refactor(docs): update readme and swagger in github pages

### DIFF
--- a/.github/workflows/api-reference-pages.yml
+++ b/.github/workflows/api-reference-pages.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - "README.md"
       - "docs/openapi.json"
       - "docs/api-reference/**"
       - "docs/api-refs/**"
@@ -29,6 +30,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install pandoc
+        run: sudo apt-get install -y pandoc
+
       - name: Validate OpenAPI contract
         run: jq empty docs/openapi.json
 
@@ -38,13 +42,221 @@ jobs:
           set -euo pipefail
 
           rm -rf public
-          mkdir -p public
+          mkdir -p public/api-docs
 
           cp docs/openapi.json public/openapi.json
+          cp docs/openapi.json public/api-docs/openapi.json
+          cp docs/favicon.svg public/api-docs/favicon.svg
           cp docs/favicon.svg public/favicon.svg
           touch public/.nojekyll
 
-          cat > public/index.html <<'HTML'
+          # Rewrite relative doc links to their GitHub equivalents so they
+          # resolve correctly from the GitHub Pages landing page.
+          REPO="https://github.com/juspay/decision-engine/blob/main"
+          sed \
+            -e "s|](docs/|]($REPO/docs/|g" \
+            -e "s|](CONTRIBUTING.md)|]($REPO/CONTRIBUTING.md)|g" \
+            README.md > /tmp/readme-rewritten.md
+
+          README_BODY=$(pandoc /tmp/readme-rewritten.md \
+            --from=gfm \
+            --to=html \
+            --no-highlight)
+
+          cat > public/index.html <<LANDING
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <title>Decision Engine</title>
+              <link rel="icon" href="./favicon.svg" />
+              <style>
+                *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+                body {
+                  background: #05070d;
+                  color: #e2e8f0;
+                  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+                }
+                /* ── header ── */
+                .site-header {
+                  display: flex;
+                  align-items: center;
+                  justify-content: space-between;
+                  padding: 16px 32px;
+                  border-bottom: 1px solid #1e293b;
+                  position: sticky;
+                  top: 0;
+                  background: #05070d;
+                  z-index: 10;
+                }
+                .site-header h1 {
+                  font-size: 1rem;
+                  font-weight: 600;
+                  color: #f8fafc;
+                  letter-spacing: -0.01em;
+                }
+                .header-links { display: flex; gap: 20px; }
+                .header-links a {
+                  color: #94a3b8;
+                  font-size: 0.875rem;
+                  text-decoration: none;
+                }
+                .header-links a:hover { color: #e2e8f0; }
+                .header-links a.cta {
+                  color: #fff;
+                  background: #3b82f6;
+                  padding: 6px 14px;
+                  border-radius: 6px;
+                  font-weight: 500;
+                }
+                .header-links a.cta:hover { background: #2563eb; }
+                /* ── hero ── */
+                .hero {
+                  text-align: center;
+                  padding: 72px 24px 56px;
+                  border-bottom: 1px solid #1e293b;
+                }
+                .hero h2 {
+                  font-size: 2.5rem;
+                  font-weight: 700;
+                  letter-spacing: -0.03em;
+                  color: #f8fafc;
+                  margin-bottom: 16px;
+                }
+                .hero p {
+                  color: #94a3b8;
+                  font-size: 1.05rem;
+                  line-height: 1.6;
+                  max-width: 520px;
+                  margin: 0 auto 36px;
+                }
+                .hero-links { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+                .hero-links a {
+                  padding: 12px 22px;
+                  border-radius: 8px;
+                  font-size: 0.95rem;
+                  font-weight: 500;
+                  text-decoration: none;
+                  transition: opacity 0.15s;
+                }
+                .hero-links a:hover { opacity: 0.85; }
+                .hero-links a.primary { background: #3b82f6; color: #fff; }
+                .hero-links a.secondary { background: #1e293b; color: #e2e8f0; border: 1px solid #334155; }
+                .spec-note {
+                  margin-top: 20px;
+                  font-size: 0.8rem;
+                  color: #475569;
+                }
+                .spec-note a { color: #64748b; text-decoration: underline; }
+                /* ── readme body ── */
+                .readme {
+                  max-width: 860px;
+                  margin: 0 auto;
+                  padding: 56px 24px 80px;
+                }
+                /* strip the h1 pandoc renders from the README — hero already has it */
+                .readme > h1:first-child { display: none; }
+                .readme h2 {
+                  font-size: 1.35rem;
+                  font-weight: 600;
+                  color: #f1f5f9;
+                  margin: 48px 0 16px;
+                  padding-bottom: 8px;
+                  border-bottom: 1px solid #1e293b;
+                }
+                .readme h3 {
+                  font-size: 1.05rem;
+                  font-weight: 600;
+                  color: #e2e8f0;
+                  margin: 28px 0 10px;
+                }
+                .readme p { color: #94a3b8; line-height: 1.7; margin-bottom: 14px; }
+                .readme a { color: #60a5fa; text-decoration: none; }
+                .readme a:hover { text-decoration: underline; }
+                .readme ul, .readme ol {
+                  color: #94a3b8;
+                  padding-left: 24px;
+                  margin-bottom: 14px;
+                  line-height: 1.7;
+                }
+                .readme li { margin-bottom: 4px; }
+                .readme strong { color: #e2e8f0; }
+                .readme code {
+                  background: #0f172a;
+                  color: #7dd3fc;
+                  padding: 2px 6px;
+                  border-radius: 4px;
+                  font-size: 0.875em;
+                  font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+                }
+                .readme pre {
+                  background: #0f172a;
+                  border: 1px solid #1e293b;
+                  border-radius: 8px;
+                  padding: 16px 20px;
+                  overflow-x: auto;
+                  margin-bottom: 16px;
+                }
+                .readme pre code {
+                  background: none;
+                  padding: 0;
+                  color: #cbd5e1;
+                  font-size: 0.875rem;
+                }
+                .readme table {
+                  width: 100%;
+                  border-collapse: collapse;
+                  margin-bottom: 16px;
+                  font-size: 0.9rem;
+                }
+                .readme th {
+                  text-align: left;
+                  color: #e2e8f0;
+                  border-bottom: 1px solid #334155;
+                  padding: 8px 12px;
+                }
+                .readme td {
+                  color: #94a3b8;
+                  border-bottom: 1px solid #1e293b;
+                  padding: 8px 12px;
+                  vertical-align: top;
+                }
+                .readme img { max-width: 100%; border-radius: 8px; margin: 8px 0; }
+                .readme hr { border: none; border-top: 1px solid #1e293b; margin: 40px 0; }
+                /* hide the div align=center wrappers pandoc passes through */
+                .readme div[align="center"] { text-align: center; }
+              </style>
+            </head>
+            <body>
+              <header class="site-header">
+                <h1>Decision Engine</h1>
+                <nav class="header-links">
+                  <a href="https://github.com/juspay/decision-engine">GitHub</a>
+                  <a href="./openapi.json">OpenAPI JSON</a>
+                  <a class="cta" href="./api-docs/">API Reference</a>
+                </nav>
+              </header>
+
+              <section class="hero">
+                <h2>Decision Engine</h2>
+                <p>Open-source payment gateway routing — rule-based, success-rate aware, and self-hosted.</p>
+                <div class="hero-links">
+                  <a class="primary" href="./api-docs/">API Reference (Swagger)</a>
+                  <a class="secondary" href="https://github.com/juspay/decision-engine">GitHub Repository</a>
+                  <a class="secondary" href="https://juspay.io/blog/juspay-orchestrator-and-merchant-controlled-routing-engine">How It Works</a>
+                </div>
+                <p class="spec-note">Raw OpenAPI spec: <a href="./openapi.json">openapi.json</a></p>
+              </section>
+
+              <article class="readme">
+                ${README_BODY}
+              </article>
+            </body>
+          </html>
+          LANDING
+
+          cat > public/api-docs/index.html <<'HTML'
           <!doctype html>
           <html lang="en">
             <head>

--- a/.github/workflows/api-reference-pages.yml
+++ b/.github/workflows/api-reference-pages.yml
@@ -31,7 +31,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pandoc
-        run: sudo apt-get install -y pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
 
       - name: Validate OpenAPI contract
         run: jq empty docs/openapi.json
@@ -58,8 +60,10 @@ jobs:
             -e "s|](CONTRIBUTING.md)|]($REPO/CONTRIBUTING.md)|g" \
             README.md > /tmp/readme-rewritten.md
 
+          # --from=gfm-raw_html strips raw HTML from README (e.g. <div align="center">)
+          # preventing any injected markup from reaching the published page.
           README_BODY=$(pandoc /tmp/readme-rewritten.md \
-            --from=gfm \
+            --from=gfm-raw_html \
             --to=html \
             --no-highlight)
 
@@ -70,6 +74,7 @@ jobs:
               <meta charset="utf-8" />
               <meta name="viewport" content="width=device-width, initial-scale=1" />
               <title>Decision Engine</title>
+              <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src https: data:; font-src https:; connect-src 'none'; script-src 'none';" />
               <link rel="icon" href="./favicon.svg" />
               <style>
                 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Prerequisites: Rust 1.85+, MySQL or PostgreSQL, Redis, [`just`](https://just.sys
 git clone https://github.com/juspay/decision-engine.git
 cd decision-engine
 
-cp config.example.toml config/development.toml
-# Edit config with your DB, Redis, and ClickHouse connection details
+# Edit config/development.toml with your DB, Redis, and ClickHouse connection details
+# (config/development.toml already exists with all required sections)
 ```
 
 **MySQL** (default features):
@@ -153,17 +153,6 @@ curl http://localhost:8080/health
 </div>
 
 Decision Engine fits into an existing payment stack without replacing your orchestrator. The orchestrator calls Decision Engine to get a gateway recommendation, then dispatches to that gateway. Card data stays in your vault — Decision Engine never touches it.
-
-| Step | Direction | Component | Action |
-|:----:|:---------:|-----------|--------|
-| 1 | → | Your App | Initiates payment request |
-| 2 | → | Orchestrator | Forwards to Decision Engine |
-| 3 | → | Decision Engine | Selects optimal gateway |
-| 4 | → | Vault | Returns card token (PCI-safe) |
-| 5 | → | Gateway | Processes payment |
-| 6 | ← | Gateway | Returns result |
-| 7 | ← | Orchestrator | Routes response back |
-| 8 | ← | Your App | Receives final result |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <br/><br/>
 
-# ⚡ Decision Engine
+# Decision Engine
 
-### **Routing control plane for payment decisions**
+### Routing control plane for payment decisions
 
 **Open-Source • Rust • Rule-Based • Success-Rate Based**
 
@@ -18,18 +18,18 @@ Configure routing rules, run gateway decisions, and inspect routing outcomes fro
 
 ---
 
-**[🚀 Quick Start](#-quick-start)** •
-**[📚 Documentation](#-documentation)** •
-**[🏗 Architecture](#-architecture)** •
-**[🤝 Contributing](#-contributing)**
+**[Quick Start](#quick-start)** •
+**[Documentation](#documentation)** •
+**[Architecture](#architecture)** •
+**[Contributing](#contributing)**
 
 </div>
 
 ---
 
-## 🎯 What is Decision Engine?
+## What is Decision Engine?
 
-Decision Engine is a payment gateway routing service built in Rust. It selects a gateway for each request using merchant-configured routing strategy, success-rate scores, rule-based policies, volume splits, and debit-routing gates.
+Decision Engine is a Rust service that sits between your orchestrator and your list of payment gateways. When a payment comes in, it picks the best available gateway based on rules you configure — priority ordering, success-rate scoring, volume splits, or debit-network gates — and returns the decision over HTTP.
 
 ```
 ┌─────────────┐     ┌──────────────────┐     ┌─────────────┐
@@ -38,66 +38,35 @@ Decision Engine is a payment gateway routing service built in Rust. It selects a
 └─────────────┘     └──────────────────┘     └─────────────┘
 ```
 
-### Core Use Cases
+It runs as a standalone service — no vendor lock-in, no mandatory orchestrator. Your existing stack calls it over HTTP before dispatching to a gateway, and over time it improves decisions using outcome feedback you push back via the score update API.
 
-| Use case | Supported surface |
-|----------|-------------------|
-| Route by connector score | Auth-rate based routing |
-| Route by explicit business condition | Rule-based routing |
-| Roll out traffic by percentage | Volume split |
-| Gate debit-network routing per merchant | Debit routing toggle |
-| Inspect routing outcomes | Analytics and Decision Audit dashboard |
+What it ships today:
 
----
-
-## ✨ Features
-
-<table>
-<tr>
-<td width="50%">
-
-### 🧠 Intelligent Routing
-
-| Feature | What It Does |
-|---------|--------------|
-| **Eligibility Check** | Filters out ineligible gateways before routing |
-| **Rule-Based Ordering** | Apply merchant-specific priority rules |
-| **Dynamic Ordering** | Success rate based gateway optimization |
-| **Downtime Detection** | Auto-pause failing gateways |
-
-</td>
-<td width="50%">
-
-### 🛠 Operational Surfaces
-
-| Capability | Details |
-|------------|---------|
-| **Dashboard** | Configure routing and inspect analytics/audit views |
-| **API reference** | OpenAPI-backed route documentation and curl examples |
-| **Analytics storage** | ClickHouse-backed analytics tables for local and deployed environments |
-| **Multi-DB app storage** | MySQL and PostgreSQL support |
-| **Deployment artifacts** | Docker Compose and Helm configuration are included |
-
-</td>
-</tr>
-</table>
+- **Rule-based routing** — define priority rules per merchant using Euclid, Juspay's open rule engine
+- **Success-rate ordering** — gateways ranked dynamically from transaction outcome feedback
+- **Volume splits** — distribute traffic across gateways by percentage
+- **Debit routing gates** — per-merchant toggle for debit-network routing
+- **Downtime detection** — auto-excludes gateways that are failing
+- **Analytics** — ClickHouse-backed tables for routing outcomes and decision audit
+- **Dashboard** — React UI for configuring rules and inspecting decisions
+- **Multi-DB** — MySQL and PostgreSQL support
+- **Team management** — invite and manage members per merchant account
 
 ---
 
-## 🏃 Quick Start
+## Quick Start
 
-### 🐳 Docker (Recommended)
+### Docker (Recommended)
 
 ```bash
-# Clone and run
 git clone https://github.com/juspay/decision-engine.git
 cd decision-engine
 docker compose --profile postgres-ghcr up -d
-
-# That's it! API ready at http://localhost:8080
 ```
 
-For API + dashboard + docs:
+API is ready at `http://localhost:8080`. That's it.
+
+For API + dashboard + docs together:
 
 ```bash
 docker compose --profile dashboard-postgres-ghcr up -d
@@ -108,29 +77,45 @@ Open:
 - API: `http://localhost:8080`
 - Dashboard: `http://localhost:8081/dashboard/`
 - Docs: `http://localhost:8081/introduction`
-- API documentation map: `http://localhost:8081/api-overview`
+- API reference: `http://localhost:8081/api-overview`
 
-For deployed docs or dashboard environments, use the same docs paths under the deployed host, for example `https://<docs-host>/api-overview`. That page links to the API examples and OpenAPI reference sections.
+For deployed docs or dashboard environments, use the same paths under your deployed host, e.g. `https://<docs-host>/api-overview`.
 
-### 🦀 From Source
+### From Source
+
+Prerequisites: Rust 1.85+, MySQL or PostgreSQL, Redis, [`just`](https://just.systems)
 
 ```bash
-# Prerequisites: Rust 1.85+, MySQL/PostgreSQL, Redis
-
 git clone https://github.com/juspay/decision-engine.git
 cd decision-engine
-cargo build --release
 
-# Configure
 cp config.example.toml config/development.toml
-# Edit config with your settings
-
-# Run migrations & start
-diesel migration run
-./target/release/open_router
+# Edit config with your DB, Redis, and ClickHouse connection details
 ```
 
-### ✅ Verify
+**MySQL** (default features):
+```bash
+cargo build --release --features release
+diesel migration run   # set DATABASE_URL=mysql://user:pass@host/dbname first
+RUSTFLAGS="-Awarnings" cargo run --features release
+```
+
+**PostgreSQL**:
+```bash
+cargo build --release --no-default-features --features middleware,kms-aws,postgres
+just migrate-pg        # sets DATABASE_URL from env or justfile defaults
+RUSTFLAGS="-Awarnings" cargo run --no-default-features --features postgres
+```
+
+For the full local dev environment (API + dashboard on port 5173 + docs), run:
+
+```bash
+./oneclick.sh
+```
+
+This brings up Postgres, Redis, ClickHouse, and Kafka via Docker Compose, runs migrations, and starts the API server and dashboard locally. See [Local Setup Guide](docs/local-setup.md) for full details and options like `ONECLICK_KEEP_INFRA=1`.
+
+### Verify
 
 ```bash
 curl http://localhost:8080/health
@@ -139,20 +124,21 @@ curl http://localhost:8080/health
 
 ---
 
-## 📖 Documentation
+## Documentation
 
-| 📘 Resource | Description |
-|-------------|-------------|
-| [Local Setup Guide](docs/local-setup.md) | Canonical guide for CLI, Docker, Compose profiles, and Helm |
+| Resource | Description |
+|----------|-------------|
+| [Local Setup Guide](docs/local-setup.md) | CLI, Docker, Compose profiles, and Helm |
 | [MySQL Setup Guide](docs/setup-guide-mysql.md) | MySQL-specific walkthrough |
 | [PostgreSQL Setup Guide](docs/setup-guide-postgres.md) | PostgreSQL-specific walkthrough |
-| [API Documentation Map](docs/api-overview.md) | Main API entrypoint with embedded links to API examples, OpenAPI schema pages, route access rules, local URLs, and deployed docs paths |
+| [API Reference (Swagger)](https://juspay.github.io/decision-engine/api-docs/) | Interactive Swagger UI — browse and try every endpoint against the OpenAPI spec |
+| [API Overview](docs/api-overview.md) | Entrypoint to API examples, OpenAPI schema, and route access rules |
 | [Configuration Guide](docs/configuration.md) | All config options explained |
-| [Deep Dive Blog](https://juspay.io/blog/juspay-orchestrator-and-merchant-controlled-routing-engine) | How routing logic works |
+| [Deep Dive Blog](https://juspay.io/blog/juspay-orchestrator-and-merchant-controlled-routing-engine) | How the routing logic works |
 
 ---
 
-## 🏗 Architecture
+## Architecture
 
 ### High-Level Flow
 
@@ -162,13 +148,11 @@ curl http://localhost:8080/health
 
 ### Integration Pattern
 
-Decision Engine integrates seamlessly into your existing payment stack:
-
 <div align="center">
   <img src="https://github.com/user-attachments/assets/272ad222-8a91-4bb2-aa3a-e1fc9c28e3da" alt="Integration Pattern" width="70%"/>
 </div>
 
-**Integration Steps:**
+Decision Engine fits into an existing payment stack without replacing your orchestrator. The orchestrator calls Decision Engine to get a gateway recommendation, then dispatches to that gateway. Card data stays in your vault — Decision Engine never touches it.
 
 | Step | Direction | Component | Action |
 |:----:|:---------:|-----------|--------|
@@ -181,62 +165,56 @@ Decision Engine integrates seamlessly into your existing payment stack:
 | 7 | ← | Orchestrator | Routes response back |
 | 8 | ← | Your App | Receives final result |
 
-**Key Benefits:**
-- **Zero PCI scope** — Vault handles all card data
-- **Drop-in integration** — Works with any orchestrator
-- **Intelligent fallback** — Auto-switches on gateway failure
-
 ---
 
-## 🗺 Roadmap
+## Roadmap
 
 | Status | Feature | Description |
 |:------:|---------|-------------|
-| ✅ | Rule-based routing | Merchant-defined priority rules |
-| ✅ | Dynamic ordering | SR-based gateway selection |
+| ✅ | Rule-based routing | Merchant-defined priority rules via Euclid |
+| ✅ | Dynamic ordering | Success-rate based gateway selection |
 | ✅ | Downtime detection | Automatic health monitoring |
 | ✅ | Multi-database | MySQL & PostgreSQL support |
+| ✅ | Dashboard | Visual rule management and decision audit UI |
+| ✅ | Team management | Invite members to merchant accounts |
 | 🔄 | Enhanced routing models | Better success rate prediction |
-| 🔄 | Admin dashboard | Visual rule management UI |
 | 📋 | Multi-tenant analytics | Per-tenant routing insights |
 | 📋 | GraphQL API | Alternative query interface |
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
-We ❤️ contributions!
+Contributions are welcome — bug reports, feature requests, docs, or code.
 
 ```bash
-# 1. Fork & clone
+# Fork & clone
 git clone https://github.com/YOUR_USERNAME/decision-engine.git
 
-# 2. Create branch
+# Create a branch
 git checkout -b feature/your-feature
 
-# 3. Make changes & test
+# Make changes and test
 cargo test
 
-# 4. Submit PR!
+# Submit a PR
 ```
 
-👉 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-
-🌱 **New to open source?** Check out [good first issues](https://github.com/juspay/decision-engine/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)!
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, and check [good first issues](https://github.com/juspay/decision-engine/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if you're new to the codebase.
 
 ---
 
-## 💬 Community
+## Community
 
-| Platform | What It's For |
-|----------|---------------|
-| [![Slack](https://img.shields.io/badge/Slack-Join_Chat-4A154B?logo=slack)](https://join.slack.com/t/hyperswitch-io/shared_invite/zt-2jqxmpsbm-WXUENx022HjNEy~Ark7Orw) | Real-time help, discussions |
-| [GitHub Discussions](https://github.com/juspay/decision-engine/discussions) | Ideas, feature requests |
+| Platform | Purpose |
+|----------|---------|
+| [![Slack](https://img.shields.io/badge/Slack-Join_Chat-4A154B?logo=slack)](https://join.slack.com/t/hyperswitch-io/shared_invite/zt-2jqxmpsbm-WXUENx022HjNEy~Ark7Orw) | Real-time help and discussions |
+| [GitHub Discussions](https://github.com/juspay/decision-engine/discussions) | Feature requests and ideas |
 | [GitHub Issues](https://github.com/juspay/decision-engine/issues) | Bug reports |
 
 ---
 
-## 📜 License
+## License
 
 Licensed under [GNU AGPL v3.0](LICENSE).
 
@@ -244,10 +222,8 @@ Licensed under [GNU AGPL v3.0](LICENSE).
 
 <div align="center">
 
-### Built with ❤️ by [Juspay](https://juspay.io)
+Built by [Juspay](https://juspay.io)
 
-*Reliable, open-source payments infrastructure for the world.*
-
-**[⬆ Back to Top](#-decision-engine)**
+**[Back to Top](#decision-engine)**
 
 </div>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,11 +8,7 @@ This document explains how to configure Decision Engine for local and on-prem de
 - `config/docker-configuration.toml`: used for Docker and Compose runs
 - `helm-charts/config/development.toml`: Kubernetes chart template config
 
-Start from the example:
-
-```bash
-cp config.example.toml config/development.toml
-```
+These files already exist with all required sections. Edit the one that matches your runtime rather than copying from `config.example.toml`, which is incomplete.
 
 ## Config Sections
 
@@ -42,10 +38,10 @@ log_format = "default"
 ```toml
 [metrics]
 host = "0.0.0.0"
-port = 9090
+port = 9094
 ```
 
-Prometheus metrics are exposed at `host:port/metrics`. Used by the `monitoring` Compose profile.
+Prometheus metrics are exposed at `host:port/metrics`. Used by the `monitoring` Compose profile (Prometheus scrapes `9094`, Grafana at `3000`).
 
 ### Rate Limiting
 
@@ -57,13 +53,7 @@ duration = 60
 
 Controls rate limiting on the delete APIs. `request_count` requests allowed per `duration` seconds.
 
-### In-Memory Cache
-
-```toml
-[cache]
-tti = 7200          # seconds of idle time before eviction
-max_capacity = 5000 # max entries per table cache
-```
+### Redis cache config
 
 ```toml
 [cache_config]
@@ -73,16 +63,31 @@ service_config_ttl = 300    # Redis TTL for service config entries, in seconds
 
 ### Database
 
+MySQL and PostgreSQL use separate config sections.
+
+**MySQL:**
+
 ```toml
 [database]
 username = "db_user"
 password = "db_pass"
 host = "localhost"
-port = 5432
+port = 3306
 dbname = "decision_engine_db"
 ```
 
-Use port `5432` for PostgreSQL and `3306` for MySQL. For Docker Compose runs this is pre-wired via service names.
+**PostgreSQL:**
+
+```toml
+[pg_database]
+pg_username = "db_user"
+pg_password = "db_pass"
+pg_host = "localhost"
+pg_port = 5432
+pg_dbname = "decision_engine_db"
+```
+
+For Docker Compose runs both are pre-wired via service names in `config/docker-configuration.toml`.
 
 ### Multi-Tenant Schema
 
@@ -112,7 +117,7 @@ jwt_expiry_seconds = 86400
 email_verification_enabled = false
 ```
 
-`jwt_secret` must be at least 32 characters. Set `email_verification_enabled = true` if you've wired an email provider.
+Use a strong, random `jwt_secret` — 32+ characters recommended. Set `email_verification_enabled = true` if you've wired an email provider.
 
 ### Admin Secret
 
@@ -129,23 +134,27 @@ Used to authenticate the `POST /merchant-account/create` endpoint (admin bootstr
 api_key_auth_enabled = true
 ```
 
-Top-level flag. When `true`, protected routes accept `x-api-key` in addition to JWT bearer tokens. Disable only in controlled environments.
+Top-level flag. When `true`, protected routes accept `x-api-key` in addition to JWT bearer tokens. When `false`, the auth middleware allows **all requests through without authentication** — this effectively disables auth for every protected route. Do not set this to `false` in any environment that should enforce auth.
 
 ### Analytics
 
+Both Kafka and ClickHouse require `enabled = true` — without it, analytics is disabled even if the connection details are configured.
+
 ```toml
 [analytics.kafka]
+enabled = true
 brokers = "localhost:9092"
 api_topic = "api"
 domain_topic = "domain"
 
 [analytics.clickhouse]
+enabled = true
 url = "http://localhost:8123"
-database = "default"
-user = "default"
+user = "decision_engine"
+password = "decision_engine"
 ```
 
-Decision outcomes are published to Kafka and consumed into ClickHouse. Both are required for analytics and audit dashboard views. For Docker runs, these are pre-configured via the Compose profiles.
+Decision outcomes are published to Kafka and consumed into ClickHouse. Both are required for analytics and audit dashboard views. For Docker runs, these are pre-configured and enabled via the Compose profiles.
 
 ### TLS
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,11 +4,17 @@ This document explains how to configure Decision Engine for local and on-prem de
 
 ## Primary Config Files
 
-- `config/development.toml`: host/source runs
-- `config/docker-configuration.toml`: Docker/Compose runs
+- `config/development.toml`: used for host/source runs
+- `config/docker-configuration.toml`: used for Docker and Compose runs
 - `helm-charts/config/development.toml`: Kubernetes chart template config
 
-## Core Sections
+Start from the example:
+
+```bash
+cp config.example.toml config/development.toml
+```
+
+## Config Sections
 
 ### Server
 
@@ -18,13 +24,7 @@ host = "0.0.0.0"
 port = 8080
 ```
 
-### Metrics
-
-```toml
-[metrics]
-host = "0.0.0.0"
-port = 9090
-```
+`host` is the bind address. Use `0.0.0.0` for Docker/deployed, `127.0.0.1` for local-only.
 
 ### Logging
 
@@ -35,12 +35,63 @@ level = "DEBUG"
 log_format = "default"
 ```
 
+`log_format` accepts `"default"` (human-readable) or `"json"` (structured, recommended for prod).
+
+### Metrics
+
+```toml
+[metrics]
+host = "0.0.0.0"
+port = 9090
+```
+
+Prometheus metrics are exposed at `host:port/metrics`. Used by the `monitoring` Compose profile.
+
+### Rate Limiting
+
+```toml
+[limit]
+request_count = 1
+duration = 60
+```
+
+Controls rate limiting on the delete APIs. `request_count` requests allowed per `duration` seconds.
+
+### In-Memory Cache
+
+```toml
+[cache]
+tti = 7200          # seconds of idle time before eviction
+max_capacity = 5000 # max entries per table cache
+```
+
+```toml
+[cache_config]
+service_config_redis_prefix = "DE_service_config_"
+service_config_ttl = 300    # Redis TTL for service config entries, in seconds
+```
+
 ### Database
 
-Use either MySQL or PostgreSQL as required by your deployment mode.
+```toml
+[database]
+username = "db_user"
+password = "db_pass"
+host = "localhost"
+port = 5432
+dbname = "decision_engine_db"
+```
 
-For Docker Compose profiles, connection details are pre-wired via service names and mounted config.
-For source runs, ensure your database URL in config matches your local DB.
+Use port `5432` for PostgreSQL and `3306` for MySQL. For Docker Compose runs this is pre-wired via service names.
+
+### Multi-Tenant Schema
+
+```toml
+[tenant_secrets]
+hyperswitch = { schema = "public" }
+```
+
+Maps tenant identifiers to database schemas. Add entries for each tenant you want to support.
 
 ### Redis
 
@@ -50,21 +101,111 @@ host = "127.0.0.1"
 port = 6379
 ```
 
-### Secrets Manager
+Redis is required — it's used for caching routing config and service config. For Docker, use the service name as host.
 
-`secrets_manager` controls encryption/key-management behavior. In local environments this is commonly set to `no_encryption`.
+### Auth
+
+```toml
+[user_auth]
+jwt_secret = "change_me_in_production_use_32chars!!"
+jwt_expiry_seconds = 86400
+email_verification_enabled = false
+```
+
+`jwt_secret` must be at least 32 characters. Set `email_verification_enabled = true` if you've wired an email provider.
+
+### Admin Secret
+
+```toml
+[admin_secret]
+secret = "test_admin"
+```
+
+Used to authenticate the `POST /merchant-account/create` endpoint (admin bootstrap). Change this in production.
+
+### API Key Auth
+
+```toml
+api_key_auth_enabled = true
+```
+
+Top-level flag. When `true`, protected routes accept `x-api-key` in addition to JWT bearer tokens. Disable only in controlled environments.
+
+### Analytics
+
+```toml
+[analytics.kafka]
+brokers = "localhost:9092"
+api_topic = "api"
+domain_topic = "domain"
+
+[analytics.clickhouse]
+url = "http://localhost:8123"
+database = "default"
+user = "default"
+```
+
+Decision outcomes are published to Kafka and consumed into ClickHouse. Both are required for analytics and audit dashboard views. For Docker runs, these are pre-configured via the Compose profiles.
+
+### TLS
+
+```toml
+[tls]
+certificate = "cert.pem"
+private_key = "key.pem"
+```
+
+Paths to PEM-format certificate and key files. Only needed if you're terminating TLS at the app layer rather than a reverse proxy.
+
+### API Client
+
+```toml
+[api_client]
+client_idle_timeout = 90
+pool_max_idle_per_host = 10
+identity = ""
+```
+
+Controls the outbound HTTP client used for upstream calls. Set `identity` to a PEM path if you need mTLS.
+
+## Secrets Management
+
+By default, secrets in config are stored in plaintext. For production, use one of the two supported backends.
+
+### AWS KMS
+
+Requires the `kms-aws` feature (included in the `release` feature set).
+
+```toml
+[secrets_management]
+secrets_manager = "aws_kms"
+
+[secrets_management.aws_kms]
+key_id = "your-kms-key-id"
+region = "us-east-1"
+```
+
+### HashiCorp Vault
+
+Requires the `kms-hashicorp-vault` feature.
+
+```toml
+[secrets_management]
+secrets_manager = "hashi_corp_vault"
+
+[secrets_management.hashi_corp_vault]
+url = "http://127.0.0.1:8200"
+token = "hvs.your_token"
+```
+
+When a secrets manager is configured, sensitive fields like `database.password` and `user_auth.jwt_secret` are resolved from the vault rather than the config file.
 
 ## Environment Overrides
 
-Use environment variables to override selected runtime values when needed (for example in Helm via `extraEnvVars`).
-
-For deployment-specific examples, see:
-
-- [Local Setup Guide](local-setup.md)
-- [Helm Chart README](https://github.com/juspay/decision-engine/blob/main/helm-charts/README.md)
+Selected values can be overridden at runtime via environment variables. This is useful in Helm deployments via `extraEnvVars`. Consult `src/config.rs` for the full mapping.
 
 ## Related Docs
 
 - [Local Setup Guide](local-setup.md)
-- [API Reference](api-reference.md)
+- [API Overview](api-overview.md)
 - [API Examples](api-refs/api-ref.mdx)

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -11,9 +11,9 @@ This is the canonical local startup guide for Decision Engine.
 Required for source runs:
 
 - Rust 1.85+
-- [`just`](https://just.systems) — used for the `migrate-pg` command
 - PostgreSQL or MySQL
 - Redis
+- [`just`](https://just.systems) — required for PostgreSQL source runs (`just migrate-pg`); MySQL can use `diesel migration run` directly
 
 ## Runtime Tracks
 

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -8,10 +8,10 @@ This is the canonical local startup guide for Decision Engine.
 - Docker Compose v2+
 - Git 2+
 
-Optional for source runs:
+Required for source runs:
 
 - Rust 1.85+
-- `just`
+- [`just`](https://just.systems) — used for the `migrate-pg` command
 - PostgreSQL or MySQL
 - Redis
 


### PR DESCRIPTION
This pull request updates the GitHub Pages workflow and refines the `README.md` and configuration documentation for Decision Engine. The changes improve the project’s public documentation, enhance the generated landing page for GitHub Pages, and clarify configuration steps for users.

**Documentation and Landing Page Improvements:**

* Significantly rewrote and reorganized `README.md` for clarity, conciseness, and easier onboarding, including improved feature lists, clearer quick start instructions, and updated integration and contribution sections. 
* Updated `docs/configuration.md` to clarify which config files to use for different environments and added explicit instructions for starting from the example config. Also added logging configuration documentation. 

**GitHub Pages Workflow Enhancements:**

* The workflow now triggers on changes to `README.md`, ensuring the landing page stays up-to-date with documentation changes.
* Added a step to install `pandoc` for Markdown-to-HTML conversion, enabling richer rendering of the README on the landing page.
* Overhauled the workflow’s build script to:
  - Rewrite relative doc links in the README to absolute GitHub URLs for correct navigation from the landing page.
  - Render the README as HTML using `pandoc` and embed it in a custom-styled landing page with a navigation header and hero section.
  - Copy OpenAPI spec and favicon to appropriate locations for both the root and `/api-docs/` paths.

These changes make the public documentation more accessible and ensure the GitHub Pages site provides a polished, up-to-date introduction to the project.