### PR TITLE
fix(user): print the full error log instead of just throwing the type

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod context;
 
+use error_stack::{Report, ResultExt};
 use josekit::jws::JwsHeader;
 use josekit::jwt::{self, JwtPayload};
 use ring::digest;
@@ -9,6 +10,30 @@ use uuid::Uuid;
 pub use context::{AuthContext, AuthKind};
 
 const KEY_PREFIX: &str = "DE_";
+
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("Failed to get current system time")]
+    SystemTime,
+    #[error("Failed to build JWT signer or verifier")]
+    JwtKeyError,
+    #[error("Failed to set JWT claim")]
+    JwtClaimError,
+    #[error("Failed to encode JWT")]
+    JwtEncodeError,
+    #[error("Failed to decode or verify JWT")]
+    JwtDecodeError,
+    #[error("JWT token has expired")]
+    TokenExpired,
+    #[error("JWT token is missing required claim: {0}")]
+    MissingClaim(&'static str),
+    #[error("Failed to hash password")]
+    PasswordHashError,
+    #[error("Failed to verify password hash")]
+    PasswordVerifyError,
+    #[error("Password does not meet strength requirements")]
+    WeakPassword,
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct JwtClaims {
@@ -29,10 +54,10 @@ pub fn generate_jwt(
     role: &str,
     secret: &str,
     expiry_seconds: u64,
-) -> Result<String, String> {
+) -> Result<String, Report<AuthError>> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_err(|e| e.to_string())?
+        .change_context(AuthError::SystemTime)?
         .as_secs();
 
     let jti = Uuid::new_v4().to_string();
@@ -44,86 +69,90 @@ pub fn generate_jwt(
             "user_id",
             Some(serde_json::Value::String(user_id.to_string())),
         )
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtClaimError)?;
     payload
         .set_claim("email", Some(serde_json::Value::String(email.to_string())))
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtClaimError)?;
     payload
         .set_claim(
             "merchant_id",
             Some(serde_json::Value::String(merchant_id.to_string())),
         )
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtClaimError)?;
     payload
         .set_claim("role", Some(serde_json::Value::String(role.to_string())))
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtClaimError)?;
     payload
         .set_claim("jti", Some(serde_json::Value::String(jti)))
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtClaimError)?;
     payload
         .set_claim("iat", Some(serde_json::Value::Number(now.into())))
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtClaimError)?;
     payload
         .set_claim(
             "exp",
             Some(serde_json::Value::Number((now + expiry_seconds).into())),
         )
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtClaimError)?;
 
     let signer = josekit::jws::HS256
         .signer_from_bytes(secret.as_bytes())
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtKeyError)?;
 
     let header = JwsHeader::new();
-    jwt::encode_with_signer(&payload, &header, &signer).map_err(|e| e.to_string())
+    jwt::encode_with_signer(&payload, &header, &signer).change_context(AuthError::JwtEncodeError)
 }
 
-pub fn verify_jwt(token: &str, secret: &str) -> Result<JwtClaims, String> {
+pub fn verify_jwt(token: &str, secret: &str) -> Result<JwtClaims, Report<AuthError>> {
     let verifier = josekit::jws::HS256
         .verifier_from_bytes(secret.as_bytes())
-        .map_err(|e| e.to_string())?;
+        .change_context(AuthError::JwtKeyError)?;
 
-    let (payload, _) = jwt::decode_with_verifier(token, &verifier).map_err(|e| e.to_string())?;
+    let (payload, _) =
+        jwt::decode_with_verifier(token, &verifier).change_context(AuthError::JwtDecodeError)?;
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_err(|e| e.to_string())?
+        .change_context(AuthError::SystemTime)?
         .as_secs();
 
     let exp = payload
         .claim("exp")
         .and_then(|v| v.as_u64())
-        .ok_or("missing exp")?;
+        .ok_or_else(|| Report::new(AuthError::MissingClaim("exp")))?;
 
     if now > exp {
-        return Err("token expired".to_string());
+        return Err(Report::new(AuthError::TokenExpired));
     }
 
-    let user_id = payload.subject().ok_or("missing sub")?.to_string();
+    let user_id = payload
+        .subject()
+        .ok_or_else(|| Report::new(AuthError::MissingClaim("sub")))?
+        .to_string();
     let email = payload
         .claim("email")
         .and_then(|v| v.as_str())
-        .ok_or("missing email")?
+        .ok_or_else(|| Report::new(AuthError::MissingClaim("email")))?
         .to_string();
     let merchant_id = payload
         .claim("merchant_id")
         .and_then(|v| v.as_str())
-        .ok_or("missing merchant_id")?
+        .ok_or_else(|| Report::new(AuthError::MissingClaim("merchant_id")))?
         .to_string();
     let role = payload
         .claim("role")
         .and_then(|v| v.as_str())
-        .ok_or("missing role")?
+        .ok_or_else(|| Report::new(AuthError::MissingClaim("role")))?
         .to_string();
     let jti = payload
         .claim("jti")
         .and_then(|v| v.as_str())
-        .ok_or("missing jti")?
+        .ok_or_else(|| Report::new(AuthError::MissingClaim("jti")))?
         .to_string();
     let iat = payload
         .claim("iat")
         .and_then(|v| v.as_u64())
-        .ok_or("missing iat")?;
+        .ok_or_else(|| Report::new(AuthError::MissingClaim("iat")))?;
 
     Ok(JwtClaims {
         sub: user_id.clone(),
@@ -137,17 +166,18 @@ pub fn verify_jwt(token: &str, secret: &str) -> Result<JwtClaims, String> {
     })
 }
 
-pub fn hash_password(password: &str) -> Result<String, String> {
-    bcrypt::hash(password, bcrypt::DEFAULT_COST).map_err(|e| e.to_string())
+pub fn hash_password(password: &str) -> Result<String, Report<AuthError>> {
+    bcrypt::hash(password, bcrypt::DEFAULT_COST).change_context(AuthError::PasswordHashError)
 }
 
-pub fn verify_password(password: &str, hash: &str) -> Result<bool, String> {
-    bcrypt::verify(password, hash).map_err(|e| e.to_string())
+pub fn verify_password(password: &str, hash: &str) -> Result<bool, Report<AuthError>> {
+    bcrypt::verify(password, hash).change_context(AuthError::PasswordVerifyError)
 }
 
-pub fn validate_password_strength(password: &str) -> Result<(), String> {
+pub fn validate_password_strength(password: &str) -> Result<(), Report<AuthError>> {
     if password.chars().count() < 10 {
-        return Err("Password must be at least 10 characters long".to_string());
+        return Err(Report::new(AuthError::WeakPassword)
+            .attach_printable("Password must be at least 10 characters long"));
     }
 
     let has_uppercase = password.chars().any(|c| c.is_ascii_uppercase());
@@ -156,10 +186,9 @@ pub fn validate_password_strength(password: &str) -> Result<(), String> {
     let has_special = password.chars().any(|c| !c.is_ascii_alphanumeric());
 
     if !(has_uppercase && has_lowercase && has_digit && has_special) {
-        return Err(
-            "Password must include an uppercase letter, a lowercase letter, a number, and a special character"
-                .to_string(),
-        );
+        return Err(Report::new(AuthError::WeakPassword).attach_printable(
+            "Password must include an uppercase letter, a lowercase letter, a number, and a special character",
+        ));
     }
 
     Ok(())
@@ -237,7 +266,6 @@ mod tests {
     fn hash_matches_on_verification() {
         let raw_key = generate_api_key();
         let stored_hash = hash_api_key(&raw_key);
-        // Simulate what the middleware does: hash the incoming key and compare
         let incoming_hash = hash_api_key(&raw_key);
         assert_eq!(
             stored_hash, incoming_hash,

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -1,6 +1,6 @@
 use crate::app::{get_tenant_app_state, APP_STATE};
 use crate::auth;
-use crate::error::{self, UserAuthError};
+use crate::error::{self, ContainerError, ResultContainerExt, UserAuthError};
 use crate::storage::types::{
     MerchantAccountNew, NewUser, NewUserMerchant, User, UserMerchant, UserMerchantIdUpdate,
 };
@@ -9,6 +9,7 @@ use axum::http::HeaderMap;
 use axum::Json;
 use diesel::associations::HasTable;
 use diesel::{BoolExpressionMethods, ExpressionMethods};
+use error_stack::ResultExt;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "mysql")]
@@ -96,7 +97,7 @@ pub async fn signup(
         dsl::email.eq(payload.email.clone()),
     )
     .await
-    .map_err(|_| UserAuthError::StorageError)?;
+    .change_error(UserAuthError::StorageError)?;
 
     if !existing.is_empty() {
         return Err(error::ContainerError::from(
@@ -104,10 +105,11 @@ pub async fn signup(
         ));
     }
 
-    auth::validate_password_strength(&payload.password).map_err(|_| UserAuthError::WeakPassword)?;
+    auth::validate_password_strength(&payload.password)
+        .change_context(UserAuthError::WeakPassword)?;
 
-    let password_hash =
-        auth::hash_password(&payload.password).map_err(|_| UserAuthError::PasswordHashingFailed)?;
+    let password_hash = auth::hash_password(&payload.password)
+        .change_context(UserAuthError::PasswordHashingFailed)?;
 
     let user_id = uuid::Uuid::new_v4().to_string();
     let now = date_time::now();
@@ -134,7 +136,7 @@ pub async fn signup(
             ma_dsl::merchant_id.eq(Some(merchant_id.clone())),
         )
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .change_error(UserAuthError::StorageError)?;
 
         if existing_merchant.is_empty() {
             return Err(error::ContainerError::from(UserAuthError::MerchantNotFound));
@@ -164,7 +166,7 @@ pub async fn signup(
 
     crate::generics::generic_insert(&app_state.db, new_user)
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .change_context(UserAuthError::StorageError)?;
 
     if let Some(merchant_id) = requested_merchant_id.as_ref() {
         let new_user_merchant = NewUserMerchant {
@@ -176,7 +178,7 @@ pub async fn signup(
 
         crate::generics::generic_insert(&app_state.db, new_user_merchant)
             .await
-            .map_err(|_| UserAuthError::StorageError)?;
+            .change_context(UserAuthError::StorageError)?;
     }
 
     if global_config.user_auth.email_verification_enabled {
@@ -191,7 +193,7 @@ pub async fn signup(
         &global_config.user_auth.jwt_secret,
         global_config.user_auth.jwt_expiry_seconds,
     )
-    .map_err(|_| UserAuthError::TokenGenerationFailed)?;
+    .change_context(UserAuthError::TokenGenerationFailed)?;
 
     Ok(Json(AuthResponse {
         token,
@@ -218,7 +220,7 @@ pub async fn login(
         dsl::email.eq(payload.email.clone()),
     )
     .await
-    .map_err(|_| UserAuthError::StorageError)?;
+    .change_error(UserAuthError::StorageError)?;
 
     let user = users.pop().ok_or(UserAuthError::UserNotFound)?;
 
@@ -251,7 +253,7 @@ pub async fn login(
     }
 
     if !auth::verify_password(&payload.password, &user.password_hash)
-        .map_err(|_| UserAuthError::StorageError)?
+        .change_context(UserAuthError::StorageError)?
     {
         return Err(error::ContainerError::from(UserAuthError::InvalidPassword));
     }
@@ -272,7 +274,7 @@ pub async fn login(
         &global_config.user_auth.jwt_secret,
         global_config.user_auth.jwt_expiry_seconds,
     )
-    .map_err(|_| UserAuthError::TokenGenerationFailed)?;
+    .change_context(UserAuthError::TokenGenerationFailed)?;
 
     Ok(Json(AuthResponse {
         token,
@@ -316,7 +318,7 @@ pub async fn create_merchant(
 
     crate::generics::generic_insert(&app_state.db, new_merchant)
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .change_context(UserAuthError::StorageError)?;
 
     let new_user_merchant = NewUserMerchant {
         user_id: claims.user_id.clone(),
@@ -327,7 +329,7 @@ pub async fn create_merchant(
 
     crate::generics::generic_insert(&app_state.db, new_user_merchant)
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .change_context(UserAuthError::StorageError)?;
 
     // Update users.merchant_id to the newly created merchant
     {
@@ -340,7 +342,7 @@ pub async fn create_merchant(
             .db
             .get_conn()
             .await
-            .map_err(|_| UserAuthError::StorageError)?;
+            .change_error(UserAuthError::StorageError)?;
         crate::generics::generic_update_if_present::<
             <User as diesel::associations::HasTable>::Table,
             UserMerchantIdUpdate,
@@ -353,7 +355,7 @@ pub async fn create_merchant(
             },
         )
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .change_context(UserAuthError::StorageError)?;
     }
 
     let merchants = fetch_user_merchants(&app_state, &claims.user_id).await?;
@@ -366,7 +368,7 @@ pub async fn create_merchant(
         &global_config.user_auth.jwt_secret,
         global_config.user_auth.jwt_expiry_seconds,
     )
-    .map_err(|_| UserAuthError::TokenGenerationFailed)?;
+    .change_context(UserAuthError::TokenGenerationFailed)?;
 
     Ok(Json(CreateMerchantResponse {
         token: new_token,
@@ -421,7 +423,7 @@ pub async fn switch_merchant(
         &global_config.user_auth.jwt_secret,
         global_config.user_auth.jwt_expiry_seconds,
     )
-    .map_err(|_| UserAuthError::TokenGenerationFailed)?;
+    .change_context(UserAuthError::TokenGenerationFailed)?;
 
     Ok(Json(AuthResponse {
         token: new_token,
@@ -484,7 +486,7 @@ pub async fn invite_member(
         dsl::email.eq(payload.email.clone()),
     )
     .await
-    .map_err(|_| UserAuthError::StorageError)?;
+    .change_error(UserAuthError::StorageError)?;
 
     let now = date_time::now();
 
@@ -501,7 +503,7 @@ pub async fn invite_member(
                 .and(um_dsl::merchant_id.eq(claims.merchant_id.clone())),
         )
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .change_error(UserAuthError::StorageError)?;
 
         if !existing_membership.is_empty() {
             return Err(error::ContainerError::from(UserAuthError::AlreadyMember));
@@ -516,7 +518,7 @@ pub async fn invite_member(
 
         crate::generics::generic_insert(&app_state.db, new_user_merchant)
             .await
-            .map_err(|_| UserAuthError::StorageError)?;
+            .change_context(UserAuthError::StorageError)?;
 
         Ok(Json(InviteMemberResponse {
             email: existing_user.email,
@@ -529,7 +531,7 @@ pub async fn invite_member(
         let generated_password = generate_random_password();
 
         let password_hash = auth::hash_password(&generated_password)
-            .map_err(|_| UserAuthError::PasswordHashingFailed)?;
+            .change_context(UserAuthError::PasswordHashingFailed)?;
 
         let user_id = uuid::Uuid::new_v4().to_string();
 
@@ -552,7 +554,7 @@ pub async fn invite_member(
 
         crate::generics::generic_insert(&app_state.db, new_user)
             .await
-            .map_err(|_| UserAuthError::StorageError)?;
+            .change_context(UserAuthError::StorageError)?;
 
         let new_user_merchant = NewUserMerchant {
             user_id: user_id.clone(),
@@ -605,7 +607,7 @@ pub async fn list_members(
             um_dsl::merchant_id.eq(claims.merchant_id.clone()),
         )
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .change_error(UserAuthError::StorageError)?;
 
     let user_ids: Vec<String> = memberships.iter().map(|m| m.user_id.clone()).collect();
 
@@ -617,7 +619,7 @@ pub async fn list_members(
             dsl::user_id.eq_any(user_ids),
         )
         .await
-        .map_err(|_| UserAuthError::StorageError)?
+        .change_error(UserAuthError::StorageError)?
     };
 
     let users_by_id: std::collections::HashMap<String, User> =
@@ -679,12 +681,12 @@ pub async fn logout(
         .ok_or(UserAuthError::StorageError)?;
 
     let claims = auth::verify_jwt(token, &global_config.user_auth.jwt_secret)
-        .map_err(|_| UserAuthError::InvalidToken)?;
+        .change_context(UserAuthError::InvalidToken)?;
 
     let app_state = get_tenant_app_state().await;
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|_| UserAuthError::StorageError)?
+        .change_error(UserAuthError::StorageError)?
         .as_secs();
     let remaining_ttl = claims.exp.saturating_sub(now) as i64;
 
@@ -719,7 +721,7 @@ pub async fn me(
         dsl::user_id.eq(claims.user_id.clone()),
     )
     .await
-    .map_err(|_| UserAuthError::StorageError)?;
+    .change_error(UserAuthError::StorageError)?;
 
     let user = users.pop().ok_or(UserAuthError::UserNotFound)?;
     let merchants = fetch_user_merchants(&app_state, &user.user_id).await?;
@@ -740,7 +742,7 @@ pub async fn me(
 async fn fetch_user_merchants(
     app_state: &crate::app::TenantAppState,
     user_id: &String,
-) -> Result<Vec<MerchantInfo>, UserAuthError> {
+) -> Result<Vec<MerchantInfo>, ContainerError<UserAuthError>> {
     #[cfg(feature = "mysql")]
     use crate::storage::schema::merchant_account::dsl as ma_dsl;
     #[cfg(feature = "postgres")]
@@ -752,7 +754,7 @@ async fn fetch_user_merchants(
         UserMerchant,
     >(&app_state.db, um_dsl::user_id.eq(user_id.clone()))
     .await
-    .map_err(|_| UserAuthError::StorageError)?;
+    .change_error(UserAuthError::StorageError)?;
 
     let mut result = Vec::new();
     for um in user_merchant_rows {
@@ -765,7 +767,7 @@ async fn fetch_user_merchants(
             ma_dsl::merchant_id.eq(Some(um.merchant_id.clone())),
         )
         .await
-        .map_err(|_| UserAuthError::StorageError)?;
+        .change_error(UserAuthError::StorageError)?;
 
         let name = accounts
             .pop()
@@ -792,14 +794,15 @@ fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, error::ContainerErr
 pub async fn verify_jwt_not_revoked(
     token: &str,
     secret: &str,
-) -> Result<auth::JwtClaims, UserAuthError> {
-    let claims = auth::verify_jwt(token, secret).map_err(|_| UserAuthError::InvalidToken)?;
+) -> Result<auth::JwtClaims, ContainerError<UserAuthError>> {
+    let claims = auth::verify_jwt(token, secret)
+        .change_context(UserAuthError::InvalidToken)?;
 
     let app_state = get_tenant_app_state().await;
     let deny_key = format!("{}{}", JWT_DENYLIST_PREFIX, claims.jti);
     if let Ok(val) = app_state.redis_conn.get_key_string(&deny_key).await {
         if !val.is_empty() {
-            return Err(UserAuthError::InvalidToken);
+            return Err(ContainerError::from(UserAuthError::InvalidToken));
         }
     }
 

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -795,8 +795,7 @@ pub async fn verify_jwt_not_revoked(
     token: &str,
     secret: &str,
 ) -> Result<auth::JwtClaims, ContainerError<UserAuthError>> {
-    let claims = auth::verify_jwt(token, secret)
-        .change_context(UserAuthError::InvalidToken)?;
+    let claims = auth::verify_jwt(token, secret).change_context(UserAuthError::InvalidToken)?;
 
     let app_state = get_tenant_app_state().await;
     let deny_key = format!("{}{}", JWT_DENYLIST_PREFIX, claims.jti);


### PR DESCRIPTION
This pull request improves error handling in the authentication and user authorization logic by introducing a structured `AuthError` enum and migrating to the `error_stack` crate for richer error reporting. The changes standardize error propagation throughout the authentication code and user-related routes, making it easier to diagnose and handle specific failure cases.

**Error handling improvements:**

* Added a new `AuthError` enum in `src/auth/mod.rs` to represent various authentication and password-related error cases. 
* Updated all authentication functions in `src/auth/mod.rs` (such as `generate_jwt`, `verify_jwt`, `hash_password`, `verify_password`, and `validate_password_strength`) to return `Result<T, Report<AuthError>>` and use `error_stack` for error context and propagation. 
* Improved password strength validation errors to include user-friendly, printable messages using `attach_printable`. 
**Route and API error propagation:**

* Refactored all user authentication route handlers in `src/routes/user_auth.rs` to use the new error types and propagate errors with context, replacing `.map_err()` with `.change_context()` or `.change_error()` as appropriate. This applies to all major user flows, including signup, login, merchant creation, member invitation, and member listing. 

These changes make error handling more robust, explicit, and maintainable throughout the authentication and user management codebase.