### PR TITLE
fix(email): add HTTP proxy support for AWS SES client in private subnets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,6 +2313,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2506,24 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3438,6 +3480,8 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "aws-sdk-sesv2",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "axum",
  "axum-server",
  "axum-test",
@@ -3462,7 +3506,9 @@ dependencies = [
  "hex",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 0.14.32",
  "hyper 1.6.0",
+ "hyper-proxy",
  "jemalloc-ctl",
  "jemallocator",
  "josekit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ aws-config = { version = "1.5.5" }
 aws-sdk-kms = { version = "1.40.0", optional = true }
 aws-sdk-sesv2 = { version = "1" }
 aws-smithy-runtime = { version = "1", features = ["connector-hyper-0-14-x"] }
+aws-smithy-runtime-api = { version = "1" }
 hyper-proxy = "0.9.1"
 hyper014 = { package = "hyper", version = "0.14", features = ["client"] }
 lettre = { version = "0.11", features = ["tokio1", "tokio1-native-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ redis_compression = ["dep:zstd"]
 aws-config = { version = "1.5.5" }
 aws-sdk-kms = { version = "1.40.0", optional = true }
 aws-sdk-sesv2 = { version = "1" }
+aws-smithy-runtime = { version = "1", features = ["connector-hyper-0-14-x"] }
+hyper-proxy = "0.9.1"
+hyper014 = { package = "hyper", version = "0.14", features = ["client"] }
 lettre = { version = "0.11", features = ["tokio1", "tokio1-native-tls"] }
 base64 = "0.22.1"
 gethostname = "0.5.0"

--- a/config/development.toml
+++ b/config/development.toml
@@ -748,6 +748,7 @@ active_email_client = "no_email_client"
 region = "us-east-1"
 email_role_arn = "arn:aws:iam::123456789012:role/SES-role"
 sts_role_session_name = "ses_session"
+# proxy_url = "http://<squid-proxy-host>:<port>"   # required in private subnets without a SES VPC endpoint
 
 [email.smtp]
 host = "localhost"

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,7 +233,9 @@ pub struct AwsSesEmailConfig {
     pub email_role_arn: Option<String>,
     /// STS session name used when assuming the role
     pub sts_role_session_name: Option<String>,
-    /// HTTP/HTTPS proxy URL for SES API calls (required in private subnets without a VPC endpoint)
+    /// HTTP proxy URL for SES API calls (e.g. "http://squid-proxy:3128"). Use an `http://` scheme
+    /// even when proxying HTTPS destinations — the proxy uses CONNECT tunneling. Required in private
+    /// subnets without a SES VPC endpoint.
     pub proxy_url: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,6 +233,8 @@ pub struct AwsSesEmailConfig {
     pub email_role_arn: Option<String>,
     /// STS session name used when assuming the role
     pub sts_role_session_name: Option<String>,
+    /// HTTP/HTTPS proxy URL for SES API calls (required in private subnets without a VPC endpoint)
+    pub proxy_url: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/email/aws_ses.rs
+++ b/src/email/aws_ses.rs
@@ -20,6 +20,7 @@ impl AwsSesEmailClient {
     ) -> error_stack::Result<Self, EmailError> {
         let region = aws_sdk_sesv2::config::Region::new(config.region.clone());
 
+        // Credential resolution intentionally uses no proxy — STS is reachable via VPC endpoint.
         let aws_config = if let (Some(role_arn), Some(session_name)) =
             (&config.email_role_arn, &config.sts_role_session_name)
         {
@@ -37,30 +38,31 @@ impl AwsSesEmailClient {
                     .build()
                     .await;
 
-            let mut loader = aws_config::defaults(BehaviorVersion::latest())
+            aws_config::defaults(BehaviorVersion::latest())
                 .region(region)
-                .credentials_provider(assume_role_provider);
-
-            if let Some(proxy_url) = &config.proxy_url {
-                let http_client = build_proxied_http_client(proxy_url)
-                    .change_context(EmailError::MissingConfig)?;
-                loader = loader.http_client(http_client);
-            }
-
-            loader.load().await
+                .credentials_provider(assume_role_provider)
+                .load()
+                .await
         } else {
-            let mut loader = aws_config::defaults(BehaviorVersion::latest()).region(region);
-
-            if let Some(proxy_url) = &config.proxy_url {
-                let http_client = build_proxied_http_client(proxy_url)
-                    .change_context(EmailError::MissingConfig)?;
-                loader = loader.http_client(http_client);
-            }
-
-            loader.load().await
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(region)
+                .load()
+                .await
         };
 
-        let client = aws_sdk_sesv2::Client::new(&aws_config);
+        // Proxy is applied only at the SES service-client level so that credential
+        // resolution (STS AssumeRole, IMDS) continues to use the direct VPC path.
+        let ses_config = {
+            let mut builder = aws_sdk_sesv2::config::Builder::from(&aws_config);
+            if let Some(proxy_url) = &config.proxy_url {
+                let http_client = build_proxied_http_client(proxy_url)
+                    .change_context(EmailError::MissingConfig)?;
+                builder = builder.http_client(http_client);
+            }
+            builder.build()
+        };
+
+        let client = aws_sdk_sesv2::Client::from_conf(ses_config);
 
         Ok(Self {
             client,

--- a/src/email/aws_ses.rs
+++ b/src/email/aws_ses.rs
@@ -1,6 +1,8 @@
 use aws_config::BehaviorVersion;
 use aws_sdk_sesv2::types::{Body, Content, Destination, EmailContent, Message};
+use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
 use error_stack::ResultExt;
+use hyper_proxy::{Intercept, Proxy, ProxyConnector};
 
 use crate::config::AwsSesEmailConfig;
 
@@ -35,16 +37,27 @@ impl AwsSesEmailClient {
                     .build()
                     .await;
 
-            aws_config::defaults(BehaviorVersion::latest())
+            let mut loader = aws_config::defaults(BehaviorVersion::latest())
                 .region(region)
-                .credentials_provider(assume_role_provider)
-                .load()
-                .await
+                .credentials_provider(assume_role_provider);
+
+            if let Some(proxy_url) = &config.proxy_url {
+                let http_client = build_proxied_http_client(proxy_url)
+                    .change_context(EmailError::MissingConfig)?;
+                loader = loader.http_client(http_client);
+            }
+
+            loader.load().await
         } else {
-            aws_config::defaults(BehaviorVersion::latest())
-                .region(region)
-                .load()
-                .await
+            let mut loader = aws_config::defaults(BehaviorVersion::latest()).region(region);
+
+            if let Some(proxy_url) = &config.proxy_url {
+                let http_client = build_proxied_http_client(proxy_url)
+                    .change_context(EmailError::MissingConfig)?;
+                loader = loader.http_client(http_client);
+            }
+
+            loader.load().await
         };
 
         let client = aws_sdk_sesv2::Client::new(&aws_config);
@@ -54,6 +67,18 @@ impl AwsSesEmailClient {
             sender_email,
         })
     }
+}
+
+fn build_proxied_http_client(
+    proxy_url: &str,
+) -> Result<aws_smithy_runtime::client::http::hyper_014::HyperClient, EmailError> {
+    let proxy_uri = proxy_url
+        .parse::<hyper014::Uri>()
+        .map_err(|_| EmailError::MissingConfig)?;
+    let proxy = Proxy::new(Intercept::All, proxy_uri);
+    let connector = ProxyConnector::from_proxy(hyper014::client::HttpConnector::new(), proxy)
+        .map_err(|_| EmailError::MissingConfig)?;
+    Ok(HyperClientBuilder::new().build(connector))
 }
 
 #[async_trait::async_trait]

--- a/src/email/aws_ses.rs
+++ b/src/email/aws_ses.rs
@@ -73,7 +73,7 @@ impl AwsSesEmailClient {
 
 fn build_proxied_http_client(
     proxy_url: &str,
-) -> Result<aws_smithy_runtime::client::http::hyper_014::HyperClient, EmailError> {
+) -> Result<aws_smithy_runtime_api::client::http::SharedHttpClient, EmailError> {
     let proxy_uri = proxy_url
         .parse::<hyper014::Uri>()
         .map_err(|_| EmailError::MissingConfig)?;


### PR DESCRIPTION
  **Problem**

  Email verification (signup / invite) was broken in the sandbox environment. On startup, the SES health check
  timed out every time:

  Email backend health check timed out during startup; continuing with email degraded.
  error: Elapsed(())

  Root cause: The decision engine pods run in a private subnet with no direct internet egress and no VPC endpoint
   for SES. The AWS SDK for Rust builds its own hyper HTTP client and — unlike curl — does not honour the
  HTTPS_PROXY environment variable, so all SES API calls were hitting email.ap-south-1.amazonaws.com:443 directly
   and timing out.

  Hyperswitch (running in the same node group) works because it explicitly threads a Squid proxy URL through its
  SES client via hyper_proxy::ProxyConnector. The decision engine had no such support.

  **Solution**

  Added an optional proxy_url field to [email.aws_ses] config. When set, the SES SDK client is built with a
  hyper_proxy::ProxyConnector injected via aws-smithy-runtime's HyperClientBuilder, routing all SES API calls
  through the proxy — matching the approach used by Hyperswitch.

  STS (used for AssumeRole) is intentionally left on the default direct path since it is already reachable via a
  VPC endpoint in the cluster.