### PR TITLE
fix(logs): add email client logs for debugging

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub debit_routing_config: network_decider::types::DebitRoutingConfig,
     pub compression_filepath: Option<CompressionFilepath>,
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub api_key_auth_enabled: bool,
     #[serde(default)]
     pub user_auth: UserAuthConfig,
@@ -69,6 +69,10 @@ pub struct UserAuthConfig {
     /// Send verification email on signup; block login until verified
     #[serde(default)]
     pub email_verification_enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_jwt_expiry() -> u64 {

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -69,11 +69,11 @@ impl GlobalAppState {
 
         if global_config.email.is_active() {
             match tokio::time::timeout(
-                 std::time::Duration::from_secs(10),
-                 email_client.health_check(),
-             )
-             .await
-             {
+                std::time::Duration::from_secs(10),
+                email_client.health_check(),
+            )
+            .await
+            {
                 Ok(Err(e)) => {
                     tracing::warn!(
                         error = ?e,

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -68,13 +68,30 @@ impl GlobalAppState {
         )?;
 
         if global_config.email.is_active() {
-            if let Err(e) = email_client.health_check().await {
-                tracing::warn!(
-                    error = ?e,
-                    "Email backend is unreachable — \
-                     fix [email.smtp] / [email.aws_ses] in config, \
-                     or set active_email_client = \"no_email_client\" to disable."
-                );
+            match tokio::time::timeout(
+                 std::time::Duration::from_secs(10),
+                 email_client.health_check(),
+             )
+             .await
+             {
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        error = ?e,
+                        "Email backend is unreachable — \
+                        fix [email.smtp] / [email.aws_ses] in config, \
+                        or set active_email_client = \"no_email_client\" to disable."
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = ?e,
+                        "Email backend health check timed out during startup; \
+                        continuing with email degraded. Fix [email.smtp] / \
+                        [email.aws_ses] in config, or set \
+                        active_email_client = \"no_email_client\" to disable."
+                    );
+                }
+                Ok(Ok(())) => {}
             }
         }
 

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -1,5 +1,4 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 use std::{collections::HashSet, sync::Arc};
 
 use error_stack::ResultExt;
@@ -69,27 +68,13 @@ impl GlobalAppState {
         )?;
 
         if global_config.email.is_active() {
-            let health_result =
-                tokio::time::timeout(Duration::from_secs(10), email_client.health_check()).await;
-
-            match health_result {
-                Err(_) => {
-                    tracing::warn!(
-                        "Email health check timed out after 10s — \
-                         email backend may be unreachable. \
-                         Fix [email.smtp] / [email.aws_ses] in config, \
-                         or set active_email_client = \"no_email_client\" to disable."
-                    );
-                }
-                Ok(Err(e)) => {
-                    tracing::warn!(
-                        error = %e,
-                        "Email backend is unreachable — \
-                         fix [email.smtp] / [email.aws_ses] in config, \
-                         or set active_email_client = \"no_email_client\" to disable."
-                    );
-                }
-                Ok(Ok(())) => {}
+            if let Err(e) = email_client.health_check().await {
+                tracing::warn!(
+                    error = ?e,
+                    "Email backend is unreachable — \
+                     fix [email.smtp] / [email.aws_ses] in config, \
+                     or set active_email_client = \"no_email_client\" to disable."
+                );
             }
         }
 


### PR DESCRIPTION
Configuration defaults:

* Changed the default for `api_key_auth_enabled` in `GlobalConfig` to `true` by using a custom `default_true` function, making API key authentication enabled by default. 

Email backend health check:

* Simplified the email backend health check by removing the 10-second timeout; the health check now awaits the result directly and logs a warning if the check fails.
* Improved the error logging in the email health check to use the debug format for error details.
