### PR TITLE
fix(email): fix user creation after email confirmation

### DIFF
--- a/src/email/aws_ses.rs
+++ b/src/email/aws_ses.rs
@@ -59,8 +59,12 @@ impl AwsSesEmailClient {
 #[async_trait::async_trait]
 impl EmailClient for AwsSesEmailClient {
     async fn health_check(&self) -> error_stack::Result<(), EmailError> {
+        // get_account() requires ses:GetAccount which send-only roles don't have.
+        // Checking the sender identity requires only ses:GetEmailIdentity and directly
+        // validates the address that will be used for sending.
         self.client
-            .get_account()
+            .get_email_identity()
+            .email_identity(&self.sender_email)
             .send()
             .await
             .change_context(EmailError::SendFailed)?;

--- a/src/redis/commands.rs
+++ b/src/redis/commands.rs
@@ -568,6 +568,31 @@ impl RedisConnectionWrapper {
             .await
             .change_context(errors::RedisError::GetFailed)
     }
+
+    /// SET key value EX ttl NX — returns true if the key was set, false if it already existed.
+    ///
+    /// Uses Option<bool> internally because fred maps a Redis nil response (key already exists)
+    /// to Ok(None) for Option types, while bool would produce a parse error on nil.
+    pub async fn set_key_if_not_exists(
+        &self,
+        key: &str,
+        value: &str,
+        ttl: i64,
+    ) -> Result<bool, errors::RedisError> {
+        let result: Option<bool> = self
+            .conn
+            .pool
+            .set(
+                key,
+                value,
+                Some(Expiration::EX(ttl)),
+                Some(SetOptions::NX),
+                false,
+            )
+            .await
+            .change_context(errors::RedisError::SetHashFailed)?;
+        Ok(result.unwrap_or(false))
+    }
     #[cfg(not(feature = "redis_compression"))]
     pub async fn setx(
         &self,

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -168,7 +168,9 @@ pub async fn signup(
             .await
             .change_context(UserAuthError::StorageError)?;
         if !acquired {
-            return Err(error::ContainerError::from(UserAuthError::EmailAlreadyExists));
+            return Err(error::ContainerError::from(
+                UserAuthError::EmailAlreadyExists,
+            ));
         }
 
         let email_client = APP_STATE

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -86,6 +86,8 @@ pub struct CreateMerchantResponse {
 
 const EMAIL_VERIFICATION_PREFIX: &str = "email_verification:";
 const EMAIL_VERIFICATION_TTL_SECONDS: i64 = 86400; // 24 hours
+const PENDING_SIGNUP_PREFIX: &str = "pending_signup:";
+const PENDING_SIGNUP_TTL_SECONDS: i64 = 300; // 5 minutes
 
 #[axum::debug_handler]
 pub async fn signup(
@@ -151,20 +153,32 @@ pub async fn signup(
     if global_config.user_auth.email_verification_enabled {
         let token = uuid::Uuid::new_v4().to_string();
         let redis_key = format!("{}{}", EMAIL_VERIFICATION_PREFIX, token);
+        let pending_key = format!("{}{}", PENDING_SIGNUP_PREFIX, payload.email);
 
         let verification_url = format!(
             "{}/verify-email?token={}",
             global_config.email.base_url, token
         );
 
+        // Acquire a short-lived NX lock to prevent concurrent duplicate signups
+        // for the same email from each racing past the DB uniqueness check above.
+        let acquired = app_state
+            .redis_conn
+            .set_key_if_not_exists(&pending_key, "1", PENDING_SIGNUP_TTL_SECONDS)
+            .await
+            .change_context(UserAuthError::StorageError)?;
+        if !acquired {
+            return Err(error::ContainerError::from(UserAuthError::EmailAlreadyExists));
+        }
+
         let email_client = APP_STATE
             .get()
             .map(|s| s.email_client.clone())
             .ok_or(UserAuthError::StorageError)?;
 
-        // Send the email before writing anything to the DB so that a delivery
-        // failure leaves no orphaned user record (which would block re-registration).
-        email_client
+        // Send the email before any DB or Redis writes so that a delivery failure
+        // leaves no records behind and the user can retry registration immediately.
+        let send_result = email_client
             .send_email(
                 crate::email::templates::EmailVerificationTemplate {
                     user_email: payload.email.clone(),
@@ -172,8 +186,22 @@ pub async fn signup(
                 }
                 .into_message(),
             )
-            .await
-            .change_context(UserAuthError::EmailSendFailed)?;
+            .await;
+        if send_result.is_err() {
+            let _ = app_state.redis_conn.delete_key(&pending_key).await;
+        }
+        send_result.change_context(UserAuthError::EmailSendFailed)?;
+
+        // Write the verification token before creating DB records so that if a
+        // DB insert fails the token does not reference a non-existent user.
+        let token_result = app_state
+            .redis_conn
+            .set_key_with_ttl(&redis_key, &user_id, EMAIL_VERIFICATION_TTL_SECONDS)
+            .await;
+        if token_result.is_err() {
+            let _ = app_state.redis_conn.delete_key(&pending_key).await;
+        }
+        token_result.change_context(UserAuthError::StorageError)?;
 
         let new_user = NewUser {
             user_id: user_id.clone(),
@@ -192,9 +220,12 @@ pub async fn signup(
             created_at: now,
         };
 
-        crate::generics::generic_insert(&app_state.db, new_user)
-            .await
-            .change_context(UserAuthError::StorageError)?;
+        let user_insert_result = crate::generics::generic_insert(&app_state.db, new_user).await;
+        if user_insert_result.is_err() {
+            let _ = app_state.redis_conn.delete_key(&redis_key).await;
+            let _ = app_state.redis_conn.delete_key(&pending_key).await;
+        }
+        user_insert_result.change_context(UserAuthError::StorageError)?;
 
         if let Some(merchant_id) = requested_merchant_id.as_ref() {
             let new_user_merchant = NewUserMerchant {
@@ -204,16 +235,24 @@ pub async fn signup(
                 created_at: now,
             };
 
-            crate::generics::generic_insert(&app_state.db, new_user_merchant)
-                .await
-                .change_context(UserAuthError::StorageError)?;
+            let merchant_insert_result =
+                crate::generics::generic_insert(&app_state.db, new_user_merchant).await;
+            if merchant_insert_result.is_err() {
+                let conn = app_state.db.get_conn().await.ok();
+                if let Some(conn) = conn {
+                    let _ = crate::generics::generic_delete::<
+                        <User as diesel::associations::HasTable>::Table,
+                        _,
+                    >(&conn, dsl::user_id.eq(user_id.clone()))
+                    .await;
+                }
+                let _ = app_state.redis_conn.delete_key(&redis_key).await;
+                let _ = app_state.redis_conn.delete_key(&pending_key).await;
+            }
+            merchant_insert_result.change_context(UserAuthError::StorageError)?;
         }
 
-        app_state
-            .redis_conn
-            .set_key_with_ttl(&redis_key, &user_id, EMAIL_VERIFICATION_TTL_SECONDS)
-            .await
-            .change_context(UserAuthError::StorageError)?;
+        let _ = app_state.redis_conn.delete_key(&pending_key).await;
 
         return Ok(Json(SignupResponse::VerificationPending(
             SignupVerificationPendingResponse {

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -148,6 +148,81 @@ pub async fn signup(
         }
     }
 
+    if global_config.user_auth.email_verification_enabled {
+        let token = uuid::Uuid::new_v4().to_string();
+        let redis_key = format!("{}{}", EMAIL_VERIFICATION_PREFIX, token);
+
+        let verification_url = format!(
+            "{}/verify-email?token={}",
+            global_config.email.base_url, token
+        );
+
+        let email_client = APP_STATE
+            .get()
+            .map(|s| s.email_client.clone())
+            .ok_or(UserAuthError::StorageError)?;
+
+        // Send the email before writing anything to the DB so that a delivery
+        // failure leaves no orphaned user record (which would block re-registration).
+        email_client
+            .send_email(
+                crate::email::templates::EmailVerificationTemplate {
+                    user_email: payload.email.clone(),
+                    verification_url,
+                }
+                .into_message(),
+            )
+            .await
+            .change_context(UserAuthError::EmailSendFailed)?;
+
+        let new_user = NewUser {
+            user_id: user_id.clone(),
+            email: payload.email.clone(),
+            password_hash,
+            merchant_id: requested_merchant_id.clone(),
+            role: "admin".to_string(),
+            #[cfg(feature = "mysql")]
+            is_active: 1,
+            #[cfg(feature = "postgres")]
+            is_active: true,
+            #[cfg(feature = "mysql")]
+            email_verified: 0,
+            #[cfg(feature = "postgres")]
+            email_verified: false,
+            created_at: now,
+        };
+
+        crate::generics::generic_insert(&app_state.db, new_user)
+            .await
+            .change_context(UserAuthError::StorageError)?;
+
+        if let Some(merchant_id) = requested_merchant_id.as_ref() {
+            let new_user_merchant = NewUserMerchant {
+                user_id: user_id.clone(),
+                merchant_id: merchant_id.clone(),
+                role: "admin".to_string(),
+                created_at: now,
+            };
+
+            crate::generics::generic_insert(&app_state.db, new_user_merchant)
+                .await
+                .change_context(UserAuthError::StorageError)?;
+        }
+
+        app_state
+            .redis_conn
+            .set_key_with_ttl(&redis_key, &user_id, EMAIL_VERIFICATION_TTL_SECONDS)
+            .await
+            .change_context(UserAuthError::StorageError)?;
+
+        return Ok(Json(SignupResponse::VerificationPending(
+            SignupVerificationPendingResponse {
+                message: "Account created. Please check your email to verify your address before logging in.".to_string(),
+                email_verification_required: true,
+            },
+        )));
+    }
+
     let new_user = NewUser {
         user_id: user_id.clone(),
         email: payload.email.clone(),
@@ -159,13 +234,9 @@ pub async fn signup(
         #[cfg(feature = "postgres")]
         is_active: true,
         #[cfg(feature = "mysql")]
-        email_verified: if global_config.user_auth.email_verification_enabled {
-            0
-        } else {
-            1
-        },
+        email_verified: 1,
         #[cfg(feature = "postgres")]
-        email_verified: !global_config.user_auth.email_verification_enabled,
+        email_verified: true,
         created_at: now,
     };
 
@@ -184,45 +255,6 @@ pub async fn signup(
         crate::generics::generic_insert(&app_state.db, new_user_merchant)
             .await
             .change_context(UserAuthError::StorageError)?;
-    }
-
-    if global_config.user_auth.email_verification_enabled {
-        let token = uuid::Uuid::new_v4().to_string();
-        let redis_key = format!("{}{}", EMAIL_VERIFICATION_PREFIX, token);
-
-        app_state
-            .redis_conn
-            .set_key_with_ttl(&redis_key, &user_id, EMAIL_VERIFICATION_TTL_SECONDS)
-            .await
-            .change_context(UserAuthError::StorageError)?;
-
-        let verification_url = format!(
-            "{}/verify-email?token={}",
-            global_config.email.base_url, token
-        );
-
-        let email_client = APP_STATE
-            .get()
-            .map(|s| s.email_client.clone())
-            .ok_or(UserAuthError::StorageError)?;
-
-        email_client
-            .send_email(
-                crate::email::templates::EmailVerificationTemplate {
-                    user_email: payload.email.clone(),
-                    verification_url,
-                }
-                .into_message(),
-            )
-            .await
-            .change_context(UserAuthError::EmailSendFailed)?;
-
-        return Ok(Json(SignupResponse::VerificationPending(
-            SignupVerificationPendingResponse {
-                message: "Account created. Please check your email to verify your address before logging in.".to_string(),
-                email_verification_required: true,
-            },
-        )));
     }
 
     let token = auth::generate_jwt(


### PR DESCRIPTION
This pull request refactors the user signup flow to improve the reliability of email verification and corrects the logic for setting the `email_verified` flag during user creation. The main changes ensure that verification emails are sent before any user record is created, preventing orphaned accounts in case of email delivery failure, and that user records are only created as verified if email verification is not required.

**User signup and email verification flow improvements:**

* The verification email is now sent before creating any user record in the database. This prevents orphaned user records when email delivery fails, as no user is created unless the email is sent successfully.
* The logic for setting the `email_verified` field has been updated: if email verification is enabled, users are always created as unverified (`email_verified: 0` for MySQL, `false` for Postgres); if verification is not required, users are created as verified.
* The code for sending the verification email and storing the verification token in Redis has been reordered and streamlined for clarity and to match the new flow.

**AWS SES email health check improvement:**

* The SES health check now uses `get_email_identity` instead of `get_account`, requiring only the `ses:GetEmailIdentity` permission and directly validating the sender address. This makes the health check compatible with send-only SES roles.