### PR TITLE
chore(ci): add frontend TypeScript type-check to PR workflow

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -105,6 +105,23 @@ jobs:
       - name: Run unit tests
         run: cargo test
 
+  frontend-typecheck:
+    name: Frontend Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: website
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+        working-directory: website
+
   helm:
     name: Helm Chart Validation
     runs-on: ubuntu-latest

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -803,7 +803,7 @@ export function DecisionExplorerPage() {
   const [volumeProgress, setVolumeProgress] = useState(initialState.volumeProgress)
   const [simulationResults, setSimulationResults] = useState<SimulationResult[]>(initialState.simulationResults)
   const [isSimulating, setIsSimulating] = useState(false)
-  const [smartRetryEnabled, setSmartRetryEnabled] = useState(initialState.smartRetryEnabled)
+  const [smartRetryEnabled] = useState(initialState.smartRetryEnabled)
   const [error, setError] = useState<string | null>(null)
   const [addGwDraft, setAddGwDraft] = useState('')
   const [addGwOpen, setAddGwOpen] = useState(false)


### PR DESCRIPTION
## Summary

- Adds a `frontend-typecheck` job to `ci-pr.yml` that runs `npx tsc --noEmit` on every PR — same role as `cargo check` for the Rust side
- Uses `npm ci` with Node cache so it doesn't re-download packages on each run
- Fixes the immediate trigger: removes the unused `setSmartRetryEnabled` setter whose only call sites were inside JSX block comments, which was causing a `TS6133` error in the Jenkins build after tagging

## Test plan

- [ ] Verify the new `Frontend Type Check` job appears in the PR checks list
- [ ] Confirm a PR with a TS error (e.g. unused variable) is blocked by this check
- [ ] Confirm clean PRs pass without adding significant CI time