### PR TITLE
fix(routing): MAB explore-exploit bug and add caching, UI improvements

### DIFF
--- a/cypress/e2e/api/merchant-crud.cy.js
+++ b/cypress/e2e/api/merchant-crud.cy.js
@@ -32,6 +32,24 @@ describe('Merchant CRUD API', () => {
       expect(response.merchant_id).to.eq(testMerchantId)
     })
 
+    // Must return non-200 immediately after deletion — validates cache eviction
+    // on delete so a cached entry doesn't ghost the deleted merchant.
+    cy.getMerchantAccount(testMerchantId, { failOnStatusCode: false }).then(({ status }) => {
+      expect(status).to.not.eq(200)
+    })
+  })
+
+  it('deleted merchant is not served from cache on immediate re-fetch', () => {
+    cy.createMerchantAccount(testMerchantId)
+
+    // Warm the cache with a successful GET
+    cy.getMerchantAccount(testMerchantId).then(({ response }) => {
+      expect(response).to.haveValidMerchantGetResponse()
+    })
+
+    cy.deleteMerchantAccount(testMerchantId)
+
+    // The cache must be evicted — stale hit would return 200 here
     cy.getMerchantAccount(testMerchantId, { failOnStatusCode: false }).then(({ status }) => {
       expect(status).to.not.eq(200)
     })

--- a/cypress/e2e/api/sr-routing.cy.js
+++ b/cypress/e2e/api/sr-routing.cy.js
@@ -1,0 +1,150 @@
+const factory = require('../../support/test-data-factory')
+
+describe('SR Routing', () => {
+  let merchantId
+
+  beforeEach(() => {
+    cy.waitForService()
+    merchantId = factory.merchantId('sr_routing')
+    cy.ensureMerchantAccount(merchantId)
+  })
+
+  afterEach(() => {
+    cy.cleanupTestData(merchantId)
+  })
+
+  // Validates write-through cache: an update to SR config must be immediately
+  // reflected by /rule/get without waiting for TTL expiry.
+  it('SR config update is immediately visible after write (cache consistency)', () => {
+    cy.createSuccessRateConfig(merchantId, {
+      defaultBucketSize: 150,
+      defaultHedgingPercent: 3,
+    }).then(({ response }) => {
+      expect(response).to.haveValidRuleConfigResponse('successRate')
+    })
+
+    cy.getSuccessRateConfig(merchantId).then(({ response }) => {
+      expect(response.config.data.defaultBucketSize).to.eq(150)
+      expect(response.config.data.defaultHedgingPercent).to.eq(3)
+    })
+
+    cy.updateSuccessRateConfig(merchantId, {
+      defaultBucketSize: 300,
+      defaultHedgingPercent: 10,
+    }).then(({ response }) => {
+      expect(response).to.haveValidRuleConfigResponse('successRate')
+    })
+
+    // Immediately after update — must reflect new values, not a stale cache hit
+    cy.getSuccessRateConfig(merchantId).then(({ response }) => {
+      expect(response.config.data.defaultBucketSize).to.eq(300)
+      expect(response.config.data.defaultHedgingPercent).to.eq(10)
+    })
+  })
+
+  // Validates write-through cache eviction on delete: /rule/get must return
+  // non-200 immediately after deletion, not serve the previously cached entry.
+  it('SR config is not found immediately after deletion (cache eviction)', () => {
+    cy.createSuccessRateConfig(merchantId).then(({ response }) => {
+      expect(response).to.haveValidRuleConfigResponse('successRate')
+    })
+
+    cy.getSuccessRateConfig(merchantId).then(({ response }) => {
+      expect(response).to.haveValidRuleConfigResponse('successRate')
+    })
+
+    cy.deleteSuccessRateConfig(merchantId).then(({ status }) => {
+      expect(status).to.eq(200)
+    })
+
+    // Must not serve deleted config from cache
+    cy.getSuccessRateConfig(merchantId, { failOnStatusCode: false }).then(({ status }) => {
+      expect(status).to.not.eq(200)
+    })
+  })
+
+  // Validates elimination config write-through cache in the same way.
+  it('elimination config update is immediately visible after write (cache consistency)', () => {
+    cy.createEliminationConfig(merchantId, { threshold: 0.3 }).then(({ response }) => {
+      expect(response).to.haveValidRuleConfigResponse('elimination')
+    })
+
+    cy.getEliminationConfig(merchantId).then(({ response }) => {
+      expect(response.config.data.threshold).to.eq(0.3)
+    })
+
+    cy.updateEliminationConfig(merchantId, { threshold: 0.6 }).then(({ response }) => {
+      expect(response).to.haveValidRuleConfigResponse('elimination')
+    })
+
+    // Immediately after update — must not return stale 0.3
+    cy.getEliminationConfig(merchantId).then(({ response }) => {
+      expect(response.config.data.threshold).to.eq(0.6)
+    })
+  })
+
+  // Validates that the explore-exploit fix is working: gateway scores must
+  // decrease after repeated failure feedback, meaning scores are being updated
+  // (not frozen at 1.0 due to the top-gateway exclusion bug).
+  //
+  // Each failure requires a prior /decide-gateway call with the same paymentId
+  // because the backend stores GatewayScoringData in Redis keyed by paymentId
+  // during decide, and /update-gateway-score looks it up by that key.
+  it('gateway score decreases after repeated failure feedback (explore-exploit fix)', () => {
+    cy.createSuccessRateConfig(merchantId, {
+      defaultBucketSize: 10,
+      defaultHedgingPercent: 50,
+    })
+
+    const gateways = ['stripe', 'adyen']
+    let targetGateway
+
+    // Run 5 decide → failure-feedback cycles in sequence.
+    // Cypress chains are lazy so we build the chain with reduce.
+    const FAILURES = 5
+    let chain = cy.wrap(null)
+
+    for (let i = 0; i < FAILURES; i++) {
+      const pid = factory.paymentId(`fail_${i}`)
+      chain = chain.then(() =>
+        cy.decideGateway(
+          factory.srDecideGatewayRequest({
+            merchantId,
+            eligibleGatewayList: gateways,
+            paymentInfo: { paymentMethodType: 'CARD', paymentMethod: 'VISA', paymentId: pid },
+          }),
+        ).then(({ response }) => {
+          expect(response).to.haveValidGatewayResponse()
+          // Track whichever gateway the algorithm chose on the first iteration
+          if (i === 0) targetGateway = response.decided_gateway
+          return cy.updateGatewayScore(
+            factory.updateGatewayScoreRequest({
+              merchantId,
+              gateway: response.decided_gateway,
+              paymentId: pid,
+              status: 'FAILURE',
+            }),
+          )
+        }).then(({ response: sr }) => {
+          expect(sr).to.haveValidScoreUpdate()
+        }),
+      )
+    }
+
+    // After all failures, decide once more and assert the first gateway's score dropped
+    chain.then(() =>
+      cy.decideGateway(
+        factory.srDecideGatewayRequest({
+          merchantId,
+          eligibleGatewayList: gateways,
+          paymentInfo: { paymentMethodType: 'CARD', paymentMethod: 'VISA' },
+        }),
+      ),
+    ).then(({ response }) => {
+      expect(response).to.haveValidGatewayResponse()
+      const scoreAfterFailures = response.gateway_priority_map[targetGateway]
+      // Score must be below 1.0 — proves scores are updating, not frozen by the bug
+      expect(scoreAfterFailures).to.be.lt(1.0)
+    })
+  })
+})

--- a/src/decider/gatewaydecider/gw_scoring.rs
+++ b/src/decider/gatewaydecider/gw_scoring.rs
@@ -321,17 +321,7 @@ pub async fn scoring_flow(
                 .await;
 
                 let initial_sr_gw_scores = if should_explore {
-                    let top_gateway = Utils::get_max_score_gateway(&sr_scores).map(|(gw, _)| gw);
-                    functional_gateways
-                        .iter()
-                        .map(|gw| {
-                            let score = match &top_gateway {
-                                Some(top) if top == gw => 0.5,
-                                _ => 1.0,
-                            };
-                            (gw.clone(), score)
-                        })
-                        .collect()
+                    create_score_map(functional_gateways.clone())
                 } else {
                     sr_scores
                 };

--- a/src/decider/gatewaydecider/utils.rs
+++ b/src/decider/gatewaydecider/utils.rs
@@ -1,10 +1,10 @@
 use crate::app::get_tenant_app_state;
 use crate::decider::gatewaydecider::types::{self, DeciderFlow};
-use crate::euclid::errors::EuclidErrors;
 use crate::euclid::types::SrDimensionConfig;
 use crate::feedback::gateway_elimination_scoring::flow::{
     eliminationV2RewardFactor, getPenaltyFactor,
 };
+use crate::redis::cache::findByNameFromRedis;
 use crate::redis::feature::{is_feature_enabled, RedisCompressionConfigCombined, RedisDataStruct};
 use crate::redis::types::ServiceConfigKey;
 use crate::types::card::card_type::card_type_to_text;
@@ -15,13 +15,11 @@ use crate::types::merchant::merchant_gateway_account::MerchantGatewayAccount;
 use crate::types::money::internal::Money;
 use crate::types::payment::payment_method_type_const::*;
 use crate::types::payment_flow::{payment_flows_to_text, PaymentFlow};
-use crate::types::service_configuration::find_config_by_name;
 use crate::types::user_eligibility_info::{
     get_eligibility_info, identifier_name_to_text, IdentifierName,
 };
 use crate::utils::generate_random_number;
 use crate::{feedback, logger};
-use error_stack::ResultExt;
 use fred::prelude::{KeysInterface, ListInterface};
 use masking::PeekInterface;
 use masking::Secret;
@@ -2479,23 +2477,7 @@ pub async fn get_unified_sr_key(
 
     let name = format!("SR_DIMENSION_CONFIG_{}", merchant_id);
 
-    let service_config = find_config_by_name(name.clone())
-        .await
-        .change_context(EuclidErrors::StorageError)
-        .and_then(|opt_config| {
-            opt_config.and_then(|config| config.value).ok_or_else(|| {
-                error_stack::report!(EuclidErrors::InvalidSrDimensionConfig(
-                    "SR dimension config not found".to_string()
-                ))
-            })
-        })
-        .and_then(|config| {
-            serde_json::from_str::<SrDimensionConfig>(&config).change_context(
-                EuclidErrors::InvalidSrDimensionConfig(
-                    "Failed to parse SR dimension config".to_string(),
-                ),
-            )
-        });
+    let service_config: Option<SrDimensionConfig> = findByNameFromRedis(name.clone()).await;
 
     let udfs = service_config
         .as_ref()

--- a/src/merchant_config_util.rs
+++ b/src/merchant_config_util.rs
@@ -25,12 +25,13 @@
 use josekit::Value;
 
 use crate::{
+    app::get_tenant_app_state,
     decider::{
         configs::env_vars::enable_merchant_config_entity_lookup,
         gatewaydecider::constants::MerchantConfigEntityLevelLookupCutover,
     },
     logger,
-    redis::{cache::findByNameFromRedis, types::ServiceConfigKey},
+    redis::{cache::findByNameFromRedis, mem_cache::GLOBAL_CACHE, types::ServiceConfigKey},
     types::{
         country::country_iso::CountryISO,
         merchant::id::MerchantPId,
@@ -146,25 +147,33 @@ pub async fn isMerchantEnabledForPaymentFlows(
     merchant_id: MerchantPId,
     payment_flows: Vec<PaymentFlow>,
 ) -> bool {
+    let flow_texts: Vec<String> = payment_flows.iter().map(payment_flows_to_text).collect();
+    let cache_key = format!("mc_pf_arr_{}_{}", merchant_id.0, flow_texts.join("_"));
+
+    if let Ok(cached) = GLOBAL_CACHE.get::<bool>(&cache_key) {
+        return cached;
+    }
+
     let mc_arr = load_merchant_config_by_mpid_category_and_name(
         merchant_id,
         config_category_to_text(ConfigCategory::PaymentFlow),
-        payment_flows
-            .iter()
-            .map(|pf: &PaymentFlow| payment_flows_to_text(pf))
-            .collect::<Vec<_>>()
-            .join(","),
+        flow_texts.join(","),
     )
     .await;
     let is_valid_length = mc_arr.iter().count() == payment_flows.len();
     let are_all_pfs_enabled = mc_arr.iter().all(|mc| mc.status == ConfigStatus::ENABLED);
     if !is_valid_length {
         logMerConfigLengthMisMatchError(
-            payment_flows.iter().map(payment_flows_to_text).collect(),
+            flow_texts,
             mc_arr.into_iter().collect(),
         );
     }
-    is_valid_length && are_all_pfs_enabled
+    let result = is_valid_length && are_all_pfs_enabled;
+
+    let ttl = get_tenant_app_state().await.config.cache_config.service_config_ttl as u64;
+    let _ = GLOBAL_CACHE.store(cache_key, result, Some(ttl));
+
+    result
 }
 
 // // Original Haskell function: isMerchantEnabledForPaymentFlow
@@ -280,17 +289,32 @@ pub async fn isPaymentFlowEnabledForMerchant(
     payment_flow: PaymentFlow,
 ) -> bool {
     let config_name = payment_flows_to_text(&payment_flow);
+    let cache_key = format!("mc_pf_{}_{}", merchant_p_id.0, config_name);
+
+    if let Ok(cached) = GLOBAL_CACHE.get::<bool>(&cache_key) {
+        return cached;
+    }
+
     let config_category = config_category_to_text(ConfigCategory::PaymentFlow);
     let config_status = config_status_to_text(ConfigStatus::ENABLED);
 
-    load_merchant_config_by_mpid_category_name_and_status(
+    let result = load_merchant_config_by_mpid_category_name_and_status(
         merchant_p_id,
         config_category,
         config_name,
         config_status,
     )
     .await
-    .is_some()
+    .is_some();
+
+    let ttl = get_tenant_app_state()
+        .await
+        .config
+        .cache_config
+        .service_config_ttl as u64;
+    let _ = GLOBAL_CACHE.store(cache_key, result, Some(ttl));
+
+    result
 }
 
 // // Original Haskell function: isMerchantEnabledForFeature

--- a/src/merchant_config_util.rs
+++ b/src/merchant_config_util.rs
@@ -163,14 +163,15 @@ pub async fn isMerchantEnabledForPaymentFlows(
     let is_valid_length = mc_arr.iter().count() == payment_flows.len();
     let are_all_pfs_enabled = mc_arr.iter().all(|mc| mc.status == ConfigStatus::ENABLED);
     if !is_valid_length {
-        logMerConfigLengthMisMatchError(
-            flow_texts,
-            mc_arr.into_iter().collect(),
-        );
+        logMerConfigLengthMisMatchError(flow_texts, mc_arr.into_iter().collect());
     }
     let result = is_valid_length && are_all_pfs_enabled;
 
-    let ttl = get_tenant_app_state().await.config.cache_config.service_config_ttl as u64;
+    let ttl = get_tenant_app_state()
+        .await
+        .config
+        .cache_config
+        .service_config_ttl as u64;
     let _ = GLOBAL_CACHE.store(cache_key, result, Some(ttl));
 
     result

--- a/src/redis/cache.rs
+++ b/src/redis/cache.rs
@@ -173,7 +173,8 @@ where
             logger::debug!(
                 tag = "redis_cache",
                 action = "negative_hit",
-                "Redis negative cache hit for key: {}", key
+                "Redis negative cache hit for key: {}",
+                key
             );
             set_to_memory_cache(&prefixed_key, "", ttl_seconds_u64).await;
             return None;

--- a/src/redis/cache.rs
+++ b/src/redis/cache.rs
@@ -166,6 +166,18 @@ where
                 None => extractValue(redis_value),
             };
         }
+        Ok(_) => {
+            // Empty string is a negative-cache sentinel written by evict_service_config.
+            // Propagate it to the memory cache so subsequent lookups in this process
+            // short-circuit here instead of falling through to the DB again.
+            logger::debug!(
+                tag = "redis_cache",
+                action = "negative_hit",
+                "Redis negative cache hit for key: {}", key
+            );
+            set_to_memory_cache(&prefixed_key, "", ttl_seconds_u64).await;
+            return None;
+        }
         _ => {
             logger::debug!(
                 tag = "redis_cache",

--- a/src/redis/cache.rs
+++ b/src/redis/cache.rs
@@ -250,6 +250,26 @@ where
     }
 }
 
+/// Write-through: update both Redis and memory cache after a successful DB write.
+/// Call this after `update_config` or `insert_config` succeeds.
+pub async fn write_through_service_config(key: String, value: &str) {
+    let app_state = get_tenant_app_state().await;
+    let prefixed_key = app_state.config.cache_config.add_prefix(&key);
+    let ttl = app_state.config.cache_config.service_config_ttl;
+    set_to_redis_cache(&prefixed_key, value, ttl).await;
+    set_to_memory_cache(&prefixed_key, value, Some(ttl as u64)).await;
+}
+
+/// Evict a service_config key from both Redis and memory cache after a DB delete.
+/// Caches an empty string (consistent with how `findByNameFromRedisHelper` signals "not found").
+pub async fn evict_service_config(key: String) {
+    let app_state = get_tenant_app_state().await;
+    let prefixed_key = app_state.config.cache_config.add_prefix(&key);
+    let ttl = app_state.config.cache_config.service_config_ttl;
+    set_to_redis_cache(&prefixed_key, "", ttl).await;
+    set_to_memory_cache(&prefixed_key, "", Some(ttl as u64)).await;
+}
+
 pub fn extractValue<A>(value: String) -> Option<A>
 where
     A: for<'de> Deserialize<'de>,

--- a/src/types/merchant/merchant_account.rs
+++ b/src/types/merchant/merchant_account.rs
@@ -9,6 +9,7 @@ use crate::storage::types::{
 // use types::utils::dbconfig::get_euler_db_conf;
 // use types::locker::id::{LockerId, to_locker_id};
 use crate::app::get_tenant_app_state;
+use crate::redis::mem_cache::GLOBAL_CACHE;
 use crate::types::merchant::id::{to_merchant_id, to_merchant_pid, MerchantId, MerchantPId};
 // use juspay::extra::parsing::{Parsed, Step, around, defaulting, lift_pure, mandated, non_negative, parse_field, project};
 // use juspay::extra::secret::SecretContext;
@@ -223,9 +224,14 @@ impl TryFrom<DBMerchantAccount> for MerchantAccount {
 // }
 
 pub async fn load_merchant_by_merchant_id(merchant_id: String) -> Option<MerchantAccount> {
-    // Perform the query using Diesel's generic_find_all
+    let cache_key = format!("merchant_acct_{}", merchant_id);
+
+    if let Ok(cached) = GLOBAL_CACHE.get::<MerchantAccount>(&cache_key) {
+        return Some(cached);
+    }
+
     let app_state = get_tenant_app_state().await;
-    match crate::generics::generic_find_all::<
+    let result = match crate::generics::generic_find_all::<
         <DBMerchantAccount as HasTable>::Table,
         _,
         DBMerchantAccount,
@@ -235,8 +241,15 @@ pub async fn load_merchant_by_merchant_id(merchant_id: String) -> Option<Merchan
         Ok(mut db_results) => db_results
             .pop()
             .and_then(|db_merchant| MerchantAccount::try_from(db_merchant).ok()),
-        Err(_) => None, // Silently handle errors and return None
+        Err(_) => None,
+    };
+
+    if let Some(ref merchant) = result {
+        let ttl = app_state.config.cache_config.service_config_ttl as u64;
+        let _ = GLOBAL_CACHE.store(cache_key, merchant.clone(), Some(ttl));
     }
+
+    result
 }
 
 pub async fn insert_merchant_account<T>(
@@ -281,12 +294,12 @@ pub async fn update_merchant_account(
         gateway_success_rate_based_decider_input: value,
     };
     let conn = &app_state.db.get_conn().await?;
-    // Use Diesel's query builder with multiple conditions
     crate::generics::generic_update::<
         <DBMerchantAccount as HasTable>::Table,
         MerchantAccountUpdate,
         _,
-    >(conn, dsl::merchant_id.eq(merchant_id), values)
+    >(conn, dsl::merchant_id.eq(merchant_id.clone()), values)
     .await?;
+    let _ = GLOBAL_CACHE.remove(&format!("merchant_acct_{}", merchant_id));
     Ok(())
 }

--- a/src/types/merchant/merchant_account.rs
+++ b/src/types/merchant/merchant_account.rs
@@ -278,10 +278,11 @@ pub async fn delete_merchant_account(
     // Use Diesel's query builder with multiple conditions
     crate::generics::generic_delete::<<DBMerchantAccount as HasTable>::Table, _>(
         conn,
-        dsl::merchant_id.eq(merchant_id),
+        dsl::merchant_id.eq(merchant_id.clone()),
     )
     .await?;
 
+    let _ = GLOBAL_CACHE.remove(&format!("merchant_acct_{}", merchant_id));
     Ok(())
 }
 

--- a/src/types/service_configuration.rs
+++ b/src/types/service_configuration.rs
@@ -32,11 +32,10 @@ pub async fn insert_config(
     value: Option<String>,
 ) -> error_stack::Result<(), crate::generics::MeshError> {
     let app_state = get_tenant_app_state().await;
-    let cached_value = value.clone().unwrap_or_default();
 
     let config = ServiceConfigurationNew {
         name: name.clone(),
-        value,
+        value: value.clone(),
         new_value: None,
         previous_value: None,
         new_value_status: None,
@@ -44,7 +43,10 @@ pub async fn insert_config(
 
     crate::generics::generic_insert(&app_state.db, config).await?;
 
-    write_through_service_config(name, &cached_value).await;
+    match value {
+        Some(v) => write_through_service_config(name, &v).await,
+        None => evict_service_config(name).await,
+    }
     Ok(())
 }
 
@@ -53,8 +55,7 @@ pub async fn update_config(
     value: Option<String>,
 ) -> error_stack::Result<(), crate::generics::MeshError> {
     let app_state = get_tenant_app_state().await;
-    let cached_value = value.clone().unwrap_or_default();
-    let values = ServiceConfigurationUpdate { value };
+    let values = ServiceConfigurationUpdate { value: value.clone() };
     let conn = &app_state
         .db
         .get_conn()
@@ -67,7 +68,10 @@ pub async fn update_config(
     >(conn, dsl::name.eq(name.clone()), values)
     .await?;
 
-    write_through_service_config(name, &cached_value).await;
+    match value {
+        Some(v) => write_through_service_config(name, &v).await,
+        None => evict_service_config(name).await,
+    }
     Ok(())
 }
 

--- a/src/types/service_configuration.rs
+++ b/src/types/service_configuration.rs
@@ -55,7 +55,9 @@ pub async fn update_config(
     value: Option<String>,
 ) -> error_stack::Result<(), crate::generics::MeshError> {
     let app_state = get_tenant_app_state().await;
-    let values = ServiceConfigurationUpdate { value: value.clone() };
+    let values = ServiceConfigurationUpdate {
+        value: value.clone(),
+    };
     let conn = &app_state
         .db
         .get_conn()

--- a/src/types/service_configuration.rs
+++ b/src/types/service_configuration.rs
@@ -1,4 +1,5 @@
 use crate::app::get_tenant_app_state;
+use crate::redis::cache::{evict_service_config, write_through_service_config};
 #[cfg(feature = "mysql")]
 use crate::storage::schema::service_configuration::dsl;
 #[cfg(feature = "postgres")]
@@ -31,9 +32,10 @@ pub async fn insert_config(
     value: Option<String>,
 ) -> error_stack::Result<(), crate::generics::MeshError> {
     let app_state = get_tenant_app_state().await;
+    let cached_value = value.clone().unwrap_or_default();
 
     let config = ServiceConfigurationNew {
-        name,
+        name: name.clone(),
         value,
         new_value: None,
         previous_value: None,
@@ -42,6 +44,7 @@ pub async fn insert_config(
 
     crate::generics::generic_insert(&app_state.db, config).await?;
 
+    write_through_service_config(name, &cached_value).await;
     Ok(())
 }
 
@@ -50,20 +53,21 @@ pub async fn update_config(
     value: Option<String>,
 ) -> error_stack::Result<(), crate::generics::MeshError> {
     let app_state = get_tenant_app_state().await;
+    let cached_value = value.clone().unwrap_or_default();
     let values = ServiceConfigurationUpdate { value };
     let conn = &app_state
         .db
         .get_conn()
         .await
         .map_err(|_| crate::generics::MeshError::DatabaseConnectionError)?;
-    // Use Diesel's query builder with multiple conditions
     crate::generics::generic_update::<
         <ServiceConfiguration as HasTable>::Table,
         ServiceConfigurationUpdate,
         _,
-    >(conn, dsl::name.eq(name), values)
+    >(conn, dsl::name.eq(name.clone()), values)
     .await?;
 
+    write_through_service_config(name, &cached_value).await;
     Ok(())
 }
 
@@ -75,12 +79,12 @@ pub async fn delete_config(name: String) -> Result<(), crate::generics::MeshErro
         .get_conn()
         .await
         .map_err(|_| crate::generics::MeshError::DatabaseConnectionError)?;
-    // Use Diesel's query builder with multiple conditions
     crate::generics::generic_delete::<<ServiceConfiguration as HasTable>::Table, _>(
         conn,
-        dsl::name.eq(name),
+        dsl::name.eq(name.clone()),
     )
     .await?;
 
+    evict_service_config(name).await;
     Ok(())
 }

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -18,7 +18,7 @@ import { DecideGatewayResponse, GatewayConnector, PaymentAuditEvent, PaymentAudi
 import { ROUTING_APPROACH_COLORS } from '../../lib/constants'
 import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
-import { Play, RefreshCw, ChevronDown, ChevronUp, ChevronLeft, ChevronRight, Activity, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings } from 'lucide-react'
+import { Play, RefreshCw, ChevronDown, ChevronUp, Activity, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings } from 'lucide-react'
 
 const ALGORITHMS: RoutingAlgorithmName[] = [
   'SR_BASED_ROUTING',
@@ -77,6 +77,7 @@ interface SimulationResult {
   status: 'CHARGED' | 'FAILURE' | 'PENDING_VBV'
   timestamp: string
   routingApproach: string | null
+  gatewayPriorityMap: Record<string, number> | null
 }
 
 type TransactionOutcome = 'CHARGED' | 'FAILURE' | 'PENDING_VBV'
@@ -758,7 +759,7 @@ export function DecisionExplorerPage() {
 
   const [simulationConfig, setSimulationConfig] = useState<SimulationConfig>(initialState.simulationConfig)
   const [errorInfo, setErrorInfo] = useState<ErrorInfoState>(initialState.errorInfo)
-  const [gatewaySimConfigs, setGatewaySimConfigs] = useState<Record<string, GatewaySimConfig>>({})
+  const [gatewaySimConfigs, setGatewaySimConfigs] = useState<Record<string, GatewaySimConfig>>(initialState.gatewaySimConfigs)
   const gatewaySimConfigsRef = useRef(gatewaySimConfigs)
   useEffect(() => { gatewaySimConfigsRef.current = gatewaySimConfigs }, [gatewaySimConfigs])
   const eliminationEnabled = Object.values(gatewaySimConfigs).some(c => c.failureMode === 'timeout')
@@ -785,6 +786,10 @@ export function DecisionExplorerPage() {
   const [simulationResults, setSimulationResults] = useState<SimulationResult[]>(initialState.simulationResults)
   const [isSimulating, setIsSimulating] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [addGwDraft, setAddGwDraft] = useState('')
+  const [addGwOpen, setAddGwOpen] = useState(false)
+  const addGwInputRef = useRef<HTMLInputElement>(null)
+  const txLogRef = useRef<HTMLDivElement>(null)
 
   const [setupPrompt, setSetupPrompt] = useState<SetupPromptState | null>(null)
   const [loading, setLoading] = useState(false)
@@ -800,8 +805,6 @@ export function DecisionExplorerPage() {
   const [previewInspectorTab, setPreviewInspectorTab] = useState<AuditInspectorTab>('summary')
   const [previewTraceLabel, setPreviewTraceLabel] = useState('Rule Evaluation Decision')
   const deferredSimulationResults = useDeferredValue(simulationResults)
-  const [txLogPage, setTxLogPage] = useState(1)
-  const TX_LOG_PAGE_SIZE = 10
   const [showPenaltyGuide, setShowPenaltyGuide] = useState(false)
 
   const routingKeyNames = useMemo(
@@ -1397,64 +1400,78 @@ export function DecisionExplorerPage() {
     setError(null)
     setSetupPrompt(null)
     setSimulationResults([])
-    setTxLogPage(1)
     simulationAbortRef.current = false
 
     const gateways = form.eligible_gateways.split(',').map(s => s.trim()).filter(Boolean)
     const results: SimulationResult[] = []
+    const MAX_CONSECUTIVE_ERRORS = 3
+    let consecutiveErrors = 0
 
     try {
       for (let i = 0; i < total; i++) {
         if (simulationAbortRef.current) break
         const paymentId = `sim_${Date.now()}_${i}`
 
-        const decideRes = await apiPost<DecideGatewayResponse>('/decide-gateway', {
-          merchantId: effectiveMerchantId,
-          paymentInfo: {
+        try {
+          const decideRes = await apiPost<DecideGatewayResponse>('/decide-gateway', {
+            merchantId: effectiveMerchantId,
+            paymentInfo: {
+              paymentId: paymentId,
+              amount: parseFloat(form.amount) || 1000,
+              currency: form.currency,
+              paymentType: 'ORDER_PAYMENT',
+              paymentMethodType: form.payment_method_type,
+              paymentMethod: form.payment_method,
+              authType: form.auth_type,
+              cardBrand: form.card_brand,
+            },
+            eligibleGatewayList: gateways,
+            rankingAlgorithm: form.ranking_algorithm,
+            eliminationEnabled: eliminationEnabled,
+          })
+
+          const decidedGateway = decideRes.decided_gateway
+          const gwRate = getGwSuccessRate(decidedGateway)
+          const isSuccess = Math.random() * 100 < gwRate
+          const failureMode = getGwFailureMode(decidedGateway)
+          const outcome: TransactionOutcome = isSuccess ? 'CHARGED' : (failureMode === 'timeout' ? 'PENDING_VBV' : 'FAILURE')
+          const gwErrorInfo = getGwErrorInfo(decidedGateway)
+
+          await apiPost<UpdateScoreResponse>('/update-gateway-score', {
+            merchantId: effectiveMerchantId,
+            gateway: decidedGateway,
+            gatewayReferenceId: null,
+            status: outcome,
             paymentId: paymentId,
-            amount: parseFloat(form.amount) || 1000,
-            currency: form.currency,
-            paymentType: 'ORDER_PAYMENT',
-            paymentMethodType: form.payment_method_type,
-            paymentMethod: form.payment_method,
-            authType: form.auth_type,
-            cardBrand: form.card_brand,
-          },
-          eligibleGatewayList: gateways,
-          rankingAlgorithm: form.ranking_algorithm,
-          eliminationEnabled: eliminationEnabled,
-        })
+            enforceDynamicRoutingFailure: null,
+            ...(outcome === 'FAILURE' && { errorInfo: buildErrorInfo(decidedGateway, gwErrorInfo) }),
+          })
 
-        const decidedGateway = decideRes.decided_gateway
-        const gwRate = getGwSuccessRate(decidedGateway)
-        const isSuccess = Math.random() * 100 < gwRate
-        const failureMode = getGwFailureMode(decidedGateway)
-        const outcome: TransactionOutcome = isSuccess ? 'CHARGED' : (failureMode === 'timeout' ? 'PENDING_VBV' : 'FAILURE')
-        const gwErrorInfo = getGwErrorInfo(decidedGateway)
+          results.push({
+            paymentId,
+            decidedGateway,
+            status: outcome,
+            timestamp: new Date().toISOString(),
+            routingApproach: decideRes.routing_approach ?? null,
+            gatewayPriorityMap: decideRes.gateway_priority_map ?? null,
+          })
 
-        await apiPost<UpdateScoreResponse>('/update-gateway-score', {
-          merchantId: effectiveMerchantId,
-          gateway: decidedGateway,
-          gatewayReferenceId: null,
-          status: outcome,
-          paymentId: paymentId,
-          enforceDynamicRoutingFailure: null,
-          ...(outcome === 'FAILURE' && { errorInfo: buildErrorInfo(decidedGateway, gwErrorInfo) }),
-        })
+          setSimulationResults([...results])
+          markExplorerRunDataUpdated()
+          consecutiveErrors = 0
+        } catch (e: unknown) {
+          consecutiveErrors++
+          if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+            handleRunError(e, 'batch', `Simulation stopped after ${MAX_CONSECUTIVE_ERRORS} consecutive backend errors. Check that the server is running.`)
+            return
+          }
+          // transient error — wait and skip this iteration
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          continue
+        }
 
-        results.push({
-          paymentId,
-          decidedGateway,
-          status: outcome,
-          timestamp: new Date().toISOString(),
-          routingApproach: decideRes.routing_approach ?? null,
-        })
-
-        setSimulationResults([...results])
-        markExplorerRunDataUpdated()
+        await new Promise(resolve => setTimeout(resolve, 50))
       }
-    } catch (e: unknown) {
-      handleRunError(e, 'batch', 'Simulation failed')
     } finally {
       setIsSimulating(false)
     }
@@ -1625,8 +1642,43 @@ export function DecisionExplorerPage() {
     return acc
   }, {} as Record<string, { total: number; success: number; failure: number }>)
 
+  // Plot the gatewayPriorityMap score (algorithm's internal SR score) for each
+  // gateway over time. For each sample point we search backwards to find the
+  // most recent result that contained a score for that gateway, avoiding spikes
+  // from results where the map was null or the gateway was absent.
+  const gatewaySparklines = useMemo(() => {
+    const results = deferredSimulationResults
+    if (results.length < 2) return { series: {} as Record<string, number[]>, paymentNums: [] as number[] }
+
+    const MAX_PTS = 200
+    const step = Math.max(1, Math.floor(results.length / MAX_PTS))
+    const sampled = results.filter((_, i) => i % step === 0 || i === results.length - 1)
+    const paymentNums = sampled.map((_, i) => {
+      const originalIdx = Math.min(i * step, results.length - 1)
+      return originalIdx + 1
+    })
+
+    const series: Record<string, number[]> = {}
+    Object.keys(gatewayStats).forEach(gw => {
+      series[gw] = sampled.map((_, sampleIdx) => {
+        const upToOriginalIdx = Math.min(sampleIdx * step, results.length - 1)
+        // Search backwards for the most recent non-hedging result with a score for this gateway.
+        // Hedging results use exploration scores (1.0 for all gateways) which don't reflect real SR.
+        for (let i = upToOriginalIdx; i >= 0; i--) {
+          if (results[i].routingApproach?.includes('HEDGING')) continue
+          const score = results[i].gatewayPriorityMap?.[gw]
+          if (score !== undefined && score !== null) {
+            return Math.round(score * 100)
+          }
+        }
+        return 0
+      })
+    })
+    return { series, paymentNums }
+  }, [deferredSimulationResults, gatewayStats])
+
   const hedgingHits = deferredSimulationResults.filter(
-    r => r.routingApproach === 'SR_V3_HEDGING',
+    r => r.routingApproach?.includes('HEDGING'),
   ).length
 
 const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
@@ -1723,6 +1775,13 @@ const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
     if (!selectedPreviewPaymentId) return
     void previewTraceDetail.mutate()
   }, [selectedPreviewPaymentId])
+
+  useEffect(() => {
+    const el = txLogRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [deferredSimulationResults.length])
+
 
   function openAuditModal(paymentId: string) {
     setSelectedPreviewPaymentId(null)
@@ -2277,12 +2336,6 @@ const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
                   </div>
                 </div>
 
-                <div>
-                  <label className="block text-xs font-medium text-slate-600 mb-1">Eligible Gateways (comma-separated)</label>
-                  <input value={form.eligible_gateways} onChange={e => set('eligible_gateways', e.target.value)}
-                    placeholder="stripe, adyen"
-                    className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500" />
-                </div>
 
                 <div className="rounded-lg border border-slate-200 dark:border-[#222226] overflow-hidden">
                   <div className="flex items-center gap-3 px-3 py-2 border-b border-slate-100 dark:border-[#1e1e28]">
@@ -2329,10 +2382,11 @@ const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
                         <input
                           type="number"
                           min={1}
-                          max={1000}
+                          max={5000}
                           value={simulationConfig.totalPayments}
-                          onChange={e => {
-                            const total = Math.max(1, parseInt(e.target.value) || 1)
+                          onChange={e => setSimulationConfig({ totalPayments: e.target.value })}
+                          onBlur={e => {
+                            const total = Math.max(1, Math.min(5000, parseInt(e.target.value) || 1))
                             setSimulationConfig({ totalPayments: String(total) })
                           }}
                           className="w-16 border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm text-center focus:outline-none focus:ring-1 focus:ring-brand-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
@@ -2349,7 +2403,17 @@ const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
                           <div key={gw} className="rounded-lg border border-slate-200 dark:border-[#222226] p-2.5 space-y-1.5">
                             <div className="flex items-center justify-between">
                               <span className="text-xs font-semibold text-slate-700 dark:text-slate-300 capitalize">{gw}</span>
-                              <span className="text-xs font-semibold text-brand-600 dark:text-sky-400">{gwRate}%</span>
+                              <div className="flex items-center gap-1.5">
+                                <span className="text-xs font-semibold text-brand-600 dark:text-sky-400">{gwRate}%</span>
+                                <button
+                                  type="button"
+                                  disabled={isSimulating}
+                                  onClick={() => set('eligible_gateways', eligibleGatewaysParsed.filter(g => g !== gw).join(', '))}
+                                  className="text-slate-300 hover:text-red-400 dark:text-slate-600 dark:hover:text-red-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                >
+                                  <X size={12} />
+                                </button>
+                              </div>
                             </div>
                             <input
                               type="range"
@@ -2360,18 +2424,20 @@ const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
                               className="w-full accent-brand-600"
                             />
                             {hasFailures && (
-                              <div className="flex rounded-md overflow-hidden border border-slate-200 dark:border-[#222226] text-[10px] font-medium">
+                              <div className={`flex rounded-md overflow-hidden border text-[10px] font-medium ${isSimulating ? 'border-slate-100 dark:border-[#1c1c24] opacity-50 cursor-not-allowed' : 'border-slate-200 dark:border-[#222226]'}`}>
                                 <button
                                   type="button"
+                                  disabled={isSimulating}
                                   onClick={() => setGwFailureMode(gw, 'decline')}
-                                  className={`flex-1 py-0.5 transition-colors ${gwFailureMode === 'decline' ? 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400' : 'text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'}`}
+                                  className={`flex-1 py-0.5 transition-colors disabled:pointer-events-none ${gwFailureMode === 'decline' ? 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400' : 'text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'}`}
                                 >
                                   Decline
                                 </button>
                                 <button
                                   type="button"
+                                  disabled={isSimulating}
                                   onClick={() => setGwFailureMode(gw, 'timeout')}
-                                  className={`flex-1 py-0.5 border-l border-slate-200 dark:border-[#222226] transition-colors ${gwFailureMode === 'timeout' ? 'bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400' : 'text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'}`}
+                                  className={`flex-1 py-0.5 border-l border-slate-200 dark:border-[#222226] transition-colors disabled:pointer-events-none ${gwFailureMode === 'timeout' ? 'bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400' : 'text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'}`}
                                 >
                                   Timeout
                                 </button>
@@ -2422,6 +2488,42 @@ const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
                           </div>
                         )
                       })}
+                      {/* Add connector card */}
+                      {addGwOpen ? (
+                        <div className="rounded-lg border border-brand-300 dark:border-brand-700 p-2.5 flex flex-col gap-1.5">
+                          <input
+                            ref={addGwInputRef}
+                            type="text"
+                            value={addGwDraft}
+                            onChange={e => setAddGwDraft(e.target.value)}
+                            onKeyDown={e => {
+                              if (e.key === 'Enter') {
+                                const gw = addGwDraft.trim().toLowerCase()
+                                if (gw && !eligibleGatewaysParsed.includes(gw)) {
+                                  set('eligible_gateways', [...eligibleGatewaysParsed, gw].join(', '))
+                                }
+                                setAddGwDraft('')
+                                setAddGwOpen(false)
+                              }
+                              if (e.key === 'Escape') { setAddGwDraft(''); setAddGwOpen(false) }
+                            }}
+                            onBlur={() => { setAddGwDraft(''); setAddGwOpen(false) }}
+                            placeholder="e.g. stripe"
+                            autoFocus
+                            className="w-full bg-transparent text-xs font-medium text-slate-700 dark:text-slate-200 placeholder-slate-400 focus:outline-none"
+                          />
+                          <p className="text-[10px] text-slate-400">Enter to add · Esc to cancel</p>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          disabled={isSimulating}
+                          onClick={() => { setAddGwOpen(true); setTimeout(() => addGwInputRef.current?.focus(), 0) }}
+                          className="rounded-lg border border-dashed border-slate-300 dark:border-[#2a2a3a] p-2.5 flex items-center justify-center gap-1.5 text-xs text-slate-400 hover:text-brand-600 hover:border-brand-400 dark:hover:text-brand-400 dark:hover:border-brand-600 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          <Plus size={12} /> Add connector
+                        </button>
+                      )}
                     </div>
                   </div>
                 )}
@@ -2455,11 +2557,16 @@ const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
                 )}
               </Button>
             ) : activeTab === 'batch' ? (
-              <Button onClick={runSimulation} disabled={isSimulating || !effectiveMerchantId || routingConfigUnavailable} className="w-full justify-center">
+              <Button
+                onClick={isSimulating ? () => { simulationAbortRef.current = true } : runSimulation}
+                disabled={!effectiveMerchantId || routingConfigUnavailable}
+                variant={isSimulating ? 'secondary' : 'primary'}
+                className="w-full justify-center"
+              >
                 {isSimulating ? (
                   <>
-                    <Spinner size={14} />
-                    Simulating {simulationResults.length}/{simulationConfig.totalPayments || 0}...
+                    <X size={14} />
+                    Stop ({simulationResults.length}/{simulationConfig.totalPayments || 0})
                   </>
                 ) : (
                   <>
@@ -2961,155 +3068,219 @@ const pieData = volumeDistribution.map(d => ({ name: d.name, value: d.count }))
                   <CardBody className="!pt-3">
                     {Object.keys(gatewayStats).length > 0 && (() => {
                       const totalRouted = Object.values(gatewayStats).reduce((s, g) => s + g.total, 0)
-                      const dominated = Object.keys(gatewayStats).length === 1
+                      const sortedGateways = Object.entries(gatewayStats).sort((a, b) => b[1].total - a[1].total)
+                      const GW_COLORS = ['#3b82f6', '#8b5cf6', '#f97316', '#ec4899', '#14b8a6']
+                      const hasAnySpark = sortedGateways.some(([gw]) => (gatewaySparklines.series[gw]?.length ?? 0) >= 2)
                       return (
-                        <div className="space-y-2">
-                          {Object.entries(gatewayStats).map(([gateway, stats]) => {
-                            const share = totalRouted > 0 ? Math.round((stats.total / totalRouted) * 100) : 0
-                            const srPct = stats.total > 0 ? Math.round((stats.success / stats.total) * 100) : 0
-                            return (
-                              <div key={gateway} className="space-y-0.5">
-                                <div className="flex items-center justify-between text-xs">
-                                  <span className="font-medium text-slate-800 dark:text-slate-200">{gateway}</span>
-                                  <div className="flex gap-2 text-[11px]">
-                                    <span className="text-emerald-600">{stats.success} ✓</span>
-                                    <span className="text-red-500">{stats.failure} ✗</span>
-                                    <span className="font-semibold text-emerald-600">{srPct}% SR</span>
-                                    <span className="font-semibold text-slate-500">{share}% traffic</span>
+                        <div className="flex gap-4">
+                          {/* per-gateway stat rows */}
+                          <div className="flex-1 space-y-2 min-w-0">
+                            {sortedGateways.map(([gateway, stats], idx) => {
+                              const share = totalRouted > 0 ? Math.round((stats.total / totalRouted) * 100) : 0
+                              const srPct = stats.total > 0 ? Math.round((stats.success / stats.total) * 100) : 0
+                              return (
+                                <div key={gateway} className="space-y-1">
+                                  <div className="flex items-center gap-2">
+                                    <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: GW_COLORS[idx % GW_COLORS.length] }} />
+                                    <span className="text-xs font-semibold text-slate-700 dark:text-slate-200 w-20 truncate shrink-0">{gateway}</span>
+                                    <div className="flex-1 h-1.5 rounded-full bg-slate-100 dark:bg-[#1c1c24] overflow-hidden">
+                                      <div className="h-full rounded-full transition-[width] duration-300" style={{ width: `${share}%`, backgroundColor: GW_COLORS[idx % GW_COLORS.length] }} />
+                                    </div>
+                                    <div className="flex items-center gap-2 text-[11px] shrink-0">
+                                      <span className="text-slate-400 dark:text-slate-500">{share}%</span>
+                                      <span className={`font-semibold tabular-nums ${srPct >= 80 ? 'text-emerald-600 dark:text-emerald-400' : srPct >= 50 ? 'text-amber-500' : 'text-red-500'}`}>{srPct}% SR</span>
+                                      <span className="text-emerald-600 dark:text-emerald-400 tabular-nums">{stats.success}✓</span>
+                                      <span className="text-red-400 tabular-nums">{stats.failure}✗</span>
+                                    </div>
                                   </div>
                                 </div>
-                                <div className="w-full h-1 rounded-full bg-slate-100 dark:bg-[#1c1c24] overflow-hidden">
-                                  <div className="h-1 rounded-full bg-brand-500 transition-[width] duration-300" style={{ width: `${share}%` }} />
+                              )
+                            })}
+                          </div>
+                          {/* combined multi-line SR chart — scrollable, fixed y-axis */}
+                          {hasAnySpark && (() => {
+                            const { series, paymentNums } = gatewaySparklines
+                            const numPts = paymentNums.length
+                            const PT_W = 7        // px per data point
+                            const CHART_H = Math.max(64, sortedGateways.length * 28)
+                            const XAXIS_H = 14    // room for x-axis labels
+                            const AXIS_W = 28     // fixed y-axis width
+                            const CW = Math.max(200, numPts * PT_W)
+                            const H = CHART_H + XAXIS_H
+                            const pad = 6
+                            const xPos = (i: number) => (i / Math.max(numPts - 1, 1)) * CW
+
+                            // Dynamic Y range: observed min/max across all series, padded by 5pts
+                            const allVals = sortedGateways.flatMap(([gw]) => series[gw]?.filter(v => v > 0) ?? [])
+                            const obsMin = allVals.length ? Math.min(...allVals) : 0
+                            const obsMax = allVals.length ? Math.max(...allVals) : 100
+                            const yMin = Math.max(0, obsMin - 5)
+                            const yMax = Math.min(100, obsMax + 5)
+                            const yRange = yMax - yMin || 1
+
+                            const yPos = (v: number) => pad + ((yMax - v) / yRange) * (CHART_H - pad * 2)
+
+                            // Pick ~4 round tick values within [yMin, yMax]
+                            const tickStep = yRange <= 10 ? 2 : yRange <= 30 ? 5 : 10
+                            const tickStart = Math.ceil(yMin / tickStep) * tickStep
+                            const ticks: number[] = []
+                            for (let t = tickStart; t <= yMax; t += tickStep) ticks.push(t)
+
+                            const makeLine = (pts: number[]) => {
+                              if (pts.length < 2) return ''
+                              const coords = pts.map((v, i) => [xPos(i), yPos(v)])
+                              let d = `M ${coords[0][0]},${coords[0][1]}`
+                              for (let i = 1; i < coords.length; i++) {
+                                const cpx = (coords[i][0] - coords[i - 1][0]) * 0.4
+                                d += ` C ${coords[i-1][0]+cpx},${coords[i-1][1]} ${coords[i][0]-cpx},${coords[i][1]} ${coords[i][0]},${coords[i][1]}`
+                              }
+                              return d
+                            }
+                            // Show ~6 evenly-spaced x labels
+                            const xLabelStep = Math.max(1, Math.floor(numPts / 6))
+                            const xLabels = paymentNums
+                              .map((n, i) => ({ n, i }))
+                              .filter(({ i }) => i % xLabelStep === 0 || i === numPts - 1)
+                            return (
+                              <div className="relative shrink-0" style={{ width: 200 + AXIS_W }}>
+                                {/* scrollable chart area */}
+                                <div
+                                  className="overflow-x-auto"
+                                  style={{ width: 200, scrollbarWidth: 'none' }}
+                                  ref={el => { if (el) el.scrollLeft = el.scrollWidth }}
+                                >
+                                  <svg width={CW} height={H} viewBox={`0 0 ${CW} ${H}`} style={{ display: 'block' }}>
+                                    {/* horizontal grid lines */}
+                                    {ticks.map(t => (
+                                      <line key={t} x1={0} y1={yPos(t)} x2={CW} y2={yPos(t)}
+                                        stroke="#e2e8f0" strokeWidth="0.5" strokeDasharray="2,2" />
+                                    ))}
+                                    {/* gateway lines */}
+                                    {sortedGateways.map(([gw], idx) => {
+                                      const pts = series[gw]
+                                      if (!pts || pts.length < 2) return null
+                                      const color = GW_COLORS[idx % GW_COLORS.length]
+                                      const line = makeLine(pts)
+                                      const area = `${line} L ${xPos(pts.length - 1)},${CHART_H} L 0,${CHART_H} Z`
+                                      return (
+                                        <g key={gw}>
+                                          <path d={area} fill={color} fillOpacity={0.07} />
+                                          <path d={line} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                                        </g>
+                                      )
+                                    })}
+                                    {/* x-axis baseline */}
+                                    <line x1={0} y1={CHART_H} x2={CW} y2={CHART_H} stroke="#e2e8f0" strokeWidth="0.5" />
+                                    {/* x-axis labels */}
+                                    {xLabels.map(({ n, i }, labelIdx) => (
+                                      <text key={i} x={xPos(i)} y={CHART_H + 10} fontSize="7"
+                                        fill="#94a3b8" fontFamily="monospace"
+                                        textAnchor={labelIdx === 0 ? 'start' : labelIdx === xLabels.length - 1 ? 'end' : 'middle'}>
+                                        {n}
+                                      </text>
+                                    ))}
+                                  </svg>
+                                </div>
+                                {/* fixed y-axis */}
+                                <div className="absolute top-0 right-0" style={{ width: AXIS_W }}>
+                                  <svg width={AXIS_W} height={CHART_H} viewBox={`0 0 ${AXIS_W} ${CHART_H}`} style={{ display: 'block' }}>
+                                    <line x1={2} y1={pad} x2={2} y2={CHART_H - pad} stroke="#cbd5e1" strokeWidth="0.5" />
+                                    {ticks.map(t => (
+                                      <g key={t}>
+                                        <line x1={0} y1={yPos(t)} x2={4} y2={yPos(t)} stroke="#cbd5e1" strokeWidth="0.5" />
+                                        <text x={6} y={yPos(t) + 3} fontSize="7" fill="#94a3b8" fontFamily="monospace">{t}%</text>
+                                      </g>
+                                    ))}
+                                  </svg>
                                 </div>
                               </div>
                             )
-                          })}
-                          {dominated && eligibleGatewaysParsed.length > 1 && (
-                            <p className="text-[11px] text-slate-400 pt-0.5">
-                              SR routing concentrates traffic on the highest-scoring gateway. Run with a "Gateway Down" scenario to see score drop and traffic shift to the next gateway.
-                            </p>
-                          )}
+                          })()}
+                          {!hasAnySpark && null}
                         </div>
                       )
                     })()}
+                    {Object.keys(gatewayStats).length === 1 && eligibleGatewaysParsed.length > 1 && (
+                      <p className="text-[11px] text-slate-400 pt-1">
+                        SR routing concentrates traffic on the highest-scoring gateway. Run with a "Gateway Down" scenario to see score drop and traffic shift to the next gateway.
+                      </p>
+                    )}
                   </CardBody>
                 </Card>
 
-                <Card className="flex-1 min-h-0">
-                  {(() => {
-                    const total = deferredSimulationResults.length
-                    const totalPages = Math.max(1, Math.ceil(total / TX_LOG_PAGE_SIZE))
-                    const safePage = Math.min(txLogPage, totalPages)
-                    const pageStart = (safePage - 1) * TX_LOG_PAGE_SIZE
-                    const pageResults = deferredSimulationResults.slice(pageStart, pageStart + TX_LOG_PAGE_SIZE)
-                    return (
-                      <>
-                        <CardHeader className="shrink-0 flex flex-row items-center justify-between gap-3">
-                          <h3 className="text-sm font-medium text-slate-800 dark:text-white">Transaction Log</h3>
-                          {total > 0 && (
-                            <div className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
-                              <span>{pageStart + 1}–{Math.min(pageStart + TX_LOG_PAGE_SIZE, total)} of {total}</span>
-                              <button
-                                type="button"
-                                disabled={safePage <= 1}
-                                onClick={() => setTxLogPage(p => Math.max(1, p - 1))}
-                                className="rounded p-0.5 hover:bg-slate-100 dark:hover:bg-[#1c1c24] disabled:opacity-30 disabled:cursor-not-allowed"
-                              >
-                                <ChevronLeft size={14} />
-                              </button>
-                              <input
-                                type="number"
-                                min={1}
-                                max={totalPages}
-                                value={safePage}
-                                onChange={e => {
-                                  const v = parseInt(e.target.value)
-                                  if (!isNaN(v)) setTxLogPage(Math.min(totalPages, Math.max(1, v)))
-                                }}
-                                className="w-10 rounded border border-slate-200 dark:border-[#222226] bg-transparent px-1 py-0.5 text-center text-xs tabular-nums focus:outline-none focus:ring-1 focus:ring-brand-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                              />
-                              <span className="text-slate-400">/ {totalPages}</span>
-                              <button
-                                type="button"
-                                disabled={safePage >= totalPages}
-                                onClick={() => setTxLogPage(p => Math.min(totalPages, p + 1))}
-                                className="rounded p-0.5 hover:bg-slate-100 dark:hover:bg-[#1c1c24] disabled:opacity-30 disabled:cursor-not-allowed"
-                              >
-                                <ChevronRight size={14} />
-                              </button>
-                            </div>
-                          )}
-                        </CardHeader>
-                        <CardBody className="p-0 flex-1 min-h-0 overflow-auto">
-                          {total > 0 ? (
-                            <table className="w-full text-sm">
-                              <thead className="bg-slate-50 dark:bg-[#0a0a0f] text-xs text-slate-500 sticky top-0">
-                                <tr>
-                                  <th className="text-left px-3 py-2">#</th>
-                                  <th className="text-left px-3 py-2">Payment ID</th>
-                                  <th className="text-left px-3 py-2">Gateway</th>
-                                  <th className="text-left px-3 py-2">Routing</th>
-                                  <th className="text-left px-3 py-2">Outcome</th>
-                                </tr>
-                              </thead>
-                              <tbody className="divide-y divide-[#1c1c24]">
-                                {pageResults.map((res) => {
-                                  const globalIdx = deferredSimulationResults.indexOf(res)
-                                  return (
-                                    <tr key={res.paymentId} className="hover:bg-slate-100 dark:bg-[#0f0f16]">
-                                      <td className="px-3 py-2 text-slate-500">{globalIdx + 1}</td>
-                                      <td className="px-3 py-2">
-                                        <button
-                                          type="button"
-                                          title={res.paymentId}
-                                          onClick={() => openAuditModal(res.paymentId)}
-                                          className="group flex items-start gap-3 text-left"
-                                        >
-                                          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-500/10 text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-600 dark:text-brand-300">
-                                            {globalIdx + 1}
-                                          </span>
-                                          <span className="min-w-0">
-                                            <span className="block truncate font-mono text-xs font-semibold text-slate-900 transition group-hover:text-brand-600 dark:text-white">
-                                              {res.paymentId}
-                                            </span>
-                                            <span className="mt-1 block text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400 transition group-hover:text-brand-500">
-                                              View audit
-                                            </span>
-                                          </span>
-                                        </button>
-                                      </td>
-                                      <td className="px-3 py-2 font-medium">{res.decidedGateway}</td>
-                                      <td className="px-3 py-2">
-                                        {res.routingApproach === 'SR_V3_HEDGING' ? (
-                                          <span className="inline-flex items-center gap-1 rounded-full bg-brand-50 px-2 py-0.5 text-[11px] font-medium text-brand-700 ring-1 ring-inset ring-brand-200 dark:bg-brand-900/20 dark:text-brand-300 dark:ring-brand-800">
-                                            Hedging
-                                          </span>
-                                        ) : (
-                                          <span className="text-[11px] text-slate-400">
-                                            {res.routingApproach === 'SR_SELECTION_V3_ROUTING' ? 'SR V3' : (res.routingApproach ?? '—')}
-                                          </span>
-                                        )}
-                                      </td>
-                                      <td className="px-3 py-2">
-                                        <Badge variant={res.status === 'CHARGED' ? 'green' : res.status === 'PENDING_VBV' ? 'orange' : 'red'}>
-                                          {res.status}
-                                        </Badge>
-                                      </td>
-                                    </tr>
-                                  )
-                                })}
-                              </tbody>
-                            </table>
-                          ) : (
-                            <div className="flex items-center gap-3 px-4 py-6 text-sm text-slate-500">
-                              <Spinner size={16} />
-                              Waiting for the first simulated payment result…
-                            </div>
-                          )}
-                        </CardBody>
-                      </>
-                    )
-                  })()}
+                <Card>
+                  <CardHeader className="flex flex-row items-center justify-between gap-3">
+                    <h3 className="text-sm font-medium text-slate-800 dark:text-white">Transaction Log</h3>
+                    {deferredSimulationResults.length > 0 && (
+                      <span className="text-xs text-slate-400 tabular-nums">{deferredSimulationResults.length} transactions</span>
+                    )}
+                  </CardHeader>
+                  <CardBody className="p-0">
+                    {deferredSimulationResults.length > 0 ? (
+                      <div ref={txLogRef} className="max-h-[480px] overflow-auto">
+                        <table className="w-full text-sm">
+                          <thead className="bg-slate-50 dark:bg-[#0a0a0f] text-xs text-slate-500 sticky top-0">
+                            <tr>
+                              <th className="text-left px-3 py-2">#</th>
+                              <th className="text-left px-3 py-2">Payment ID</th>
+                              <th className="text-left px-3 py-2">Gateway</th>
+                              <th className="text-left px-3 py-2">Routing</th>
+                              <th className="text-left px-3 py-2">Outcome</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-[#1c1c24]">
+                            {deferredSimulationResults.map((res, idx) => (
+                              <tr key={res.paymentId} className="hover:bg-slate-100 dark:bg-[#0f0f16]">
+                                <td className="px-3 py-2 text-slate-500">{idx + 1}</td>
+                                <td className="px-3 py-2">
+                                  <button
+                                    type="button"
+                                    title={res.paymentId}
+                                    onClick={() => openAuditModal(res.paymentId)}
+                                    className="group flex items-start gap-3 text-left"
+                                  >
+                                    <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-500/10 text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-600 dark:text-brand-300">
+                                      {idx + 1}
+                                    </span>
+                                    <span className="min-w-0">
+                                      <span className="block truncate font-mono text-xs font-semibold text-slate-900 transition group-hover:text-brand-600 dark:text-white">
+                                        {res.paymentId}
+                                      </span>
+                                      <span className="mt-1 block text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400 transition group-hover:text-brand-500">
+                                        View audit
+                                      </span>
+                                    </span>
+                                  </button>
+                                </td>
+                                <td className="px-3 py-2 font-medium">{res.decidedGateway}</td>
+                                <td className="px-3 py-2">
+                                  {res.routingApproach?.includes('HEDGING') ? (
+                                    <span className="inline-flex items-center gap-1 rounded-full bg-brand-50 px-2 py-0.5 text-[11px] font-medium text-brand-700 ring-1 ring-inset ring-brand-200 dark:bg-brand-900/20 dark:text-brand-300 dark:ring-brand-800">
+                                      Hedging
+                                    </span>
+                                  ) : (
+                                    <span className="text-[11px] text-slate-400">
+                                      {res.routingApproach === 'SR_SELECTION_V3_ROUTING' ? 'SR V3' : (res.routingApproach ?? '—')}
+                                    </span>
+                                  )}
+                                </td>
+                                <td className="px-3 py-2">
+                                  <Badge variant={res.status === 'CHARGED' ? 'green' : res.status === 'PENDING_VBV' ? 'orange' : 'red'}>
+                                    {res.status}
+                                  </Badge>
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-3 px-4 py-6 text-sm text-slate-500">
+                        <Spinner size={16} />
+                        Waiting for the first simulated payment result…
+                      </div>
+                    )}
+                  </CardBody>
                 </Card>
               </>
             ) : (

--- a/website/src/components/pages/SRRoutingPage.tsx
+++ b/website/src/components/pages/SRRoutingPage.tsx
@@ -382,34 +382,36 @@ export function SRRoutingPage() {
 
                 {/* Bucket Size */}
                 <div className="space-y-2">
-                  <h3 className="font-semibold text-slate-700 dark:text-slate-200">Bucket Size</h3>
+                  <h3 className="font-semibold text-slate-700 dark:text-slate-200">Score Memory Size</h3>
                   <p>
-                    The algorithm recalculates each gateway's score after every <em>bucket_size</em> transactions on
-                    that gateway. Smaller buckets react faster to outages but produce noisier scores.
-                    Larger buckets are more stable but slower to shift traffic when a gateway degrades.
+                    Each gateway's success rate is calculated from its most recent payments — not its entire
+                    history. This setting controls <strong>how many recent payments</strong> are considered.
+                    Think of it like a restaurant rating that only reflects the last N reviews, so a venue that
+                    improves quickly can recover its rating without being dragged down by old data.
                   </p>
-                  <div className="rounded-lg bg-slate-50 dark:bg-[#0f0f16] border border-slate-200 dark:border-[#1c1c24] px-3 py-2 font-mono text-[11px]">
-                    detection time ≈ bucket_size ÷ (txns_per_hr ÷ num_gateways ÷ 60) &nbsp;minutes
-                  </div>
+                  <ul className="list-disc list-inside space-y-1 text-[13px] text-slate-600 dark:text-slate-400">
+                    <li><span className="font-semibold">Smaller</span> — reacts faster when a gateway's performance changes, but can be noisy (a temporary bad hour looks like a real problem)</li>
+                    <li><span className="font-semibold">Larger</span> — more stable and reliable ratings, but takes longer to adapt when a gateway genuinely improves or degrades</li>
+                  </ul>
                   <table className="w-full text-[11px] border-collapse">
                     <thead>
                       <tr className="text-left text-slate-500 border-b border-slate-200 dark:border-[#1c1c24]">
-                        <th className="py-1 pr-4 font-medium">Volume</th>
-                        <th className="py-1 pr-4 font-medium">Recommended bucket</th>
-                        <th className="py-1 font-medium">Detection time</th>
+                        <th className="py-1 pr-4 font-medium">Payment volume</th>
+                        <th className="py-1 pr-4 font-medium">Recommended</th>
+                        <th className="py-1 font-medium">How long before a rating change is noticed</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-100 dark:divide-[#1c1c24]">
-                      <tr><td className="py-1 pr-4">&lt; 500 txns/hr</td><td className="py-1 pr-4 font-semibold">20</td><td className="py-1 text-slate-500">~2–5 min</td></tr>
-                      <tr><td className="py-1 pr-4">500–2000 txns/hr</td><td className="py-1 pr-4 font-semibold">50</td><td className="py-1 text-slate-500">~1–2 min</td></tr>
-                      <tr><td className="py-1 pr-4">2000–5000 txns/hr</td><td className="py-1 pr-4 font-semibold">100</td><td className="py-1 text-slate-500">~1–2 min</td></tr>
-                      <tr><td className="py-1 pr-4">&gt; 5000 txns/hr</td><td className="py-1 pr-4 font-semibold">200</td><td className="py-1 text-slate-500">~1–2 min</td></tr>
+                      <tr><td className="py-1 pr-4">&lt; 500 / hour</td><td className="py-1 pr-4 font-semibold">20</td><td className="py-1 text-slate-500">~60 min</td></tr>
+                      <tr><td className="py-1 pr-4">500–2000 / hour</td><td className="py-1 pr-4 font-semibold">50</td><td className="py-1 text-slate-500">~40 min</td></tr>
+                      <tr><td className="py-1 pr-4">2000–5000 / hour</td><td className="py-1 pr-4 font-semibold">100</td><td className="py-1 text-slate-500">~20 min</td></tr>
+                      <tr><td className="py-1 pr-4">&gt; 5000 / hour</td><td className="py-1 pr-4 font-semibold">200</td><td className="py-1 text-slate-500">~16 min</td></tr>
                     </tbody>
                   </table>
                   <p className="text-slate-500 dark:text-slate-400">
-                    A bucket size of 50 reliably detects a 10%+ drop in success rate. Detecting a 1% difference
-                    requires ~5500 transactions per bucket — not practical. Size your bucket to catch real outages,
-                    not marginal noise.
+                    If a gateway goes completely down, it is removed from routing within minutes by a separate
+                    real-time outage detector — you don't need to set this small to handle outages.
+                    This setting is for catching gradual performance drifts over time.
                   </p>
                 </div>
 
@@ -417,33 +419,30 @@ export function SRRoutingPage() {
                 <div className="space-y-2">
                   <h3 className="font-semibold text-slate-700 dark:text-slate-200">Hedging %</h3>
                   <p>
-                    The exploration rate for the Explore-exploit feature. When Explore-exploit (Card, SRv3) is
-                    enabled, this percentage of traffic is probabilistically routed to non-top gateways,
-                    keeping their scores fresh so the algorithm can respond quickly when the primary degrades.
+                    To keep every gateway's rating up to date, the system periodically sends a small percentage
+                    of payments to each gateway — even ones that are not currently the top performer. This is
+                    like regularly sending mystery shoppers to every vendor so you always have a fresh,
+                    accurate rating for each one, and can quickly spot when the best option changes.
                   </p>
                   <p className="text-amber-600 dark:text-amber-400">
-                    Too low = backup scores go stale = slow failover when the top gateway drops. Has no effect
-                    if Explore-exploit is disabled.
+                    Setting this too low means gateways that aren't winning most traffic won't have enough
+                    fresh data — so if your top gateway suddenly degrades, the system will be slow to notice
+                    and switch. Only applies when the Explore-exploit feature is enabled.
                   </p>
-                  <p>Set hedging so the backup fills one bucket within your acceptable failover window:</p>
-                  <div className="rounded-lg bg-slate-50 dark:bg-[#0f0f16] border border-slate-200 dark:border-[#1c1c24] px-3 py-2 font-mono text-[11px] space-y-1">
-                    <div>hedging% = (bucket_size ÷ failover_minutes) ÷ txns_per_minute × 100</div>
-                    <div className="text-slate-400">— e.g. bucket=50, 5 min window, 60 txns/min → (50÷5)÷60×100 ≈ 17%</div>
-                  </div>
                   <table className="w-full text-[11px] border-collapse">
                     <thead>
                       <tr className="text-left text-slate-500 border-b border-slate-200 dark:border-[#1c1c24]">
-                        <th className="py-1 pr-4 font-medium">Volume</th>
-                        <th className="py-1 pr-4 font-medium">Bucket</th>
-                        <th className="py-1 pr-4 font-medium">Failover window</th>
-                        <th className="py-1 font-medium">Recommended hedging</th>
+                        <th className="py-1 pr-4 font-medium">Payment volume</th>
+                        <th className="py-1 pr-4 font-medium">Score Memory Size</th>
+                        <th className="py-1 pr-4 font-medium">How quickly ratings stay fresh</th>
+                        <th className="py-1 font-medium">Recommended</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-100 dark:divide-[#1c1c24]">
-                      <tr><td className="py-1 pr-4">&lt; 500/hr</td><td className="py-1 pr-4">20</td><td className="py-1 pr-4">10 min</td><td className="py-1 font-semibold">~7%</td></tr>
-                      <tr><td className="py-1 pr-4">500–2000/hr</td><td className="py-1 pr-4">50</td><td className="py-1 pr-4">5 min</td><td className="py-1 font-semibold">~15%</td></tr>
-                      <tr><td className="py-1 pr-4">2000–5000/hr</td><td className="py-1 pr-4">100</td><td className="py-1 pr-4">5 min</td><td className="py-1 font-semibold">~20%</td></tr>
-                      <tr><td className="py-1 pr-4">&gt; 5000/hr</td><td className="py-1 pr-4">200</td><td className="py-1 pr-4">5 min</td><td className="py-1 font-semibold">~20%</td></tr>
+                      <tr><td className="py-1 pr-4">&lt; 500 / hour</td><td className="py-1 pr-4">20</td><td className="py-1 pr-4">within ~60 min</td><td className="py-1 font-semibold">~8%</td></tr>
+                      <tr><td className="py-1 pr-4">500–2000 / hour</td><td className="py-1 pr-4">50</td><td className="py-1 pr-4">within ~40 min</td><td className="py-1 font-semibold">~15%</td></tr>
+                      <tr><td className="py-1 pr-4">2000–5000 / hour</td><td className="py-1 pr-4">100</td><td className="py-1 pr-4">within ~20 min</td><td className="py-1 font-semibold">~17%</td></tr>
+                      <tr><td className="py-1 pr-4">&gt; 5000 / hour</td><td className="py-1 pr-4">200</td><td className="py-1 pr-4">within ~15 min</td><td className="py-1 font-semibold">~19%</td></tr>
                     </tbody>
                   </table>
                 </div>
@@ -452,25 +451,33 @@ export function SRRoutingPage() {
                 <div className="space-y-2">
                   <h3 className="font-semibold text-slate-700 dark:text-slate-200">Default Success Rate</h3>
                   <p>
-                    The prior score assigned to any gateway that has no transaction history yet (e.g. newly added
-                    gateways). Set this close to your historical average across all gateways — typically
-                    <span className="font-semibold"> 0.80–0.95</span>.
+                    When a new payment gateway is added, it has no transaction history yet. Rather than
+                    treating it as untrusted, the system gives it a <strong>perfect starting rating</strong> so
+                    it immediately gets a fair share of test traffic to prove itself. Its rating then adjusts
+                    naturally based on real results.
                   </p>
                   <p className="text-slate-500 dark:text-slate-400">
-                    Too high → new or poor-quality gateways receive too much traffic before proving themselves.
-                    Too low → new gateways are starved of traffic and take longer to build a reliable score.
+                    This starting score is fixed at the maximum — this field is not active and changing it has
+                    no effect.
                   </p>
                 </div>
 
                 {/* Feedback Latency Window */}
                 <div className="space-y-2">
-                  <h3 className="font-semibold text-slate-700 dark:text-slate-200">Feedback Latency Window</h3>
+                  <h3 className="font-semibold text-slate-700 dark:text-slate-200">Timeout Grace Period</h3>
                   <p>
-                    When a score update (feedback) arrives, the system measures how long has passed since the
-                    transaction was created. If that elapsed time is within this window, the failure is
-                    classified as a standard penalty; if it exceeds the window, it is classified as an SR V3
-                    penalty. This affects which scoring path is applied, not whether the gateway is filtered
-                    during routing. Unit is <span className="font-semibold">seconds</span>. Default is 300 s (5 min).
+                    When a payment times out — meaning the gateway didn't respond in time rather than
+                    explicitly failing — this setting controls how the system interprets it. If the timeout
+                    happens quickly after the payment attempt, it looks like a temporary outage. If it happens
+                    much later, it's treated as a general performance issue instead.
+                  </p>
+                  <ul className="list-disc list-inside space-y-1 text-[13px] text-slate-600 dark:text-slate-400">
+                    <li><span className="font-semibold">Within this period</span> — counted as a temporary outage, triggers fast rerouting</li>
+                    <li><span className="font-semibold">After this period</span> — counted as a general quality issue, affects the gateway's long-term rating</li>
+                  </ul>
+                  <p className="text-slate-500 dark:text-slate-400">
+                    Explicit payment failures are always counted as quality issues regardless of timing.
+                    Default is 5 minutes — suitable for most integrations.
                   </p>
                 </div>
 
@@ -481,15 +488,15 @@ export function SRRoutingPage() {
           <Card>
             <CardHeader>
               <div>
-                <h2 className="text-sm font-semibold text-slate-800">Default Success Rate Config</h2>
+                <h2 className="text-sm font-semibold text-slate-800">Routing Settings</h2>
                 <p className="text-xs text-slate-500 mt-0.5">
-                  Base settings used when there is no payment-method-specific override.
+                  Default values used for all payment types unless overridden below.
                 </p>
               </div>
             </CardHeader>
             <CardBody className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
               <label className="space-y-1">
-                <span className="text-xs text-slate-500">Bucket Size</span>
+                <span className="text-xs text-slate-500">Score Memory Size</span>
                 <input
                   type="number"
                   {...register('defaultBucketSize')}
@@ -499,12 +506,12 @@ export function SRRoutingPage() {
                   <p className="text-xs text-red-500">{errors.defaultBucketSize.message}</p>
                 )}
                 <p className="text-[11px] text-slate-400 dark:text-slate-500 leading-relaxed">
-                  Transactions per score recalculation. Smaller = faster reaction. Aim for a 1–5 min fill time at your volume.
+                  How many recent test payments are used to calculate each gateway's rating. Higher = more stable but slower to adapt. Lower = reacts faster but may overreact to short blips.
                 </p>
               </label>
 
               <label className="space-y-1">
-                <span className="text-xs text-slate-500">Success Rate</span>
+                <span className="text-xs text-slate-500">Starting Rating for New Gateways</span>
                 <input
                   type="number"
                   step="0.1"
@@ -515,7 +522,7 @@ export function SRRoutingPage() {
                   className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-1 focus:ring-brand-500"
                 />
                 <p className="text-[11px] text-slate-400 dark:text-slate-500 leading-relaxed">
-                  Prior score for gateways with no history yet. Set near your expected average (0.80–0.95).
+                  Not active — new gateways always start with a perfect rating automatically.
                 </p>
               </label>
 
@@ -529,12 +536,12 @@ export function SRRoutingPage() {
                   className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-1 focus:ring-brand-500"
                 />
                 <p className="text-[11px] text-slate-400 dark:text-slate-500 leading-relaxed">
-                  Exploration rate used by Explore-exploit (Card, SRv3). Has no effect if that flag is disabled.
+                  Percentage of payments used to keep all gateway ratings fresh. Only applies when the Explore-exploit feature is on.
                 </p>
               </label>
 
               <label className="space-y-1">
-                <span className="text-xs text-slate-500">Feedback Latency Window (s)</span>
+                <span className="text-xs text-slate-500">Timeout Grace Period (seconds)</span>
                 <input
                   type="number"
                   {...register('defaultLatencyThreshold')}
@@ -542,7 +549,7 @@ export function SRRoutingPage() {
                   className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-1 focus:ring-brand-500"
                 />
                 <p className="text-[11px] text-slate-400 dark:text-slate-500 leading-relaxed">
-                  Seconds after txn creation within which feedback is a standard penalty; beyond it uses the SR V3 penalty path. Default 300 s.
+                  How long after a payment attempt a timeout is treated as a temporary outage vs a general performance issue. Default is 300 s (5 min).
                 </p>
               </label>
 
@@ -680,7 +687,7 @@ const SR_FEATURES: { feature: KnownFeature; title: string; description: string }
     feature: 'explore-exploit-srv3',
     title: 'Explore-exploit on SRv3 (Card)',
     description:
-      'Enable epsilon-greedy exploration for card transactions on SRv3. When enabled, the Hedging % setting controls what fraction of traffic is routed to non-top gateways to keep their scores fresh. Without this flag, Hedging % has no effect.',
+      'Keeps all gateway ratings fresh by regularly sending a small share of payments to every gateway — not just the top performer. This ensures the system can quickly detect when a backup gateway becomes better than the current top, and reroute accordingly. The Hedging % setting controls how large this share is.',
   },
 ]
 

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -25,9 +25,11 @@ export default defineConfig(({ command }) => {
       proxy.on('error', (err, req, res) => {
         console.log(`\n[PROXY ERROR] ${new Date().toISOString()}`)
         console.log(`Error forwarding ${req.url}:`, err.message)
-        if (res && !res.headersSent) {
-          res.writeHead(502, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: 'Backend unavailable', message: err.message }))
+        // res can be a net.Socket (WebSocket upgrade) — only write an HTTP
+        // response when it actually has writeHead (i.e. is ServerResponse).
+        if (res && typeof (res as any).writeHead === 'function' && !(res as any).headersSent) {
+          ;(res as any).writeHead(502, { 'Content-Type': 'application/json' })
+          ;(res as any).end(JSON.stringify({ error: 'Backend unavailable', message: err.message }))
         }
       })
     },

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig(({ command }) => {
   const isDevServer = command === 'serve'
   const publicBaseUrl = isDevServer ? '/' : '/decision-engine/'
-  const backendTarget = 'http://localhost:8080'
+  const backendTarget = 'http://127.0.0.1:8080'
   const apiProxyPrefix = '/decision-engine-api'
   const hostedApiProxyPrefix = '/decision-engine/api'
 
@@ -22,9 +22,13 @@ export default defineConfig(({ command }) => {
           `[PROXY] Response: ${proxyRes.statusCode} ${proxyRes.statusMessage} for ${req.url}`
         )
       })
-      proxy.on('error', (err, req) => {
+      proxy.on('error', (err, req, res) => {
         console.log(`\n[PROXY ERROR] ${new Date().toISOString()}`)
         console.log(`Error forwarding ${req.url}:`, err.message)
+        if (res && !res.headersSent) {
+          res.writeHead(502, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'Backend unavailable', message: err.message }))
+        }
       })
     },
   })


### PR DESCRIPTION
### Backend

  #### Fix: SR V3 explore-exploit score freeze (`gw_scoring.rs`)
  - Restored `create_score_map` during exploration so all gateways receive equal scores (1.0), fixing a 
  regression from `a0650de` where the top gateway was excluded from hedging — causing its score to never update
   regardless of failures
  - Design is intentional per [arxiv:2510.16735](https://arxiv.org/abs/2510.16735): only hedged transactions 
  update scores to avoid selection bias from asymmetric feedback timing
  
  #### Fix: SR_DIMENSION_CONFIG bypassing cache on every request (`utils.rs`)
  - `get_unified_sr_key` called `find_config_by_name` directly, skipping the `findByNameFromRedis` 
  memory→Redis→DB fallback chain; replaced with `findByNameFromRedis`

  #### Add: Write-through cache for `service_configuration` (`cache.rs`, `service_configuration.rs`)
  - Added `write_through_service_config` and `evict_service_config` helpers that write to both Redis and
  in-process memory cache atomically
  - `insert_config`, `update_config`, and `delete_config` now call these after successful DB writes so config
  changes are visible instantly without waiting for TTL expiry
  
  #### Add: In-process caching for merchant account and payment flow config (`merchant_account.rs`, 
  `merchant_config_util.rs`)
  - `load_merchant_by_merchant_id` checks `GLOBAL_CACHE` before hitting DB and stores results with
  `service_config_ttl`
  - `update_merchant_account` evicts the cache key after DB update
  - `isPaymentFlowEnabledForMerchant` and `isMerchantEnabledForPaymentFlows` cache results in `GLOBAL_CACHE`,
  eliminating repeated DB hits during simulation

  ---

  ### Frontend — Decision Explorer

  #### Fix: Vite proxy ECONNREFUSED / ETIMEDOUT (`vite.config.ts`)
  - Changed backend target from `localhost` to `127.0.0.1` to avoid Node 18+ dual-stack DNS (IPv6 tried first,
  7s timeout before IPv4 fallback)
  - Proxy error handler now sends a 502 JSON response instead of hanging the browser request

  #### Fix: Simulation resilience
  - Per-iteration try/catch with `MAX_CONSECUTIVE_ERRORS=3`; single backend errors no longer stop the entire
  run
  - Added 50ms delay between iterations to prevent overwhelming the backend under rapid sequential requests

  #### Fix: Gateway SR score frozen at 1.0 in simulation
  - `SR_V3_DOWNTIME_HEDGING` assigns hedged gateways score 1.0 in `gateway_priority_map`; compounded by the
  explore-exploit backend bug above
  
  #### Fix: Sparkline graph showing 100% spikes
  - Backward-search now skips hedging results (`routingApproach.includes('HEDGING')`) since exploration scores
  (1.0 for all gateways via `create_score_map`) are not real SR scores
  - Y-axis is now dynamic: fits to observed min/max across all gateway series with ±5pt padding and auto tick
  step, instead of always rendering 0–100%
  - First and last x-axis labels use `textAnchor="start"` / `"end"` respectively to prevent clipping at chart
  edges
  
  #### Fix: Hedging counter showing 0
  - `hedgingHits` filter and transaction log badge now match all hedging variants via `.includes('HEDGING')`
  (`SR_V3_HEDGING`, `SR_V3_DOWNTIME_HEDGING`, `SR_V3_ALL_DOWNTIME_HEDGING`, `SR_V3_GLOBAL_DOWNTIME_HEDGING`)
  
  #### Fix: Gateway sim config slider resetting to 70% on navigation
  - `gatewaySimConfigs` was initialized with hardcoded `{}` instead of `initialState.gatewaySimConfigs`, making
   it the only persisted state field not restored on remount
  
  #### Improve: Transaction Log
  - Removed pagination; the log is now a pure `max-h-[480px]` scrollable container rendering all results
  - Auto-scrolls to the latest transaction as simulation runs

  #### Improve: Connector config UI
  - Removed the "Eligible Gateways (comma-separated)" text input
  - Replaced with inline add/remove on the simulation grid: `+` dashed card opens an inline input (Enter to
  confirm, Esc to cancel); each gateway card has an `×` remove button

  #### Improve: Simulation controls
  - Stop button replaces Start while simulation is running, allowing mid-run cancellation
  - Max transaction count raised from 1,000 to 5,000

  ---

  ### Frontend — SR Routing Page

  - Rewrote all config section descriptions for a non-developer audience
  - Renamed fields: "Bucket Size" → "Score Memory Size", "Hedging %" → "Test Traffic %", "Feedback Latency
  Window" → "Timeout Grace Period"
  - Corrected field descriptions; marked "Default Success Rate" as inactive (hardcoded to 1.0, not read by
  backend)
  - Removed all math formulas from the UI