### PR TITLE
feat(frontend): analytics redesign, compact date picker, and UI fixes

### DIFF
--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -89,6 +89,26 @@ They reflect sustainable throughput for a typical integration, not raw server ca
 See the saturation section below for the throughput ceiling.
 </Note>
 
+### Feedback path — `/update-gateway-score`
+
+Every `/decide-gateway` call is followed by a fire-and-forget feedback write to
+`/update-gateway-score`. This is what keeps SR scores current — it records the
+outcome of each routing decision back into Redis so the next decision reflects
+real gateway performance. It runs outside the routing response path and does not
+block the caller, but it does consume pod resources and contributes to Redis load.
+
+| VUs | Feedback avg | Feedback p95 |
+|----:|-------------:|-------------:|
+| 5   | 2 ms         | 4 ms         |
+| 20  | 3 ms         | 7 ms         |
+| 50  | 3 ms         | 6 ms         |
+
+Feedback latency stays flat under load because it is a single Redis write with no
+read dependencies. At 345 req/s (50 VUs) this means ~345 score updates per second
+— well within the Redis pool capacity at `pool_size = 5` with auto-pipelining.
+
+---
+
 ### Saturation point
 
 To find the raw throughput ceiling, the same endpoint was driven with **no sleep**

--- a/oneclick.sh
+++ b/oneclick.sh
@@ -48,11 +48,30 @@ check_and_kill_ports() {
         local pids
         pids=$(lsof -t -iTCP:$port -sTCP:LISTEN 2>/dev/null || true)
         if [ -n "$pids" ]; then
-            ports_in_use+=("$port")
             while IFS= read -r pid; do
                 [ -z "$pid" ] && continue
                 local cmd
                 cmd=$(ps -p "$pid" -o command= 2>/dev/null || echo "unknown process")
+
+                # OrbStack and Docker Desktop forward container ports via their own helper
+                # processes. Killing them would take down the entire container runtime.
+                # Stop the container instead.
+                if echo "$cmd" | grep -qiE "OrbStack|com\.docker\.backend|dockerd"; then
+                    local container_id
+                    container_id=$(docker ps --filter "publish=$port" -q 2>/dev/null | head -1 || true)
+                    if [ -n "$container_id" ]; then
+                        local container_name
+                        container_name=$(docker ps --filter "publish=$port" --format "{{.Names}}" 2>/dev/null | head -1)
+                        echo "  [docker] Port $port is forwarded by container '$container_name' — stopping it..."
+                        docker stop "$container_id" >/dev/null 2>&1 || true
+                    else
+                        echo "  [skip] Port $port is held by the container runtime (OrbStack/Docker)."
+                        echo "         No matching container found. Free the port manually before retrying."
+                    fi
+                    continue
+                fi
+
+                ports_in_use+=("$port")
                 pids_to_kill+=("$pid")
                 echo "  [!] Port $port is in use by PID $pid"
                 echo "      Command: $cmd"

--- a/scripts/load-test/benchmark.sh
+++ b/scripts/load-test/benchmark.sh
@@ -29,11 +29,11 @@ MAX_VUS_SAT=200
 STEP_DUR_SAT=20s
 RAMP_DUR_SAT=5s
 
-# sandbox baseline (100m CPU provisioning — used for before/after diff)
+# sandbox baseline — measured 2026-05-24, current build with hot-path caching
 SANDBOX_BASELINE='{
-  "5":  {"rps":18.5,"rt_p95":200.3,"svr_avg":38.6,"svr_p95":108.8},
-  "12": {"rps":22.5,"rt_p95":509.8,"svr_avg":226.0,"svr_p95":398.4},
-  "20": {"rps":null,"rt_p95":null,"svr_avg":null,"svr_p95":null}
+  "5":  {"rps":25.0,"rt_p95":50.0,"svr_avg":3.5,"svr_p95":5.0},
+  "20": {"rps":94.5,"rt_p95":68.0,"svr_avg":5.7,"svr_p95":12.0},
+  "50": {"rps":218.0,"rt_p95":90.0,"svr_avg":13.0,"svr_p95":29.0}
 }'
 
 while [[ $# -gt 0 ]]; do

--- a/website/src/components/layout/AuthGuard.tsx
+++ b/website/src/components/layout/AuthGuard.tsx
@@ -37,7 +37,7 @@ export function AuthGuard() {
   const clearAuth = useAuthStore((s) => s.clearAuth)
   const setMerchantId = useMerchantStore((s) => s.setMerchantId)
 
-  const { data: me, error, isLoading } = useSWR<MeResponse>(
+  const { data: me, error, isValidating } = useSWR<MeResponse>(
     token && hasHydrated ? '/auth/me' : null,
     fetcher,
     { revalidateOnFocus: false, shouldRetryOnError: false },
@@ -51,21 +51,28 @@ export function AuthGuard() {
   }, [me, token, setAuth, setMerchantId])
 
   useEffect(() => {
-    if (!error) return
+    // Don't clear auth while SWR is revalidating — the stale error may be from a previous
+    // session and the fresh request (with the new token) could still succeed.
+    if (!error || isValidating) return
     const statusCode = (error as { status?: number }).status
     if (statusCode === 401 || statusCode === 403) {
       clearAuth()
       setMerchantId('')
     }
-  }, [error, clearAuth, setMerchantId])
+  }, [error, isValidating, clearAuth, setMerchantId])
 
   if (!hasHydrated) return <SessionSpinner label="Restoring session" />
   if (!token) return <Navigate to="/login" replace />
-  if (isLoading) return <SessionSpinner label="Validating session" />
+  if (!me && !error) return <SessionSpinner label="Validating session" />
 
   if (error) {
     const statusCode = (error as { status?: number }).status
-    if (statusCode === 401 || statusCode === 403) return <Navigate to="/login" replace />
+    if (statusCode === 401 || statusCode === 403) {
+      // Wait for the in-flight revalidation before rejecting — the stale error may be from
+      // a prior expired session and the current token could be valid.
+      if (isValidating) return <SessionSpinner label="Validating session" />
+      return <Navigate to="/login" replace />
+    }
     // Transient failure (network/5xx): keep the session, let the user through.
   }
 

--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -2,17 +2,12 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import useSWR from 'swr'
 import {
-  Area,
-  AreaChart,
   Bar,
   BarChart,
   CartesianGrid,
-  Cell,
   Legend,
   Line,
   LineChart,
-  Pie,
-  PieChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -278,6 +273,7 @@ function formatPercentPointDelta(value: number | undefined, digits = 1) {
   return `${sign}${formatNumber(Math.abs(value), digits)} pp`
 }
 
+
 function readChartValue(row: Record<string, number | null>, key: string) {
   const value = row[key]
   return typeof value === 'number' && Number.isFinite(value) ? value : 0
@@ -520,37 +516,6 @@ function InfoButton({ content }: { content: InfoContent }) {
   )
 }
 
-function HitsCard({
-  label,
-  value,
-  subtitle,
-  eyebrow = 'Endpoint hits',
-}: {
-  label: string
-  value: number
-  subtitle?: string
-  eyebrow?: string
-}) {
-  return (
-    <Card className="h-full overflow-hidden">
-      <CardBody className="flex h-full min-h-[150px] flex-col justify-between">
-        <div className="space-y-2">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
-            {eyebrow}
-          </p>
-          <p className="text-lg font-semibold text-slate-900 dark:text-white">{label}</p>
-        </div>
-        <div className="flex items-end justify-between gap-4">
-          <p className="text-5xl font-semibold tracking-tight text-slate-950 dark:text-white">
-            {formatNumber(value, 0)}
-          </p>
-          {subtitle ? <Badge variant="blue">{subtitle}</Badge> : null}
-        </div>
-      </CardBody>
-    </Card>
-  )
-}
-
 function RoutingAlignmentCard({
   summary,
   comparisonRows,
@@ -747,6 +712,18 @@ function analyticsRouteLabel(route: string) {
   return route
 }
 
+function authRateColor(rate: number) {
+  if (rate >= 0.85) return 'text-emerald-600 dark:text-emerald-400'
+  if (rate >= 0.70) return 'text-amber-500 dark:text-amber-400'
+  return 'text-red-500 dark:text-red-400'
+}
+
+function srBadgeVariant(valuePercent: number): BadgeVariant {
+  if (valuePercent >= 85) return 'green'
+  if (valuePercent >= 70) return 'orange'
+  return 'red'
+}
+
 function SmartRetrySection({ stats }: { stats: SmartRetryStats | null }) {
   if (!stats || stats.retried_count === 0) return null
   const recoveryRate = Math.round((stats.recovered_count / stats.retried_count) * 100)
@@ -869,8 +846,8 @@ export function AnalyticsPage() {
   const [range, setRange] = useState<AnalyticsRangeValue>('1d')
   const [view, setView] = useState<AnalyticsView>('transactions')
   const [routingFilters, setRoutingFilters] = useState<RoutingFilters>(EMPTY_ROUTING_FILTERS)
-  const [connectorFiltersOpen, setConnectorFiltersOpen] = useState(false)
   const [customRangeOpen, setCustomRangeOpen] = useState(false)
+  const [connectorFiltersOpen, setConnectorFiltersOpen] = useState(false)
   const [routingAlignmentOpen, setRoutingAlignmentOpen] = useState(false)
   const [showAllFilters, setShowAllFilters] = useState(false)
   const [previewListPage, setPreviewListPage] = useState(1)
@@ -1133,6 +1110,13 @@ export function AnalyticsPage() {
     () => routeHits.filter((item) => item.route !== '/rule_evaluate'),
     [routeHits],
   )
+  const overallAuthRate = useMemo(() => {
+    const scores = overview.data?.top_scores ?? []
+    const totalTx = scores.reduce((sum, s) => sum + s.transaction_count, 0)
+    if (!totalTx) return null
+    const weightedSum = scores.reduce((sum, s) => sum + s.score_value * s.transaction_count, 0)
+    return weightedSum / totalTx
+  }, [overview.data])
   const ruleEvaluateHits = useMemo(
     () => routeHits.find((item) => item.route === '/rule_evaluate')?.count || 0,
     [routeHits],
@@ -1164,6 +1148,15 @@ export function AnalyticsPage() {
       .map(([status, count]) => ({ status, count }))
       .sort((left, right) => right.count - left.count)
   }, [previewRows])
+  const previewStatusTotal = useMemo(
+    () => previewStatusSummary.reduce((sum, item) => sum + item.count, 0),
+    [previewStatusSummary],
+  )
+  const ruleMatchRate = useMemo(() => {
+    if (!previewStatusTotal) return null
+    const successCount = previewStatusSummary.find((s) => s.status === 'success')?.count ?? 0
+    return successCount / previewStatusTotal
+  }, [previewStatusSummary, previewStatusTotal])
   const chartBucketSize = useMemo(
     () => bucketSizeForWindow(range, activeQueryWindow),
     [activeQueryWindow, range],
@@ -1217,29 +1210,10 @@ export function AnalyticsPage() {
     1,
     Math.ceil(previewListTotalResults / PREVIEW_LIST_PAGE_SIZE),
   )
-  const previewListStart = previewListTotalResults
-    ? (previewListPage - 1) * PREVIEW_LIST_PAGE_SIZE + 1
-    : 0
-  const previewListEnd = previewListTotalResults
-    ? previewListStart + previewListRows.length - 1
-    : 0
   const previewGatewaysTouched = previewGatewaySummary.filter(
     (item) => item.gateway !== 'No gateway selected',
   ).length
   const previewGatewayMaxCount = previewGatewaySummary[0]?.count || 1
-  const previewGatewayMixData = useMemo(() => {
-    const total = previewGatewaySummary.reduce((sum, item) => sum + item.count, 0)
-
-    return previewGatewaySummary.map((item, index) => ({
-      name: item.gateway,
-      value: item.count,
-      percentage: total ? (item.count / total) * 100 : 0,
-      color:
-        item.gateway === 'No gateway selected'
-          ? '#64748b'
-          : CHART_COLORS[index % CHART_COLORS.length],
-    }))
-  }, [previewGatewaySummary])
   const previewIngestionPending =
     ruleEvaluateHits > 0 &&
     !previewTrace.error &&
@@ -1575,15 +1549,6 @@ export function AnalyticsPage() {
     routingAlignmentSummary.volumeLeader?.gateway,
   ])
 
-  const activeFilterSummary = useMemo(() => {
-    const parts = availableFilters.dimensions.flatMap((dimension) => {
-      const value = routingFilters.dimensions[dimension.key]
-      return value ? [`${dimension.label}: ${value}`] : []
-    })
-    if (routingFilters.gateways.length) parts.push(routingFilters.gateways.join(', '))
-    return parts.length ? parts.join(' / ') : 'All routing dimensions'
-  }, [availableFilters.dimensions, routingFilters])
-
   const visibleDimensions = useMemo(() => {
     if (showAllFilters || availableFilters.dimensions.length <= MAX_VISIBLE_DIMENSIONS) {
       return availableFilters.dimensions
@@ -1794,17 +1759,45 @@ export function AnalyticsPage() {
       <div className="relative">
       {view === 'transactions' ? (
         <div className="space-y-6">
-          <section className="space-y-5">
-            <div className="grid gap-5 lg:grid-cols-2">
-              {transactionRouteHits.map((item) => (
-                <HitsCard
-                  key={item.route}
-                  label={analyticsRouteLabel(item.route)}
-                  value={item.count}
-                />
-              ))}
-            </div>
-          </section>
+          <Card>
+            <CardBody>
+              <div className="grid gap-6 sm:grid-cols-3">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
+                    Overall auth rate
+                  </p>
+                  {overallAuthRate !== null ? (
+                    <>
+                      <p className={`mt-2 text-4xl font-semibold tabular-nums ${authRateColor(overallAuthRate)}`}>
+                        {formatPercent(overallAuthRate)}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                        Weighted across all gateways
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <p className="mt-2 text-4xl font-semibold text-slate-300 dark:text-slate-700">—</p>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">No score data yet</p>
+                    </>
+                  )}
+                </div>
+                {transactionRouteHits.map((item) => (
+                  <div key={item.route}>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
+                      {analyticsRouteLabel(item.route)}
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold tabular-nums text-slate-950 dark:text-white">
+                      {formatNumber(item.count, 0)}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                      {item.route === '/decide_gateway' ? 'routing decisions' : 'score feedback calls'}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </CardBody>
+          </Card>
 
           <RoutingAlignmentCard
             summary={routingAlignmentSummary}
@@ -1831,8 +1824,8 @@ export function AnalyticsPage() {
           {gatewayShareData.rows.length ? (
             <div className="h-80">
               <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={gatewayShareData.rows}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                <BarChart data={gatewayShareData.rows} barCategoryGap="35%" barGap={3}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" vertical={false} />
                   <XAxis dataKey="bucket_ms" tickFormatter={bucketTickFormatter} tick={{ fontSize: 11 }} />
                   <YAxis tick={{ fontSize: 11 }} />
                   <Tooltip
@@ -1844,18 +1837,15 @@ export function AnalyticsPage() {
                   />
                   <Legend />
                   {gatewayShareData.gateways.map((gateway, index) => (
-                    <Area
+                    <Bar
                       key={gateway}
-                      type="monotone"
                       dataKey={gateway}
-                      stroke={CHART_COLORS[index % CHART_COLORS.length]}
-                      strokeWidth={3}
                       fill={CHART_COLORS[index % CHART_COLORS.length]}
-                      fillOpacity={0.14}
                       name={gateway}
+                      radius={[3, 3, 0, 0]}
                     />
                   ))}
-                </AreaChart>
+                </BarChart>
               </ResponsiveContainer>
             </div>
           ) : (
@@ -1876,9 +1866,6 @@ export function AnalyticsPage() {
               </h2>
               <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
                 Historical connector success rate for the active filters; compare it with selected volume above.
-              </p>
-              <p className="mt-2 text-xs font-medium text-slate-600 dark:text-[#b3b3bd]">
-                Active filters: {activeFilterSummary}
               </p>
             </div>
             <div className="flex items-center gap-2">
@@ -2034,7 +2021,7 @@ export function AnalyticsPage() {
           {latestConnectorSummary.length ? (
             <div className="flex flex-wrap gap-2">
               {latestConnectorSummary.map((item) => (
-                <Badge key={item.gateway} variant="blue">
+                <Badge key={item.gateway} variant={srBadgeVariant(item.value)}>
                   {item.gateway}: {formatPercent(item.value)}
                 </Badge>
               ))}
@@ -2088,33 +2075,52 @@ export function AnalyticsPage() {
         </div>
       ) : (
         <div className="space-y-6">
-          <section className="space-y-5">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Rule-based activity</h2>
-                <p className="mt-1 text-sm text-slate-500 dark:text-[#8a8a93]">
-                  Routing decisions from <code>/routing/evaluate</code>, kept separate from auth-rate transaction routing and gateway scoring.
-                </p>
+          <Card>
+            <CardBody>
+              <div className="grid gap-6 sm:grid-cols-3">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
+                    Rule match rate
+                  </p>
+                  {ruleMatchRate !== null ? (
+                    <>
+                      <p className={`mt-2 text-4xl font-semibold tabular-nums ${authRateColor(ruleMatchRate)}`}>
+                        {formatPercent(ruleMatchRate)}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                        Decisions matched to a configured rule
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <p className="mt-2 text-4xl font-semibold text-slate-300 dark:text-slate-700">—</p>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">No decision data yet</p>
+                    </>
+                  )}
+                </div>
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
+                    Rule Evaluate
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold tabular-nums text-slate-950 dark:text-white">
+                    {formatNumber(ruleEvaluateHits, 0)}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">routing decisions</p>
+                </div>
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
+                    Gateways active
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold tabular-nums text-slate-950 dark:text-white">
+                    {previewGatewaysTouched}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">unique connectors selected</p>
+                </div>
               </div>
-              <InfoButton content={CARD_INFO.preview_hits} />
-            </div>
+            </CardBody>
+          </Card>
 
-            <div className="grid gap-5 lg:grid-cols-2">
-              <HitsCard
-                label="Rule Evaluate"
-                value={ruleEvaluateHits}
-              />
-              <HitsCard
-                label="Gateways touched"
-                value={previewGatewaysTouched}
-                subtitle="Across recent rule decisions"
-                eyebrow="Decision coverage"
-              />
-            </div>
-          </section>
-
-          <div className="grid gap-5 xl:grid-cols-2">
-            <Card className="overflow-visible">
+          <Card className="overflow-visible">
               <CardHeader>
                 <div className="flex items-start justify-between gap-3">
                   <div>
@@ -2132,8 +2138,8 @@ export function AnalyticsPage() {
                 {previewConnectorSeriesData.gateways.length ? (
                   <div className="h-80">
                     <ResponsiveContainer width="100%" height="100%">
-                      <BarChart data={previewConnectorSeriesData.rows} barGap={6}>
-                        <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                      <BarChart data={previewConnectorSeriesData.rows} barCategoryGap="35%" barGap={3}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" vertical={false} />
                         <XAxis dataKey="bucket_ms" tickFormatter={bucketTickFormatter} tick={{ fontSize: 11 }} />
                         <YAxis tick={{ fontSize: 11 }} />
                         <Tooltip
@@ -2148,7 +2154,6 @@ export function AnalyticsPage() {
                           <Bar
                             key={gateway}
                             dataKey={gateway}
-                            stackId="preview-connectors"
                             fill={
                               gateway === 'No gateway selected'
                                 ? '#64748b'
@@ -2175,114 +2180,14 @@ export function AnalyticsPage() {
               </CardBody>
             </Card>
 
-            <Card className="overflow-visible">
-              <CardHeader>
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <h2 className="text-sm font-semibold text-slate-800 dark:text-white">
-                      Gateway selection mix
-                    </h2>
-                    <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                      Connector share for selected rule decisions.
-                    </p>
-                  </div>
-                  <InfoButton content={CARD_INFO.preview_share} />
-                </div>
-              </CardHeader>
-              <CardBody>
-                {previewGatewayMixData.length ? (
-                  <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px]">
-                    <div className="relative h-80">
-                      <ResponsiveContainer width="100%" height="100%">
-                        <PieChart>
-                          <Tooltip
-                            formatter={(value: unknown, name: string | number, item: { payload?: { percentage?: number } }) => [
-                              `${formatNumber(value as number, 0)} decisions`,
-                              `${String(name)} (${formatPercent(item.payload?.percentage || 0)})`,
-                            ]}
-                            contentStyle={CHART_TOOLTIP_STYLE}
-                            labelStyle={CHART_TOOLTIP_LABEL_STYLE}
-                            itemStyle={CHART_TOOLTIP_ITEM_STYLE}
-                            wrapperStyle={CHART_TOOLTIP_WRAPPER_STYLE}
-                          />
-                          <Legend />
-                          <Pie
-                            data={previewGatewayMixData}
-                            dataKey="value"
-                            nameKey="name"
-                            innerRadius={72}
-                            outerRadius={108}
-                            paddingAngle={3}
-                          >
-                            {previewGatewayMixData.map((entry) => (
-                              <Cell key={entry.name} fill={entry.color} />
-                            ))}
-                          </Pie>
-                        </PieChart>
-                      </ResponsiveContainer>
-                      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
-                          Sample size
-                        </p>
-                        <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">
-                          {previewRows.length}
-                        </p>
-                        <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                          decisions
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="space-y-3">
-                      {previewGatewayMixData.map((item) => (
-                        <div
-                          key={item.name}
-                          className="rounded-[20px] border border-slate-200 bg-white/80 px-4 py-3 dark:border-[#1d1d23] dark:bg-[#0c0c0e]"
-                        >
-                          <div className="flex items-center justify-between gap-3">
-                            <div className="flex items-center gap-2">
-                              <span
-                                className="h-2.5 w-2.5 rounded-full"
-                                style={{ backgroundColor: item.color }}
-                              />
-                              <p className="text-sm font-medium text-slate-900 dark:text-white">
-                                {item.name}
-                              </p>
-                            </div>
-                            <p className="text-xs font-semibold text-slate-500 dark:text-[#8a8a93]">
-                              {item.value}
-                            </p>
-                          </div>
-                          <p className="mt-2 text-xs text-slate-500 dark:text-[#8a8a93]">
-                            {formatPercent(item.percentage)} of decisions
-                          </p>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ) : previewIngestionPending ? (
-                  <PendingState
-                    title="Building decision connector mix"
-                    body="Recent rule decisions are still being processed. This card will update automatically once decision rows are available."
-                  />
-                ) : (
-                  <EmptyState
-                    title="No decision connector mix yet"
-                    body="Rule decisions need to return gateway selections before the mix chart can render."
-                  />
-                )}
-              </CardBody>
-            </Card>
-          </div>
-
           <div className="grid items-stretch gap-5 xl:grid-cols-2">
             <Card className="h-full overflow-visible">
               <CardHeader>
                 <div className="flex items-start justify-between gap-3">
                   <div>
-                    <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Recent rule decisions</h2>
+                    <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Recent decisions</h2>
                     <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                      Decisions captured from <code>/routing/evaluate</code>. This does not affect transaction scoring.
+                      Latest decisions from <code>/routing/evaluate</code>.
                     </p>
                   </div>
                   <Badge variant="purple">
@@ -2291,96 +2196,41 @@ export function AnalyticsPage() {
                 </div>
               </CardHeader>
               <CardBody>
-                {!previewList.data && previewList.isLoading ? (
-                  <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-[#8a8a93]">
-                    <Spinner size={16} />
-                    Loading rule decisions…
-                  </div>
-                ) : previewList.error && !previewList.data ? (
-                  <ErrorMessage error={previewList.error.message} />
-                ) : previewListRows.length ? (
-                  <div className="space-y-4">
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <p className="text-xs text-slate-500 dark:text-[#8a8a93]">
-                        Showing {previewListStart}-{previewListEnd} of {previewListTotalResults}
-                      </p>
-                      {previewList.isLoading ? (
-                        <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-[#8a8a93]">
-                          <Spinner size={14} />
-                          Loading page…
-                        </div>
-                      ) : null}
-                    </div>
-                    <div className="max-h-[520px] space-y-3 overflow-y-auto pr-1">
-                      {previewListRows.map((row) => (
+                {previewRows.length ? (
+                  <div className="space-y-2">
+                    {previewRows.slice(0, 10).map((row) => {
+                      const statusVariant: BadgeVariant = row.latest_status?.toLowerCase().includes('fail') ? 'red' : row.latest_status === 'default_selection' ? 'orange' : 'green'
+                      return (
                         <div
                           key={row.lookup_key}
-                          className="rounded-[22px] border border-slate-200 bg-white/90 px-4 py-4 dark:border-[#1d1d23] dark:bg-[#0c0c0e]"
+                          className="flex items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-slate-50/60 px-3 py-2.5 dark:border-[#1d1d23] dark:bg-[#0c0c0e]"
                         >
-                          <div className="flex flex-wrap items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
-                                {row.payment_id || row.request_id || row.lookup_key}
-                              </p>
-                              <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                                {(row.merchant_id || 'unknown merchant')} · {formatDateTime(row.last_seen_ms)}
-                              </p>
-                            </div>
-                            <Badge variant="purple">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <Badge variant={statusVariant}>
                               {row.latest_status || 'decision'}
                             </Badge>
+                            {row.latest_gateway ? (
+                              <span className="truncate text-xs font-medium text-slate-700 dark:text-[#c8d3e6]">
+                                {row.latest_gateway}
+                              </span>
+                            ) : null}
                           </div>
-                          <div className="mt-3 flex flex-wrap gap-2">
-                            <Badge variant="blue">Rule Evaluate</Badge>
-                            {row.latest_gateway ? <Badge variant="green">{row.latest_gateway}</Badge> : null}
-                            <Badge variant="gray">{row.event_count} events</Badge>
-                          </div>
+                          <span className="shrink-0 text-xs text-slate-400 dark:text-[#5a6478]">
+                            {formatDateTime(row.last_seen_ms)}
+                          </span>
                         </div>
-                      ))}
-                    </div>
-                    {previewListTotalPages > 1 ? (
-                      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4 dark:border-[#1d1d23]">
-                        <p className="text-xs text-slate-500 dark:text-[#8a8a93]">
-                          Page {previewListPage} of {previewListTotalPages}
-                        </p>
-                        <div className="flex items-center gap-2">
-                          <Button
-                            size="sm"
-                            variant="secondary"
-                            onClick={() =>
-                              setPreviewListPage((current) => Math.max(1, current - 1))
-                            }
-                            disabled={previewListPage === 1 || previewList.isLoading}
-                          >
-                            Previous
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="secondary"
-                            onClick={() =>
-                              setPreviewListPage((current) =>
-                                Math.min(previewListTotalPages, current + 1),
-                              )
-                            }
-                            disabled={
-                              previewListPage >= previewListTotalPages || previewList.isLoading
-                            }
-                          >
-                            Next
-                          </Button>
-                        </div>
-                      </div>
-                    ) : null}
+                      )
+                    })}
                   </div>
                 ) : previewIngestionPending ? (
                   <PendingState
-                    title="Waiting for decision rows"
-                    body="Recent /routing/evaluate calls were recorded. Detailed rule decision rows will appear as soon as they are ready."
+                    title="Processing recent decisions"
+                    body="Rule evaluate calls were received. Decision rows will appear as soon as they are ready."
                   />
                 ) : (
                   <EmptyState
-                    title="No rule-based activity yet"
-                    body="Rule-based activity will appear after /routing/evaluate calls in this window."
+                    title="No decisions yet"
+                    body="Recent rule decisions will appear after /routing/evaluate calls in this window."
                   />
                 )}
               </CardBody>
@@ -2434,20 +2284,36 @@ export function AnalyticsPage() {
               <Card className="h-full overflow-visible">
                 <CardHeader>
                   <div>
-                    <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Recent decision outcomes</h2>
+                    <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Decision outcomes</h2>
                     <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                      Status mix from the loaded decisions.
+                      How decisions resolved — rule match vs. default fallback.
                     </p>
                   </div>
                 </CardHeader>
                 <CardBody>
                   {previewStatusSummary.length ? (
-                    <div className="flex flex-wrap gap-2">
-                      {previewStatusSummary.map((item) => (
-                        <Badge key={item.status} variant={item.status.toLowerCase().includes('fail') ? 'red' : item.status === 'default_selection' ? 'orange' : 'purple'}>
-                          {item.status} · {item.count}
-                        </Badge>
-                      ))}
+                    <div className="space-y-4">
+                      {previewStatusSummary.map((item) => {
+                        const pct = previewStatusTotal ? (item.count / previewStatusTotal) * 100 : 0
+                        const variant: BadgeVariant = item.status.toLowerCase().includes('fail') ? 'red' : item.status === 'default_selection' ? 'orange' : 'green'
+                        const barColor = variant === 'green' ? '#22c55e' : variant === 'orange' ? '#f97316' : '#ef4444'
+                        return (
+                          <div key={item.status} className="space-y-1.5">
+                            <div className="flex items-center justify-between gap-3">
+                              <Badge variant={variant}>{item.status}</Badge>
+                              <span className="text-xs font-semibold tabular-nums text-slate-900 dark:text-white">
+                                {item.count} <span className="font-normal text-slate-500 dark:text-[#8a8a93]">({formatPercent(pct)})</span>
+                              </span>
+                            </div>
+                            <div className="h-1.5 overflow-hidden rounded-full bg-slate-100 dark:bg-[#141822]">
+                              <div
+                                className="h-full rounded-full"
+                                style={{ width: `${pct}%`, backgroundColor: barColor }}
+                              />
+                            </div>
+                          </div>
+                        )
+                      })}
                     </div>
                   ) : previewIngestionPending ? (
                     <PendingState

--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -718,9 +718,9 @@ function authRateColor(rate: number) {
   return 'text-red-500 dark:text-red-400'
 }
 
-function srBadgeVariant(value: number): BadgeVariant {
-  if (value >= 0.85) return 'green'
-  if (value >= 0.70) return 'orange'
+function srBadgeVariant(valuePercent: number): BadgeVariant {
+  if (valuePercent >= 85) return 'green'
+  if (valuePercent >= 70) return 'orange'
   return 'red'
 }
 

--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -718,9 +718,9 @@ function authRateColor(rate: number) {
   return 'text-red-500 dark:text-red-400'
 }
 
-function srBadgeVariant(valuePercent: number): BadgeVariant {
-  if (valuePercent >= 85) return 'green'
-  if (valuePercent >= 70) return 'orange'
+function srBadgeVariant(value: number): BadgeVariant {
+  if (value >= 0.85) return 'green'
+  if (value >= 0.70) return 'orange'
   return 'red'
 }
 
@@ -2199,7 +2199,7 @@ export function AnalyticsPage() {
                 {previewRows.length ? (
                   <div className="space-y-2">
                     {previewRows.slice(0, 10).map((row) => {
-                      const statusVariant: BadgeVariant = row.latest_status?.toLowerCase().includes('fail') ? 'red' : row.latest_status === 'default_selection' ? 'orange' : 'green'
+                      const statusVariant: BadgeVariant = row.latest_status?.toLowerCase()?.includes('fail') ? 'red' : row.latest_status === 'default_selection' ? 'orange' : 'green'
                       return (
                         <div
                           key={row.lookup_key}

--- a/website/src/components/pages/OverviewPage.tsx
+++ b/website/src/components/pages/OverviewPage.tsx
@@ -1,21 +1,17 @@
-import type { ElementType, ReactNode } from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import useSWR from 'swr'
 import {
-  Activity,
-  AlertCircle,
-  BarChart3,
+  BookOpen,
   CheckCircle2,
-  Clock3,
+  ChevronRight,
   GitBranch,
   Network,
-  ShieldCheck,
-  Sparkles,
-  XCircle,
+  TrendingUp,
 } from 'lucide-react'
 import { useMerchantStore } from '../../store/merchantStore'
 import { useAuthStore } from '../../store/authStore'
-import { apiFetch, apiPost, fetcher } from '../../lib/api'
+import { apiPost, fetcher } from '../../lib/api'
 import {
   AnalyticsRange,
   AnalyticsOverviewResponse,
@@ -25,7 +21,6 @@ import {
 } from '../../types/api'
 import { Badge } from '../ui/Badge'
 import { Card as GlassCard, SurfaceLabel } from '../ui/Card'
-import { Spinner } from '../ui/Spinner'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
 
 const OVERVIEW_RANGE_OPTIONS: {
@@ -43,15 +38,14 @@ const OVERVIEW_RANGE_OPTIONS: {
 ]
 
 function useHealth() {
-  const [status, setStatus] = useState<'up' | 'down' | 'loading'>('loading')
-
-  useEffect(() => {
-    apiFetch<{ message: string }>('/health')
-      .then(() => setStatus('up'))
-      .catch(() => setStatus('down'))
-  }, [])
-
-  return status
+  const { data, error } = useSWR<{ message: string }>(
+    '/health',
+    fetcher,
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  )
+  if (data) return 'up' as const
+  if (error) return 'down' as const
+  return 'loading' as const
 }
 
 function formatCompactNumber(value: number | undefined) {
@@ -72,65 +66,18 @@ function healthLabel(status: 'up' | 'down' | 'loading') {
   return 'Checking'
 }
 
-function HeroStat({
-  label,
-  value,
-  detail,
-}: {
-  label: string
-  value: string
-  detail?: string
-}) {
-  const hasDetail = Boolean(detail)
-
-  return (
-    <div className={`min-h-[118px] rounded-[22px] border border-slate-200 bg-white px-4 py-4 dark:border-[#2a303a] dark:bg-[#161b24] ${hasDetail ? '' : 'flex flex-col justify-center'}`}>
-      <SurfaceLabel>{label}</SurfaceLabel>
-      <p className="mt-3 text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">
-        {value}
-      </p>
-      {detail ? <p className="mt-1 text-sm text-slate-500 dark:text-[#b2bdd1]">{detail}</p> : null}
-    </div>
-  )
+function timeAgo(ms: number) {
+  const diff = Date.now() - ms
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return `${Math.floor(diff / 86_400_000)}d ago`
 }
 
-function MetricCard({
-  icon: Icon,
-  label,
-  value,
-  detail,
-}: {
-  icon: ElementType
-  label: string
-  value: ReactNode
-  detail?: string
-}) {
-  const hasDetail = Boolean(detail)
-
-  return (
-    <GlassCard className="h-full p-5">
-      <div className={`flex min-h-[118px] justify-between gap-4 ${hasDetail ? 'items-start' : 'items-center'}`}>
-        <div>
-          <SurfaceLabel>{label}</SurfaceLabel>
-          <p className="mt-4 text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">
-            {value}
-          </p>
-          {detail ? <p className="mt-2 text-sm text-slate-500 dark:text-[#b2bdd1]">{detail}</p> : null}
-        </div>
-        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 dark:border-[#2a303a] dark:bg-[#161b24]">
-          <Icon className="h-5 w-5 text-brand-600 dark:text-sky-300" />
-        </div>
-      </div>
-    </GlassCard>
-  )
-}
-
-function formatRouteLabel(route: string) {
-  return route
-    .replace(/_/g, '-')
-    .replace(/^\/routing-evaluate$/, '/routing/evaluate')
-    .replace(/^\/decide-gateway$/, '/decide-gateway')
-    .replace(/^\/update-gateway$/, '/update-gateway')
+function scoreColor(score: number) {
+  if (score >= 0.85) return { dot: 'bg-emerald-500', text: 'text-emerald-600 dark:text-emerald-400' }
+  if (score >= 0.70) return { dot: 'bg-amber-500', text: 'text-amber-600 dark:text-amber-400' }
+  return { dot: 'bg-red-500', text: 'text-red-600 dark:text-red-400' }
 }
 
 function EmptyWorkspace() {
@@ -151,7 +98,7 @@ function EmptyWorkspace() {
         <div className="space-y-5">
           {[
             {
-              icon: Activity,
+              icon: CheckCircle2,
               title: 'System status',
               text: 'Check whether the service is reachable.',
             },
@@ -161,7 +108,7 @@ function EmptyWorkspace() {
               text: 'See whether a strategy is configured.',
             },
             {
-              icon: BarChart3,
+              icon: Network,
               title: 'Gateway activity',
               text: 'View recent request distribution by gateway.',
             },
@@ -182,24 +129,6 @@ function EmptyWorkspace() {
   )
 }
 
-function RefreshingState({ label }: { label: string }) {
-  return (
-    <div className="overflow-hidden rounded-[22px] border border-brand-500/20 bg-white shadow-[0_10px_30px_-24px_rgba(0,105,237,0.9)] dark:bg-[#0c0c0e]">
-      <div className="h-2 w-full bg-brand-500/15">
-        <div className="h-full origin-left animate-[analytics-progress_1.8s_ease-in-out_infinite] rounded-r-full bg-brand-500" />
-      </div>
-      <div className="flex items-center justify-between gap-3 px-4 py-3">
-        <div className="flex items-center gap-2">
-          <Spinner size={14} />
-          <p className="text-sm font-medium text-slate-900 dark:text-white">{label}</p>
-        </div>
-        <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-brand-600 dark:text-brand-300">
-          Loading
-        </span>
-      </div>
-    </div>
-  )
-}
 
 type RuleConfigResponse = {
   merchant_id: string
@@ -248,6 +177,25 @@ export function OverviewPage() {
   const totalErrors =
     analyticsOverview.data?.top_errors?.reduce((sum, item) => sum + item.count, 0) || 0
 
+  const topErrors = analyticsOverview.data?.top_errors || []
+
+  const gatewayScores = useMemo(() => {
+    const map = new Map<string, { scoreSum: number; txSum: number }>()
+    for (const s of analyticsOverview.data?.top_scores || []) {
+      const e = map.get(s.gateway) ?? { scoreSum: 0, txSum: 0 }
+      e.scoreSum += s.score_value * s.transaction_count
+      e.txSum += s.transaction_count
+      map.set(s.gateway, e)
+    }
+    return Array.from(map.entries())
+      .map(([gateway, e]) => ({
+        gateway,
+        score: e.txSum > 0 ? e.scoreSum / e.txSum : 0,
+        txCount: e.txSum,
+      }))
+      .sort((a, b) => b.txCount - a.txCount)
+  }, [analyticsOverview.data])
+
   const gatewayUsage = useMemo(() => {
     const totals = new Map<string, number>()
 
@@ -271,11 +219,7 @@ export function OverviewPage() {
     OVERVIEW_RANGE_OPTIONS.find((option) => option.value === range) || OVERVIEW_RANGE_OPTIONS[1]
   const hasAuthRateConfig = Boolean(srConfig?.config?.data)
   const hasDebitRouting = debitRoutingFlag.isEnabled
-  const totalRouteHits = routeHits.reduce((sum, item) => sum + item.count, 0)
-  const topRouteHit = [...routeHits].sort((left, right) => right.count - left.count)[0] || null
-  const topRouteShare = topRouteHit && totalRouteHits ? (topRouteHit.count / totalRouteHits) * 100 : 0
   const configuredBasics = [
-    health === 'up',
     Boolean(activeRouting),
     hasAuthRateConfig,
     hasRuleBasedRouting,
@@ -284,38 +228,40 @@ export function OverviewPage() {
 
   const setupItems = [
     {
-      label: 'Service health',
-      description: health === 'up' ? 'Service is reachable.' : 'Please verify service health.',
-      state: health === 'up' ? 'Live' : health === 'down' ? 'Issue' : 'Checking',
-      icon: health === 'up' ? CheckCircle2 : health === 'down' ? XCircle : AlertCircle,
-    },
-    {
       label: 'Routing strategy',
-      description: activeRouting ? activeRouting.name : 'No active routing configured.',
+      description: activeRouting ? activeRouting.name : 'None configured',
       state: activeRouting ? 'Configured' : 'Not set',
       icon: GitBranch,
+      required: true,
+      href: '../routing',
     },
     {
       label: 'Auth-rate config',
-      description: hasAuthRateConfig ? 'Configured and available.' : 'Not configured yet.',
+      description: hasAuthRateConfig ? 'Configured' : 'Not configured',
       state: hasAuthRateConfig ? 'Configured' : 'Not set',
-      icon: ShieldCheck,
+      icon: TrendingUp,
+      required: true,
+      href: '../routing/sr',
     },
     {
       label: 'Rule-based routing',
-      description: hasRuleBasedRouting ? 'Enabled.' : 'Not enabled.',
+      description: hasRuleBasedRouting ? 'Enabled' : 'Not enabled',
       state: hasRuleBasedRouting ? 'Enabled' : 'Optional',
-      icon: Sparkles,
+      icon: BookOpen,
+      required: false,
+      href: '../routing/rules',
     },
     {
       label: 'Debit routing',
       description: debitRoutingFlag.isLoading
-        ? 'Checking debit-routing access.'
+        ? 'Checking…'
         : hasDebitRouting
-          ? 'Enabled.'
-          : 'Not enabled yet.',
-      state: debitRoutingFlag.isLoading ? 'Checking' : hasDebitRouting ? 'Enabled' : 'Not set',
+          ? 'Enabled'
+          : 'Not enabled',
+      state: debitRoutingFlag.isLoading ? 'Checking' : hasDebitRouting ? 'Enabled' : 'Optional',
       icon: Network,
+      required: false,
+      href: '../routing/debit',
     },
   ]
 
@@ -326,16 +272,16 @@ export function OverviewPage() {
     !analyticsLoading &&
     (analyticsOverview.isValidating || analyticsRouting.isValidating)
 
+  const gatewayColors = ['#38bdf8', '#60a5fa', '#22c55e', '#f59e0b']
+
   return (
     <div className="space-y-6 px-5 sm:px-6 lg:px-8 xl:px-10">
-      <header className="flex flex-wrap items-start justify-between gap-4">
-        <div className="space-y-2">
-          <div className="flex flex-wrap items-center gap-2">
-            <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Overview</h1>
-            {(analyticsOverview.data?.merchant_id || effectiveMerchantId) ? (
-              <Badge variant="blue">{analyticsOverview.data?.merchant_id || effectiveMerchantId}</Badge>
-            ) : null}
-          </div>
+      <header className="relative flex flex-wrap items-start justify-between gap-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Overview</h1>
+          {(analyticsOverview.data?.merchant_id || effectiveMerchantId) ? (
+            <Badge variant="blue">{analyticsOverview.data?.merchant_id || effectiveMerchantId}</Badge>
+          ) : null}
         </div>
 
         <div className="flex flex-wrap items-center gap-2 md:justify-end">
@@ -381,216 +327,281 @@ export function OverviewPage() {
             })}
           </div>
         </div>
+
+        {/* loading bar — sits at the bottom edge of the header, no layout shift */}
+        <div className={`absolute bottom-0 left-0 right-0 h-[2px] overflow-hidden transition-opacity duration-500 ${analyticsLoading || analyticsRefreshing ? 'opacity-100' : 'opacity-0'}`}>
+          <div className="h-full origin-left animate-[analytics-progress_1.8s_ease-in-out_infinite] bg-brand-500" />
+        </div>
       </header>
 
       {!effectiveMerchantId ? (
         <EmptyWorkspace />
       ) : (
         <>
-          {analyticsLoading ? (
-            <div>
-              <RefreshingState label={`Loading overview analytics for ${selectedWindow.detail.toLowerCase()}`} />
-            </div>
-          ) : null}
 
-          {analyticsRefreshing ? (
-            <div>
-              <RefreshingState label={`Refreshing overview analytics for ${selectedWindow.detail.toLowerCase()}`} />
-            </div>
-          ) : null}
+          {/* ── top stat row ─────────────────────────────────────── */}
+          <div className={`grid gap-4 sm:grid-cols-3 transition-opacity duration-200 ${analyticsRefreshing ? 'opacity-60' : 'opacity-100'}`}>
+            <GlassCard className="p-5">
+              <SurfaceLabel>Requests</SurfaceLabel>
+              <p className="mt-3 text-[2rem] font-semibold leading-none tracking-tight text-slate-950 dark:text-white">
+                {formatCompactNumber(decideHits)}
+              </p>
+              <p className="mt-2 text-xs text-slate-500 dark:text-[#8390a7]">
+                /decide-gateway · {selectedWindow.detail.toLowerCase()}
+              </p>
+            </GlassCard>
 
-          <div className={`grid gap-5 xl:grid-cols-[1.15fr_0.85fr] transition-opacity duration-200 ${analyticsRefreshing ? 'opacity-60' : 'opacity-100'}`}>
-              <GlassCard className="p-6 md:p-7">
-                <div className="flex h-full flex-col justify-between">
-                  <div>
-                    <SurfaceLabel>Traffic leader</SurfaceLabel>
-                    <div className="mt-5 flex flex-wrap items-end gap-4">
-                      <h2 className="text-[2.5rem] font-semibold tracking-[-0.05em] text-slate-950 md:text-[3rem] dark:text-white">
-                        {topGateway?.toUpperCase() || '--'}
-                      </h2>
-                      <div className="pb-2">
-                        <p className="text-lg font-medium text-slate-700 dark:text-[#d5dded]">
-                          {gatewayUsage[0] ? formatPercent(gatewayUsage[0].share) : '0%'}
-                        </p>
-                        <p className="mt-1 text-xs uppercase tracking-[0.16em] text-slate-500 dark:text-[#8390a7]">
-                          Share in selected window
+            <GlassCard className={`p-5 transition-colors ${totalErrors > 0 ? 'border-red-300/60 dark:border-red-500/30' : ''}`}>
+              <SurfaceLabel>Errors</SurfaceLabel>
+              <p className={`mt-3 text-[2rem] font-semibold leading-none tracking-tight ${totalErrors > 0 ? 'text-red-600 dark:text-red-400' : 'text-slate-950 dark:text-white'}`}>
+                {formatCompactNumber(totalErrors)}
+              </p>
+              <p className="mt-2 text-xs text-slate-500 dark:text-[#8390a7]">
+                {totalErrors > 0 ? 'Issues detected in window' : 'No issues in window'}
+              </p>
+            </GlassCard>
+
+            <GlassCard className="p-5">
+              <SurfaceLabel>Top gateway</SurfaceLabel>
+              <p className="mt-3 text-[2rem] font-semibold leading-none tracking-tight text-slate-950 dark:text-white">
+                {topGateway?.toUpperCase() || '—'}
+              </p>
+              <p className="mt-2 text-xs text-slate-500 dark:text-[#8390a7]">
+                {gatewayUsage[0] ? `${formatPercent(gatewayUsage[0].share)} of traffic` : 'No activity yet'}
+              </p>
+            </GlassCard>
+          </div>
+
+          {/* ── main content ─────────────────────────────────────── */}
+          <div className={`grid gap-6 xl:grid-cols-[1.1fr_0.9fr] transition-opacity duration-200 ${analyticsRefreshing ? 'opacity-60' : 'opacity-100'}`}>
+
+            {/* Gateway activity */}
+            <GlassCard className="p-6">
+              <div className="flex items-center justify-between gap-4">
+                <SurfaceLabel>Gateway activity</SurfaceLabel>
+                <Badge variant="blue">{selectedWindow.badge}</Badge>
+              </div>
+
+              <div className="mt-6 space-y-3">
+                {gatewayUsage.length ? (
+                  gatewayUsage.slice(0, 4).map((item, index) => (
+                    <div
+                      key={item.gateway}
+                      className="rounded-[20px] border border-slate-200 bg-slate-50/80 p-4 dark:border-[#2a303a] dark:bg-[#121720]"
+                    >
+                      <div className="flex items-center justify-between gap-4">
+                        <div className="flex items-center gap-3">
+                          <span
+                            className="h-2.5 w-2.5 flex-shrink-0 rounded-full"
+                            style={{ backgroundColor: gatewayColors[index] || gatewayColors[0] }}
+                          />
+                          <div>
+                            <p className="text-sm font-semibold text-slate-950 dark:text-white">
+                              {item.gateway.toUpperCase()}
+                            </p>
+                            <p className="mt-0.5 text-xs text-slate-500 dark:text-[#98a3b8]">
+                              {formatCompactNumber(item.count)} requests
+                            </p>
+                          </div>
+                        </div>
+                        <p className="text-sm font-semibold tabular-nums text-slate-950 dark:text-white">
+                          {formatPercent(item.share)}
                         </p>
                       </div>
+
+                      <div className="mt-3 h-1.5 rounded-full bg-slate-200 dark:bg-[#232933]">
+                        <div
+                          className="h-full rounded-full transition-all duration-500"
+                          style={{
+                            width: `${Math.max(4, item.share)}%`,
+                            backgroundColor: gatewayColors[index] || gatewayColors[0],
+                          }}
+                        />
+                      </div>
                     </div>
+                  ))
+                ) : (
+                  <div className="rounded-[20px] border border-dashed border-slate-200 px-5 py-12 text-center dark:border-[#2a303a]">
+                    <p className="text-sm font-semibold text-slate-950 dark:text-white">
+                      No gateway activity yet
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-500 dark:text-[#a6b0c3]">
+                      Traffic by gateway will appear here once requests flow through.
+                    </p>
                   </div>
-
-                  <div className="mt-8 grid gap-3 sm:grid-cols-3">
-                    <HeroStat
-                      label="Requests"
-                      value={formatCompactNumber(decideHits)}
-                    />
-                    <HeroStat label="Setup ready" value={`${configuredBasics}/5`} detail="Core basics configured" />
-                    <HeroStat label="Window" value={selectedWindow.label} />
-                  </div>
-                </div>
-              </GlassCard>
-
-              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
-                <MetricCard
-                  icon={GitBranch}
-                  label="Primary traffic path"
-                  value={topRouteHit ? formatRouteLabel(topRouteHit.route) : 'No traffic yet'}
-                  detail={
-                    topRouteHit
-                      ? `${formatCompactNumber(topRouteHit.count)} requests · ${topRouteShare.toFixed(topRouteShare >= 100 ? 0 : 1)}% of tracked routes`
-                      : 'No routing endpoint activity in this window'
-                  }
-                />
-                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-2">
-                  <MetricCard
-                    icon={Clock3}
-                    label="Requests"
-                    value={formatCompactNumber(decideHits)}
-                  />
-                  <MetricCard
-                    icon={BarChart3}
-                    label="Errors"
-                    value={formatCompactNumber(totalErrors)}
-                    detail={totalErrors ? 'Issues in selected window' : 'No issues in selected window'}
-                  />
-                </div>
+                )}
               </div>
-            </div>
+            </GlassCard>
 
-            <div className={`grid gap-6 xl:grid-cols-[1.02fr_0.98fr] transition-opacity duration-200 ${analyticsRefreshing ? 'opacity-60' : 'opacity-100'}`}>
-              <GlassCard className="p-6">
-                <div className="flex items-center justify-between gap-4">
-                  <div>
-                    <SurfaceLabel>Current setup</SurfaceLabel>
-                  </div>
-                  <Badge variant={configuredBasics >= 3 ? 'green' : 'orange'}>
-                    {configuredBasics}/5 ready
-                  </Badge>
-                </div>
+            {/* Setup */}
+            <GlassCard className="p-6">
+              <div className="flex items-center justify-between gap-4">
+                <SurfaceLabel>Setup</SurfaceLabel>
+                <Badge variant={configuredBasics >= 2 ? 'green' : 'orange'}>
+                  {configuredBasics}/4 ready
+                </Badge>
+              </div>
 
-                <div className="mt-5 grid gap-4 md:grid-cols-2">
-                  {setupItems.map((item) => (
-                    <GlassCard
-                      key={item.label}
-                      className="min-h-[158px] p-5"
-                    >
-                      <div className="flex h-full flex-col justify-between">
-                        <div className="flex items-start justify-between gap-4">
-                          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 dark:border-[#2a303a] dark:bg-[#161b24]">
-                            <item.icon className="h-5 w-5 text-brand-600 dark:text-sky-300" />
-                          </div>
-                          <Badge
-                            variant={
-                              item.state === 'Live' || item.state === 'Configured' || item.state === 'Enabled'
-                                ? 'green'
-                                : item.state === 'Issue'
-                                  ? 'red'
-                                  : item.state === 'Checking' || item.state === 'Optional'
-                                    ? 'gray'
-                                    : 'orange'
-                            }
-                          >
-                            {item.state}
-                          </Badge>
-                        </div>
+              {/* Progress bar */}
+              <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-slate-200 dark:bg-[#232933]">
+                <div
+                  className="h-full rounded-full bg-emerald-500 transition-all duration-500"
+                  style={{ width: `${(configuredBasics / 4) * 100}%` }}
+                />
+              </div>
 
-                        <div className="mt-6">
-                          <p className="text-sm font-semibold text-slate-950 dark:text-white">{item.label}</p>
-                          <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-[#a6b0c3]">
+              {/* Checklist */}
+              <div className="mt-4 divide-y divide-slate-100 dark:divide-[#1e2535]">
+                {setupItems.map((item) => {
+                  const iconColor =
+                    item.state === 'Issue'
+                      ? 'text-red-500'
+                      : item.state === 'Live' || item.state === 'Configured' || item.state === 'Enabled'
+                        ? 'text-emerald-500'
+                        : 'text-slate-400 dark:text-[#5a6a82]'
+                  const badgeVariant =
+                    item.state === 'Live' || item.state === 'Configured' || item.state === 'Enabled'
+                      ? 'green'
+                      : item.state === 'Issue'
+                        ? 'red'
+                        : item.state === 'Checking'
+                          ? 'gray'
+                          : item.required
+                            ? 'orange'
+                            : 'gray'
+                  const inner = (
+                    <>
+                      <div className="flex items-center gap-3 min-w-0">
+                        <item.icon className={`h-4 w-4 flex-shrink-0 ${iconColor}`} />
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-slate-900 dark:text-white">
+                            {item.label}
+                          </p>
+                          <p className="truncate text-xs text-slate-500 dark:text-[#8390a7]">
                             {item.description}
                           </p>
                         </div>
                       </div>
-                    </GlassCard>
-                  ))}
-                </div>
-              </GlassCard>
-
-              <GlassCard className="p-6">
-                <div className="flex items-center justify-between gap-4">
-                  <div>
-                    <SurfaceLabel>Gateway activity</SurfaceLabel>
-                  </div>
-                  <Badge variant="blue">{selectedWindow.badge}</Badge>
-                </div>
-
-                <div className="mt-6 space-y-4">
-                  {gatewayUsage.length ? (
-                    gatewayUsage.slice(0, 4).map((item, index) => (
-                      <div
-                        key={item.gateway}
-                        className="rounded-[24px] border border-slate-200 bg-slate-50/80 p-4 dark:border-[#2a303a] dark:bg-[#121720]"
-                      >
-                        <div className="flex items-center justify-between gap-4">
-                          <div className="flex items-center gap-3">
-                            <span
-                              className="h-2.5 w-2.5 rounded-full"
-                              style={{
-                                backgroundColor:
-                                  ['#38bdf8', '#60a5fa', '#22c55e', '#f59e0b'][index] || '#38bdf8',
-                              }}
-                            />
-                            <div>
-                              <p className="text-sm font-semibold text-slate-950 dark:text-white">
-                                {item.gateway.toUpperCase()}
-                              </p>
-                              <p className="mt-1 text-xs text-slate-500 dark:text-[#98a3b8]">
-                                {formatCompactNumber(item.count)} requests
-                              </p>
-                            </div>
-                          </div>
-                          <p className="text-sm font-medium text-slate-950 dark:text-white">
-                            {formatPercent(item.share)}
-                          </p>
-                        </div>
-
-                        <div className="mt-4 h-2 rounded-full bg-slate-200 dark:bg-[#232933]">
-                          <div
-                            className="h-full rounded-full bg-gradient-to-r from-sky-400 via-blue-500 to-cyan-300"
-                            style={{ width: `${Math.max(10, item.share)}%` }}
-                          />
-                        </div>
+                      <div className="flex flex-shrink-0 items-center gap-1.5">
+                        <Badge variant={badgeVariant}>{item.state}</Badge>
+                        {item.href && (
+                          <ChevronRight className="h-3.5 w-3.5 text-slate-400 dark:text-[#5a6a82]" />
+                        )}
                       </div>
-                    ))
-                  ) : (
-                    <div className="rounded-[24px] border border-dashed border-white/10 px-5 py-10 text-center">
-                      <p className="text-sm font-semibold text-slate-950 dark:text-white">
-                        No gateway activity yet
-                      </p>
-                      <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-[#a6b0c3]">
-                        Once requests start flowing, this section will show traffic by gateway.
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </GlassCard>
-            </div>
-
-            <div className={`transition-opacity duration-200 ${analyticsRefreshing ? 'opacity-60' : 'opacity-100'}`}>
-              <GlassCard className="p-6">
-                <SurfaceLabel>Quick summary</SurfaceLabel>
-                <div className="mt-5 space-y-4">
-                  {[
-                    { label: 'Signed-in merchant', value: analyticsOverview.data?.merchant_id || effectiveMerchantId || '--' },
-                    { label: 'Time window', value: selectedWindow.detail },
-                    { label: selectedWindow.summaryLabel, value: formatCompactNumber(totalErrors) },
-                    { label: 'Top gateway', value: topGateway?.toUpperCase() || 'No activity' },
-                  ].map((item) => (
-                    <div
+                    </>
+                  )
+                  const rowClass = 'flex items-center justify-between gap-3 py-3.5 rounded-lg -mx-2 px-2'
+                  return item.href ? (
+                    <Link
                       key={item.label}
-                      className="flex items-center justify-between gap-4 rounded-[20px] border border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-[#2a303a] dark:bg-[#121720]"
+                      to={item.href}
+                      relative="path"
+                      className={`${rowClass} transition-colors hover:bg-slate-50 dark:hover:bg-[#13192a]`}
                     >
-                      <span className="text-sm text-slate-600 dark:text-[#a6b0c3]">{item.label}</span>
-                      <span className="text-sm font-semibold text-slate-950 dark:text-white">
-                        {item.value}
-                      </span>
+                      {inner}
+                    </Link>
+                  ) : (
+                    <div key={item.label} className={rowClass}>
+                      {inner}
+                    </div>
+                  )
+                })}
+              </div>
+            </GlassCard>
+          </div>
+
+          {/* ── gateway health + errors ───────────────────────────── */}
+          <div className={`grid gap-6 xl:grid-cols-2 transition-opacity duration-200 ${analyticsRefreshing ? 'opacity-60' : 'opacity-100'}`}>
+
+            {/* Gateway health */}
+            <GlassCard className="p-6">
+              <div className="flex items-center justify-between gap-4">
+                <SurfaceLabel>Gateway health</SurfaceLabel>
+                <Badge variant="blue">{selectedWindow.badge}</Badge>
+              </div>
+
+              <div className="mt-5 space-y-2">
+                {gatewayScores.length ? (
+                  gatewayScores.slice(0, 5).map((gw) => {
+                    const color = scoreColor(gw.score)
+                    return (
+                      <div
+                        key={gw.gateway}
+                        className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-[#2a303a] dark:bg-[#121720]"
+                      >
+                        <span className={`h-2 w-2 flex-shrink-0 rounded-full ${color.dot}`} />
+                        <span className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-950 dark:text-white">
+                          {gw.gateway.toUpperCase()}
+                        </span>
+                        <span className={`text-sm font-semibold tabular-nums ${color.text}`}>
+                          {(gw.score * 100).toFixed(1)}%
+                        </span>
+                      </div>
+                    )
+                  })
+                ) : (
+                  <div className="rounded-xl border border-dashed border-slate-200 px-5 py-10 text-center dark:border-[#2a303a]">
+                    <p className="text-sm font-semibold text-slate-950 dark:text-white">No score data yet</p>
+                    <p className="mt-1.5 text-xs text-slate-500 dark:text-[#a6b0c3]">
+                      SR scores appear once gateways handle traffic.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </GlassCard>
+
+            {/* Recent errors */}
+            <GlassCard className={`p-6 transition-colors ${totalErrors > 0 ? 'border-red-300/40 dark:border-red-500/20' : ''}`}>
+              <div className="flex items-center justify-between gap-4">
+                <SurfaceLabel>Recent errors</SurfaceLabel>
+                {totalErrors > 0 ? (
+                  <Badge variant="red">{formatCompactNumber(totalErrors)} total</Badge>
+                ) : (
+                  <Badge variant="green">Clean</Badge>
+                )}
+              </div>
+
+              {topErrors.length ? (
+                <div className="mt-4 divide-y divide-slate-100 dark:divide-[#1e2535]">
+                  {topErrors.slice(0, 5).map((err, index) => (
+                    <div key={index} className="flex items-start justify-between gap-3 py-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="rounded bg-red-50 px-1.5 py-0.5 font-mono text-[11px] font-medium text-red-700 dark:bg-red-500/10 dark:text-red-400">
+                            {err.error_code}
+                          </span>
+                          <span className="truncate text-xs text-slate-500 dark:text-[#8390a7]">
+                            {err.route}
+                          </span>
+                        </div>
+                        <p className="mt-1 truncate text-xs text-slate-500 dark:text-[#8390a7]">
+                          {err.error_message}
+                        </p>
+                      </div>
+                      <div className="flex-shrink-0 text-right">
+                        <p className="text-sm font-semibold tabular-nums text-slate-950 dark:text-white">
+                          {formatCompactNumber(err.count)}
+                        </p>
+                        <p className="text-[11px] text-slate-400 dark:text-[#5a6a82]">
+                          {timeAgo(err.last_seen_ms)}
+                        </p>
+                      </div>
                     </div>
                   ))}
                 </div>
-              </GlassCard>
-            </div>
-          </>
-        )}
+              ) : (
+                <div className="mt-5 flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 px-5 py-10 text-center dark:border-[#2a303a]">
+                  <CheckCircle2 className="h-8 w-8 text-emerald-500" />
+                  <p className="mt-3 text-sm font-semibold text-slate-950 dark:text-white">No errors in window</p>
+                  <p className="mt-1.5 text-xs text-slate-500 dark:text-[#a6b0c3]">
+                    All requests resolved without errors.
+                  </p>
+                </div>
+              )}
+            </GlassCard>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/website/src/components/pages/PaymentAuditPage.tsx
+++ b/website/src/components/pages/PaymentAuditPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import useSWR from 'swr'
 import { useSearchParams } from 'react-router-dom'
 import { ArrowLeft, SlidersHorizontal } from 'lucide-react'
@@ -506,6 +506,8 @@ export function PaymentAuditPage() {
   const [customEnd, setCustomEnd] = useState(() =>
     toDateTimeInputValue(initialCustomWindow.end_ms),
   )
+  const [customRangeOpen, setCustomRangeOpen] = useState(false)
+  const timeRangeControlRef = useRef<HTMLDivElement | null>(null)
   const pageSize = 12
 
   const customWindow = useMemo(() => {
@@ -516,6 +518,24 @@ export function PaymentAuditPage() {
     if (start_ms === null || end_ms === null || end_ms <= start_ms || start_ms > now || end_ms > now) return undefined
     return { start_ms, end_ms }
   }, [customEnd, customStart, range])
+
+  useEffect(() => {
+    if (!customRangeOpen) return
+    function handlePointerDown(event: MouseEvent) {
+      if (!timeRangeControlRef.current?.contains(event.target as Node)) {
+        setCustomRangeOpen(false)
+      }
+    }
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') setCustomRangeOpen(false)
+    }
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [customRangeOpen])
 
   const auditPath = mode === 'rule_based' ? '/analytics/preview-trace' : '/analytics/payment-audit'
   const modeRoutingApproach = routingApproachForMode(mode)
@@ -750,6 +770,7 @@ export function PaymentAuditPage() {
     setPage(nextPage)
     setTrailFocused(false)
     setSelectedEventId(null)
+    setCustomRangeOpen(nextRange === 'custom')
     if (nextRange !== 'custom') {
       const preset = presetWindow(nextRange)
       setCustomStart(toDateTimeInputValue(preset.start_ms))
@@ -811,47 +832,46 @@ export function PaymentAuditPage() {
           <Button size="sm" variant="ghost" onClick={refreshAll}>
             Refresh
           </Button>
-          <div className="flex items-center gap-1 rounded-[18px] border border-slate-200 bg-white/70 p-1 dark:border-[#2a303a] dark:bg-[#161b24]">
-            {RANGE_OPTIONS.map((value) => (
-              <Button
-                key={value}
-                size="sm"
-                variant="secondary"
-                className={sectionButtonClass(range === value)}
-                onClick={() => updateRange(value)}
-              >
-                {value}
-              </Button>
-            ))}
+          <div ref={timeRangeControlRef} className="relative">
+            <div className="flex items-center gap-1 rounded-[18px] border border-slate-200 bg-white/70 p-1 dark:border-[#2a303a] dark:bg-[#161b24]">
+              {RANGE_OPTIONS.map((value) => (
+                <Button
+                  key={value}
+                  size="sm"
+                  variant="secondary"
+                  className={sectionButtonClass(range === value)}
+                  onClick={() => updateRange(value)}
+                >
+                  {value}
+                </Button>
+              ))}
+            </div>
+            {range === 'custom' && customRangeOpen ? (
+              <div className="absolute right-0 top-[calc(100%+10px)] z-[90] w-[min(92vw,560px)] rounded-[24px] border border-slate-200 bg-white/95 p-4 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.45)] backdrop-blur dark:border-[#2a303a] dark:bg-[#11151d]/95 dark:shadow-[0_24px_70px_-40px_rgba(0,0,0,0.7)]">
+                <div className="flex items-center justify-between gap-4">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">Select time range</p>
+                  <Button size="sm" variant="ghost" onClick={() => setCustomRangeOpen(false)}>Close</Button>
+                </div>
+                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <div>
+                    <p className="mb-1.5 text-xs font-medium text-slate-500 dark:text-[#8a8a93]">Start time</p>
+                    <DateTimePicker className="w-full" value={customStart} onChange={setCustomStart} />
+                  </div>
+                  <div>
+                    <p className="mb-1.5 text-xs font-medium text-slate-500 dark:text-[#8a8a93]">End time</p>
+                    <DateTimePicker className="w-full" value={customEnd} onChange={setCustomEnd} />
+                  </div>
+                </div>
+                {!customWindow ? (
+                  <p className="mt-3 text-xs text-red-500">
+                    Choose an end time after the start time. Future dates are not available.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </div>
       </div>
-
-      {range === 'custom' ? (
-        <GlassCard className="overflow-visible p-4">
-          <div className="grid gap-3 md:grid-cols-2">
-            <FilterField label="Start time">
-              <DateTimePicker
-                className="w-full"
-                value={customStart}
-                onChange={setCustomStart}
-              />
-            </FilterField>
-            <FilterField label="End time">
-              <DateTimePicker
-                className="w-full"
-                value={customEnd}
-                onChange={setCustomEnd}
-              />
-            </FilterField>
-          </div>
-          {!customWindow ? (
-            <p className="mt-3 text-xs text-red-500">
-              Choose an end time after the start time. Future dates are not available.
-            </p>
-          ) : null}
-        </GlassCard>
-      ) : null}
 
       <div className="space-y-4">
         <div className="inline-flex max-w-full flex-wrap items-center gap-1 rounded-[18px] border border-slate-200 bg-white/70 p-1 dark:border-[#2a303a] dark:bg-[#11151d]">

--- a/website/src/components/pages/RoutingHubPage.tsx
+++ b/website/src/components/pages/RoutingHubPage.tsx
@@ -1,15 +1,14 @@
 import type { ElementType } from 'react'
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import useSWR, { useSWRConfig } from 'swr'
 import {
   BookOpen,
-  CheckCircle2,
+  ChevronRight,
   FlaskConical,
-  GitBranch,
   Network,
   PieChart,
   PowerOff,
-  ShieldCheck,
   TrendingUp,
 } from 'lucide-react'
 import { Card, CardBody, SurfaceLabel } from '../ui/Card'
@@ -18,8 +17,8 @@ import { Button } from '../ui/Button'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { useMerchantStore } from '../../store/merchantStore'
 import { useAuthStore } from '../../store/authStore'
-import { apiPost } from '../../lib/api'
-import { RoutingAlgorithm, RuleConfig } from '../../types/api'
+import { apiPost, fetcher } from '../../lib/api'
+import { AnalyticsOverviewResponse, RoutingAlgorithm, RuleConfig, SRConfigData } from '../../types/api'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
 
 type StrategyId = 'auth-rate' | 'rules' | 'volume' | 'debit' | 'ab-test'
@@ -28,13 +27,24 @@ type StrategyState = 'configured' | 'enabled' | 'not_set'
 interface StrategyRow {
   id: StrategyId
   title: string
-  eyebrow: string
   description: string
   useCase: string
   icon: ElementType
   state: StrategyState
-  evidence: string
   canDeactivate: boolean
+  href: string
+}
+
+const strategyLabels: Record<StrategyId, string> = {
+  'auth-rate': 'Auth-Rate Configuration',
+  rules: 'Rule-Based Routing',
+  volume: 'Volume Split Routing',
+  debit: 'Debit Routing',
+  'ab-test': 'A/B Testing',
+}
+
+function formatCompactNumber(value: number) {
+  return new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(value)
 }
 
 function algorithmType(algorithm?: RoutingAlgorithm) {
@@ -43,12 +53,6 @@ function algorithmType(algorithm?: RoutingAlgorithm) {
 
 function isRuleBasedAlgorithmType(type: string) {
   return type === 'advanced' || type === 'priority' || type === 'single'
-}
-
-function stateBadge(state: StrategyState) {
-  if (state === 'enabled') return <Badge variant="green">Enabled</Badge>
-  if (state === 'configured') return <Badge variant="green">Configured</Badge>
-  return <Badge variant="gray">Not set</Badge>
 }
 
 export function RoutingHubPage() {
@@ -72,45 +76,23 @@ export function RoutingHubPage() {
     () => apiPost('/rule/get', { merchant_id: merchantId, algorithm: 'successRate' }),
   )
 
+  const { data: analyticsData } = useSWR<AnalyticsOverviewResponse>(
+    merchantId ? '/analytics/overview?range=1d' : null,
+    fetcher,
+    { shouldRetryOnError: false },
+  )
+
   const activeAlgorithm = activeAlgorithms?.[0]
-  const activeType = algorithmType(activeAlgorithm)
-  const hasAuthRateConfig = Boolean((srConfig as any)?.config?.data || srConfig?.data)
-  const hasRuleBasedRouting = (activeAlgorithms || []).some((algorithm) => isRuleBasedAlgorithmType(algorithmType(algorithm)))
-  const hasVolumeSplit = (activeAlgorithms || []).some((algorithm) => algorithmType(algorithm) === 'volume_split')
+  const srData = ((srConfig as any)?.config?.data ?? srConfig?.data) as SRConfigData | undefined
+  const hasAuthRateConfig = Boolean(srData)
+  const hasRuleBasedRouting = (activeAlgorithms || []).some((a) => isRuleBasedAlgorithmType(algorithmType(a)))
+  const hasVolumeSplit = (activeAlgorithms || []).some((a) => algorithmType(a) === 'volume_split')
   const hasDebitRouting = debitRoutingFlag.isEnabled
-  const hasAbTest = (activeAlgorithms || []).some((algorithm) => algorithmType(algorithm) === 'ab_test')
-  const readiness = [hasAuthRateConfig, hasRuleBasedRouting || hasVolumeSplit, hasDebitRouting].filter(Boolean).length
+  const hasAbTest = (activeAlgorithms || []).some((a) => algorithmType(a) === 'ab_test')
   const loading = activeLoading || srLoading || debitRoutingFlag.isLoading
-  const activeRuleAlgorithm = (activeAlgorithms || []).find((algorithm) => isRuleBasedAlgorithmType(algorithmType(algorithm)))
-  const activeVolumeAlgorithm = (activeAlgorithms || []).find((algorithm) => algorithmType(algorithm) === 'volume_split')
-  const hasRuntimeStrategy = Boolean(activeAlgorithm || hasAuthRateConfig || hasDebitRouting)
-  const activeStrategyId: StrategyId | null = isRuleBasedAlgorithmType(activeType)
-    ? 'rules'
-    : activeType === 'volume_split'
-      ? 'volume'
-      : hasAuthRateConfig
-        ? 'auth-rate'
-        : hasDebitRouting
-          ? 'debit'
-          : null
-  const runtimeName = activeAlgorithm?.name
-    || (hasAuthRateConfig ? 'Auth-rate based routing' : hasDebitRouting ? 'Debit routing' : 'No active strategy')
-  const runtimeDescription = activeAlgorithm
-    ? `${activeAlgorithm.description || 'Active routing strategy'} is currently selected for payment routing.`
-    : hasAuthRateConfig && hasDebitRouting
-      ? 'Success-rate routing is configured and debit routing is enabled.'
-      : hasAuthRateConfig
-        ? 'Success-rate routing is configured and available for runtime routing decisions.'
-        : hasDebitRouting
-          ? 'Debit network routing is enabled.'
-          : 'Configure and activate a strategy before expecting runtime routing decisions to follow a custom policy.'
-  const runtimeType = activeType
-    ? activeType.replace('_', ' ')
-    : hasAuthRateConfig
-      ? 'success rate'
-      : hasDebitRouting
-        ? 'debit'
-        : '--'
+  const activeRuleAlgorithm = (activeAlgorithms || []).find((a) => isRuleBasedAlgorithmType(algorithmType(a)))
+  const activeVolumeAlgorithm = (activeAlgorithms || []).find((a) => algorithmType(a) === 'volume_split')
+
 
   async function deactivateStrategy(strategyId: StrategyId) {
     if (!merchantId) return
@@ -118,27 +100,15 @@ export function RoutingHubPage() {
   }
 
   async function doDeactivateStrategy(strategyId: StrategyId) {
-    const labels: Record<StrategyId, string> = {
-      'auth-rate': 'auth-rate configuration',
-      rules: 'rule-based routing',
-      volume: 'volume split routing',
-      debit: 'debit routing',
-      'ab-test': 'A/B experiment',
-    }
-
     setDeactivatingStrategy(strategyId)
     setActionMessage(null)
     setActionError(null)
-
     try {
       if (strategyId === 'auth-rate') {
         await apiPost('/rule/delete', { merchant_id: merchantId, algorithm: 'successRate' })
         await mutateSrConfig(undefined, { revalidate: false })
       } else if (strategyId === 'rules' && activeRuleAlgorithm) {
-        await apiPost('/routing/deactivate', {
-          created_by: merchantId,
-          routing_algorithm_id: activeRuleAlgorithm.id,
-        })
+        await apiPost('/routing/deactivate', { created_by: merchantId, routing_algorithm_id: activeRuleAlgorithm.id })
         await Promise.all([
           mutateActiveAlgorithms(),
           mutateCache(['active-routing', merchantId]),
@@ -146,10 +116,7 @@ export function RoutingHubPage() {
           mutateCache(`/routing/list/${merchantId}`),
         ])
       } else if (strategyId === 'volume' && activeVolumeAlgorithm) {
-        await apiPost('/routing/deactivate', {
-          created_by: merchantId,
-          routing_algorithm_id: activeVolumeAlgorithm.id,
-        })
+        await apiPost('/routing/deactivate', { created_by: merchantId, routing_algorithm_id: activeVolumeAlgorithm.id })
         await Promise.all([
           mutateActiveAlgorithms(),
           mutateCache(['active-routing', merchantId]),
@@ -159,7 +126,7 @@ export function RoutingHubPage() {
       } else if (strategyId === 'debit') {
         await debitRoutingFlag.setDebitRoutingEnabled(false)
       }
-      setActionMessage(`${labels[strategyId]} deactivated.`)
+      setActionMessage(`${strategyLabels[strategyId]} deactivated.`)
     } catch (err) {
       setActionError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -171,96 +138,64 @@ export function RoutingHubPage() {
     {
       id: 'auth-rate',
       title: 'Auth-rate based',
-      eyebrow: 'Performance routing',
-      description: 'Use connector score updates to steer traffic toward the best authorization rate.',
-      useCase: 'Best when you want automatic gateway choice based on live success-rate signals.',
+      description: 'Steers traffic toward the best authorization rate using live connector score signals.',
+      useCase: 'Use when you want automatic gateway selection driven by real-time success-rate data.',
       icon: TrendingUp,
       state: hasAuthRateConfig ? 'configured' : 'not_set',
-      evidence: hasAuthRateConfig ? 'Score config is available for runtime decisions.' : 'Set score defaults before relying on auth-rate routing.',
       canDeactivate: hasAuthRateConfig,
+      href: 'sr',
     },
     {
       id: 'rules',
       title: 'Rule based',
-      eyebrow: 'Policy routing',
-      description: 'Enforce explicit business conditions before traffic reaches connector selection.',
-      useCase: 'Best for BIN, network, country, amount, metadata, or merchant policy overrides.',
+      description: 'Evaluates explicit business conditions before traffic reaches connector selection.',
+      useCase: 'Use for BIN, network, country, amount, metadata, or merchant policy overrides.',
       icon: BookOpen,
       state: hasRuleBasedRouting ? 'enabled' : 'not_set',
-      evidence: hasRuleBasedRouting ? 'An advanced rule algorithm is active.' : 'No active advanced rule algorithm found.',
       canDeactivate: Boolean(activeRuleAlgorithm),
+      href: 'rules',
     },
     {
       id: 'volume',
       title: 'Volume split',
-      eyebrow: 'Controlled rollout',
-      description: 'Distribute payments by configured percentages and verify actual traffic share.',
-      useCase: 'Best for ramp-ups, A/B routing, new connector rollout, and traffic balancing.',
+      description: 'Distributes payments by configured percentages across gateways.',
+      useCase: 'Use for ramp-ups, new gateway rollout, traffic balancing, or controlled migrations.',
       icon: PieChart,
       state: hasVolumeSplit ? 'enabled' : 'not_set',
-      evidence: hasVolumeSplit ? 'A volume split algorithm is active.' : 'No active volume split algorithm found.',
       canDeactivate: Boolean(activeVolumeAlgorithm),
+      href: 'volume',
     },
     {
       id: 'debit',
       title: 'Debit routing',
-      eyebrow: 'Network cost routing',
-      description: 'Enable debit-network decisions for co-badged card payment flows.',
-      useCase: 'Best when debit network cost, issuer country, and regulated-card behavior matter.',
+      description: 'Enables debit-network decisions for co-badged card payment flows.',
+      useCase: 'Use when debit network cost, issuer country, or regulated-card behavior matters.',
       icon: Network,
       state: hasDebitRouting ? 'enabled' : 'not_set',
-      evidence: hasDebitRouting ? 'Merchant debit-routing flag is enabled.' : 'Enable the merchant flag before running debit network decisions.',
       canDeactivate: hasDebitRouting,
+      href: 'debit',
     },
     {
       id: 'ab-test',
       title: 'A/B Testing',
-      eyebrow: 'Experimentation',
-      description: 'Test two routing strategies against each other with statistical significance reporting.',
-      useCase: 'Best when validating a new routing algorithm, rule, or gateway before full rollout.',
+      description: 'Tests two routing strategies against each other with statistical significance reporting.',
+      useCase: 'Use when validating a new algorithm, rule, or gateway before full rollout.',
       icon: FlaskConical,
       state: hasAbTest ? 'enabled' : 'not_set',
-      evidence: hasAbTest ? 'An A/B test experiment is running.' : 'No active experiment. Create one to start testing.',
       canDeactivate: false,
+      href: 'ab-testing',
     },
   ]
 
-  const nextAction = !merchantId
-    ? {
-        title: 'Select or create a merchant first',
-        body: 'Routing setup and live strategy state require a signed-in merchant.',
-        icon: ShieldCheck,
-      }
-    : !hasAuthRateConfig
-      ? {
-          title: 'Start with auth-rate configuration',
-          body: 'Score defaults prepare auth-rate routing before custom rules are active.',
-          icon: TrendingUp,
-        }
-      : !hasRuntimeStrategy
-        ? {
-            title: 'Activate one routing strategy',
-            body: 'Create and activate a rule-based, volume-split, or debit routing strategy before runtime traffic depends on policy.',
-            icon: GitBranch,
-          }
-        : {
-            title: 'Active strategy is ready',
-            body: 'Routing is configured and ready for live traffic.',
-            icon: FlaskConical,
-          }
+  const activeStrategies = strategies.filter((s) => s.state !== 'not_set')
 
-  const NextActionIcon = nextAction.icon
-
-  const strategyLabels: Record<StrategyId, string> = {
-    'auth-rate': 'Auth-Rate Configuration',
-    rules: 'Rule-Based Routing',
-    volume: 'Volume Split Routing',
-    debit: 'Debit Routing',
-    'ab-test': 'A/B Testing',
-  }
+  const topRules = analyticsData?.top_rules || []
+  const activeNamedAlgorithm = activeAlgorithm?.name
+    ? activeAlgorithm
+    : null
 
   return (
-    <div className="mx-auto max-w-[1380px] space-y-6">
+    <div className="space-y-6 px-5 sm:px-6 lg:px-8 xl:px-10">
       <ConfirmDialog
         open={pendingDeactivateStrategy !== null}
         title={`Deactivate ${pendingDeactivateStrategy ? strategyLabels[pendingDeactivateStrategy] : ''}?`}
@@ -270,172 +205,206 @@ export function RoutingHubPage() {
         onConfirm={() => { const s = pendingDeactivateStrategy!; setPendingDeactivateStrategy(null); doDeactivateStrategy(s) }}
         onCancel={() => setPendingDeactivateStrategy(null)}
       />
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <div className="flex flex-wrap items-center gap-2">
-            <h1 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">Routing Hub</h1>
-            <Badge variant={merchantId ? 'blue' : 'orange'}>{merchantId || 'No merchant selected'}</Badge>
-          </div>
+
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Routing Hub</h1>
+      </header>
+
+      {actionError && (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/8 px-3 py-2 text-sm text-red-600 dark:text-red-400">
+          {actionError}
         </div>
-      </div>
+      )}
+      {actionMessage && (
+        <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-3 py-2 text-sm text-emerald-600 dark:text-emerald-400">
+          {actionMessage}
+        </div>
+      )}
 
-      <section className="grid gap-5 xl:grid-cols-[1.2fr_0.8fr]">
+      <div className="grid gap-6 xl:grid-cols-[1.3fr_0.7fr]">
+
+        {/* ── strategy list ──────────────────────────────────── */}
         <Card>
-          <CardBody className="p-6 md:p-7">
-            <div className="flex h-full flex-col justify-between gap-8">
-              <div className="flex flex-wrap items-start justify-between gap-4">
-                <div>
-                  <SurfaceLabel>Runtime posture</SurfaceLabel>
-                  <h2 className="mt-4 text-4xl font-semibold tracking-[-0.04em] text-slate-950 dark:text-white">
-                    {runtimeName}
-                  </h2>
-                  <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-500 dark:text-[#9aa6bb]">
-                    {runtimeDescription}
-                  </p>
-                </div>
-                <Badge variant={hasRuntimeStrategy ? 'green' : 'gray'}>
-                  {hasRuntimeStrategy ? 'Active' : loading ? 'Checking' : 'Inactive'}
-                </Badge>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-3">
-                <PostureStat label="Ready surfaces" value={`${readiness}/3`} detail="Auth-rate, traffic policy, debit" />
-                <PostureStat label="Runtime type" value={runtimeType} detail="Active routing mode" />
-                <PostureStat label="Debit gate" value={hasDebitRouting ? 'Enabled' : 'Off'} detail="Debit routing access" />
-              </div>
-
-              {activeStrategyId ? (
-                <div className="flex flex-wrap gap-2">
-                  <Button
-                    variant="danger"
-                    onClick={() => deactivateStrategy(activeStrategyId)}
-                    disabled={deactivatingStrategy === activeStrategyId}
+          <CardBody className="p-0">
+            <div className="px-6 pt-5">
+              <SurfaceLabel>Routing strategies</SurfaceLabel>
+            </div>
+            <div className="mt-3 divide-y divide-slate-100 dark:divide-[#1e2535]">
+              {strategies.map((strategy) => {
+                const Icon = strategy.icon
+                const active = strategy.state !== 'not_set'
+                return (
+                  <div
+                    key={strategy.id}
+                    className={`flex items-center gap-4 px-6 py-4 ${active ? 'bg-emerald-500/[0.04] dark:bg-emerald-500/[0.06]' : ''}`}
                   >
-                    <PowerOff size={16} />
-                    {deactivatingStrategy === activeStrategyId ? 'Deactivating' : 'Deactivate'}
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-          </CardBody>
-        </Card>
-
-        <Card>
-          <CardBody className="p-6 md:p-7">
-            <div className="flex items-start gap-4">
-              <div className="rounded-2xl border border-brand-500/20 bg-brand-500/10 p-3 text-brand-600 dark:text-sky-300">
-                <NextActionIcon size={22} />
-              </div>
-              <div>
-                <SurfaceLabel>Routing status</SurfaceLabel>
-                <h3 className="mt-3 text-2xl font-semibold text-slate-950 dark:text-white">{nextAction.title}</h3>
-                <p className="mt-3 text-sm leading-7 text-slate-500 dark:text-[#9aa6bb]">{nextAction.body}</p>
-              </div>
-            </div>
-
-            <div className="mt-7 space-y-3 border-t border-slate-200 pt-5 dark:border-[#242b36]">
-              <RunbookStep done={hasAuthRateConfig} label="Configure" detail="Define score defaults or routing policy." />
-              <RunbookStep done={hasRuntimeStrategy} label="Activate" detail="Make one strategy live." />
-              <RunbookStep done={false} label="Verify" detail="Confirm live routing behavior with a real decision flow." />
-            </div>
-          </CardBody>
-        </Card>
-      </section>
-
-      <section className="space-y-3">
-        <div>
-          <SurfaceLabel>Routing surfaces</SurfaceLabel>
-          <h2 className="mt-2 text-xl font-semibold text-slate-950 dark:text-white">Current configuration state</h2>
-        </div>
-
-        {actionError && (
-          <div className="rounded-lg border border-red-500/20 bg-red-500/8 px-3 py-2 text-sm text-red-500">
-            {actionError}
-          </div>
-        )}
-        {actionMessage && (
-          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-3 py-2 text-sm text-emerald-500">
-            {actionMessage}
-          </div>
-        )}
-
-        <div className="overflow-hidden rounded-[30px] border border-slate-200 bg-white dark:border-[#2a303a] dark:bg-[#11151d]">
-          {strategies.map((strategy, index) => {
-            const Icon = strategy.icon
-            return (
-              <div
-                key={strategy.id}
-                className={`grid gap-5 px-5 py-5 lg:grid-cols-[minmax(320px,520px)_minmax(280px,1fr)] lg:items-center xl:grid-cols-[minmax(360px,560px)_minmax(320px,1fr)_max-content] ${
-                  index === 0 ? '' : 'border-t border-slate-200 dark:border-[#252d3a]'
-                }`}
-              >
-                <div className="flex items-start gap-4">
-                  <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-slate-500 dark:border-[#273141] dark:bg-[#0c1119] dark:text-[#8ea0bb]">
-                    <Icon size={22} />
-                  </div>
-                  <div className="min-w-0 max-w-[470px]">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-lg font-semibold text-slate-950 dark:text-white">{strategy.title}</h3>
-                      {stateBadge(strategy.state)}
+                    <div className={`rounded-xl border p-2.5 flex-shrink-0 ${
+                      active
+                        ? 'border-emerald-200/60 bg-emerald-50 text-emerald-600 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-400'
+                        : 'border-slate-200 bg-slate-50 text-slate-400 dark:border-[#273141] dark:bg-[#0c1119] dark:text-[#6d778a]'
+                    }`}>
+                      <Icon size={17} />
                     </div>
-                    <p className="mt-1 text-xs font-semibold uppercase tracking-[0.16em] text-slate-400 dark:text-[#6d768a]">
-                      {strategy.eyebrow}
-                    </p>
-                    <p className="mt-3 text-sm leading-6 text-slate-500 dark:text-[#9aa6bb]">
-                      {strategy.description}
-                    </p>
-                  </div>
-                </div>
 
-                <div className="max-w-[520px]">
-                  <p className="text-sm font-medium text-slate-700 dark:text-[#d8deea]">{strategy.useCase}</p>
-                  <p className="mt-2 text-xs leading-5 text-slate-500 dark:text-[#7d879b]">{strategy.evidence}</p>
-                </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-sm font-semibold text-slate-950 dark:text-white">{strategy.title}</p>
+                        {strategy.state === 'enabled' || strategy.state === 'configured'
+                          ? <Badge variant="green">{strategy.state === 'configured' ? 'Configured' : 'Enabled'}</Badge>
+                          : <Badge variant="gray">Not set</Badge>}
+                      </div>
+                      <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-[#8390a7]">
+                        {strategy.description}
+                      </p>
+                      <p className="mt-0.5 text-xs leading-5 text-slate-400 dark:text-[#5a6a82]">
+                        {strategy.useCase}
+                      </p>
+                    </div>
 
-                {strategy.canDeactivate ? (
-                  <div className="flex flex-wrap justify-start gap-2 lg:col-start-2 xl:col-start-auto xl:justify-end xl:whitespace-nowrap">
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      onClick={() => deactivateStrategy(strategy.id)}
-                      disabled={deactivatingStrategy === strategy.id}
-                    >
-                      <PowerOff size={14} />
-                      {deactivatingStrategy === strategy.id ? 'Deactivating' : 'Deactivate'}
-                    </Button>
+                    <div className="flex flex-shrink-0 items-center gap-2">
+                      {strategy.canDeactivate && (
+                        <Button
+                          size="sm"
+                          variant="danger"
+                          onClick={() => deactivateStrategy(strategy.id)}
+                          disabled={deactivatingStrategy === strategy.id}
+                        >
+                          <PowerOff size={13} />
+                          {deactivatingStrategy === strategy.id ? 'Deactivating' : 'Deactivate'}
+                        </Button>
+                      )}
+                      <Link
+                        to={strategy.href}
+                        className="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition-colors hover:bg-slate-50 dark:border-[#2a303a] dark:bg-[#11151d] dark:text-[#c4cfdf] dark:hover:bg-[#161b26]"
+                      >
+                        Configure
+                        <ChevronRight size={13} className="text-slate-400 dark:text-[#5a6a82]" />
+                      </Link>
+                    </div>
                   </div>
-                ) : null}
+                )
+              })}
+            </div>
+          </CardBody>
+        </Card>
+
+        {/* ── status panel ───────────────────────────────────── */}
+        <Card>
+          <CardBody className="p-6 space-y-6">
+
+            {/* Active strategies */}
+            <div>
+              <SurfaceLabel>Active strategies</SurfaceLabel>
+              <div className="mt-3 divide-y divide-slate-100 dark:divide-[#1e2535]">
+                {activeStrategies.length > 0 ? activeStrategies.map((s) => {
+                  const Icon = s.icon
+                  return (
+                    <div key={s.id} className="flex items-center justify-between gap-3 py-2.5">
+                      <div className="flex items-center gap-2.5 min-w-0">
+                        <Icon size={14} className="flex-shrink-0 text-emerald-500" />
+                        <span className="truncate text-sm font-medium text-slate-900 dark:text-white">
+                          {s.title}
+                        </span>
+                      </div>
+                      <Badge variant="green">
+                        {s.state === 'configured' ? 'Configured' : 'Enabled'}
+                      </Badge>
+                    </div>
+                  )
+                }) : (
+                  <p className="py-2 text-sm text-slate-500 dark:text-[#8390a7]">
+                    {loading ? 'Checking…' : 'No active strategies yet'}
+                  </p>
+                )}
               </div>
-            )
-          })}
-        </div>
-      </section>
+            </div>
 
-    </div>
-  )
-}
+            {/* Running algorithm */}
+            {activeNamedAlgorithm && (
+              <div className="border-t border-slate-100 pt-6 dark:border-[#1e2535]">
+                <SurfaceLabel>Running algorithm</SurfaceLabel>
+                <p className="mt-3 text-sm font-semibold text-slate-950 dark:text-white">
+                  {activeNamedAlgorithm.name}
+                </p>
+                {activeNamedAlgorithm.description && (
+                  <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-[#8390a7]">
+                    {activeNamedAlgorithm.description}
+                  </p>
+                )}
+                <div className="mt-2">
+                  <Badge variant="blue">
+                    {algorithmType(activeNamedAlgorithm).replace(/_/g, ' ')}
+                  </Badge>
+                </div>
+              </div>
+            )}
 
-function PostureStat({ label, value, detail }: { label: string; value: string; detail: string }) {
-  return (
-    <div className="rounded-[22px] border border-slate-200 bg-slate-50 px-4 py-4 dark:border-[#273141] dark:bg-[#0c1119]">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400 dark:text-[#6d768a]">{label}</p>
-      <p className="mt-3 text-2xl font-semibold text-slate-950 dark:text-white">{value}</p>
-      <p className="mt-1 text-xs text-slate-500 dark:text-[#7d879b]">{detail}</p>
-    </div>
-  )
-}
+            {/* Top rules triggered */}
+            <div className="border-t border-slate-100 pt-6 dark:border-[#1e2535]">
+              <div className="flex items-center justify-between gap-2">
+                <SurfaceLabel>Rules triggered</SurfaceLabel>
+                <Badge variant="blue">Last 24h</Badge>
+              </div>
+              {topRules.length > 0 ? (
+                <div className="mt-3 space-y-2">
+                  {topRules.slice(0, 5).map((rule) => (
+                    <div key={rule.rule_name} className="flex items-center justify-between gap-3">
+                      <span className="truncate text-xs text-slate-700 dark:text-[#c4cfdf]">
+                        {rule.rule_name}
+                      </span>
+                      <span className="flex-shrink-0 text-xs font-semibold tabular-nums text-slate-950 dark:text-white">
+                        {formatCompactNumber(rule.count)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-2 text-xs text-slate-500 dark:text-[#8390a7]">
+                  No rule hits in the last 24 hours.
+                </p>
+              )}
+            </div>
 
-function RunbookStep({ done, label, detail }: { done: boolean; label: string; detail: string }) {
-  return (
-    <div className="flex items-start gap-3">
-      <div className={`mt-0.5 rounded-full ${done ? 'text-emerald-500' : 'text-slate-400 dark:text-[#6d768a]'}`}>
-        <CheckCircle2 size={17} />
+            {/* Auth-rate config */}
+            {hasAuthRateConfig && srData && (
+              <div className="border-t border-slate-100 pt-6 dark:border-[#1e2535]">
+                <div className="flex items-center justify-between gap-2">
+                  <SurfaceLabel>Auth-rate config</SurfaceLabel>
+                  <Badge variant="green">Configured</Badge>
+                </div>
+                <div className="mt-3 divide-y divide-slate-100 dark:divide-[#1e2535]">
+                  <SRRow label="Score window" value={`${srData.defaultBucketSize} requests`} />
+                  {srData.defaultHedgingPercent != null && (
+                    <SRRow label="Hedging" value={`${srData.defaultHedgingPercent}%`} />
+                  )}
+                  {srData.defaultLatencyThreshold != null && (
+                    <SRRow label="Latency threshold" value={`${srData.defaultLatencyThreshold} ms`} />
+                  )}
+                  {srData.defaultLowerResetFactor != null && (
+                    <SRRow label="Lower reset" value={String(srData.defaultLowerResetFactor)} />
+                  )}
+                  {srData.defaultUpperResetFactor != null && (
+                    <SRRow label="Upper reset" value={String(srData.defaultUpperResetFactor)} />
+                  )}
+                  {(srData.subLevelInputConfig?.length ?? 0) > 0 && (
+                    <SRRow label="Payment method overrides" value={`${srData.subLevelInputConfig!.length}`} />
+                  )}
+                </div>
+              </div>
+            )}
+
+          </CardBody>
+        </Card>
       </div>
-      <div>
-        <p className="text-sm font-semibold text-slate-900 dark:text-white">{label}</p>
-        <p className="text-xs leading-5 text-slate-500 dark:text-[#7d879b]">{detail}</p>
-      </div>
     </div>
   )
 }
 
+function SRRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-2">
+      <span className="text-xs text-slate-500 dark:text-[#8390a7]">{label}</span>
+      <span className="text-xs font-semibold tabular-nums text-slate-950 dark:text-white">{value}</span>
+    </div>
+  )
+}

--- a/website/src/components/ui/DateTimePicker.tsx
+++ b/website/src/components/ui/DateTimePicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { CalendarDays, ChevronLeft, ChevronRight, Clock3 } from 'lucide-react'
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from './Button'
 
 type DateTimePickerProps = {
@@ -73,12 +73,12 @@ function clampToNow(date: Date) {
 }
 
 function buildCalendar(viewDate: Date): CalendarCell[] {
-  const startOfMonth = new Date(viewDate.getFullYear(), viewDate.getMonth(), 1)
-  const startOffset = startOfMonth.getDay()
-  const start = new Date(startOfMonth)
+  const firstOfMonth = new Date(viewDate.getFullYear(), viewDate.getMonth(), 1)
+  const startOffset = firstOfMonth.getDay()
+  const start = new Date(firstOfMonth)
   start.setDate(start.getDate() - startOffset)
 
-  return Array.from({ length: 42 }, (_, index) => {
+  const cells: CalendarCell[] = Array.from({ length: 42 }, (_, index) => {
     const date = new Date(start)
     date.setDate(start.getDate() + index)
     return {
@@ -87,6 +87,13 @@ function buildCalendar(viewDate: Date): CalendarCell[] {
       inMonth: date.getMonth() === viewDate.getMonth(),
     }
   })
+
+  // Trim the 6th row if all cells are outside the current month
+  const lastRow = cells.slice(35)
+  if (lastRow.every((cell) => !cell.inMonth)) {
+    return cells.slice(0, 35)
+  }
+  return cells
 }
 
 export function DateTimePicker({ value, onChange, className = '' }: DateTimePickerProps) {
@@ -179,47 +186,47 @@ export function DateTimePicker({ value, onChange, className = '' }: DateTimePick
           }
           setOpen((current) => !current)
         }}
-        className="flex h-11 w-full items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white/90 px-4 text-left text-sm text-slate-700 shadow-[0_12px_30px_-24px_rgba(15,23,42,0.2)] transition focus:outline-none focus:ring-2 focus:ring-brand-500/20 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-[#e5ecf7] dark:shadow-none"
+        className="flex h-9 w-full items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white/90 px-3 text-left text-sm text-slate-700 shadow-[0_12px_30px_-24px_rgba(15,23,42,0.2)] transition focus:outline-none focus:ring-2 focus:ring-brand-500/20 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-[#e5ecf7] dark:shadow-none"
       >
-        <span className="truncate">{formatDisplayValue(parsedValue)}</span>
-        <CalendarDays size={16} className="shrink-0 text-slate-400 dark:text-[#8a8a93]" />
+        <span className="truncate text-[13px]">{formatDisplayValue(parsedValue)}</span>
+        <CalendarDays size={14} className="shrink-0 text-slate-400 dark:text-[#8a8a93]" />
       </button>
 
       {open ? (
-        <div className="absolute left-0 top-[calc(100%+10px)] z-[80] w-[284px] rounded-[24px] border border-slate-200 bg-white/95 p-3 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.45)] backdrop-blur dark:border-[#2a303a] dark:bg-[#11151d]/95 dark:shadow-[0_24px_70px_-40px_rgba(0,0,0,0.7)]">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-[13px] font-semibold text-slate-900 dark:text-white">{monthLabel(viewDate)}</p>
-              <p className="mt-1 text-[11px] text-slate-500 dark:text-[#8a8a93]">Choose a day and time</p>
-            </div>
+        <div className="absolute left-0 top-[calc(100%+8px)] z-[80] w-[252px] rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.45)] backdrop-blur dark:border-[#2a303a] dark:bg-[#11151d]/95 dark:shadow-[0_24px_70px_-40px_rgba(0,0,0,0.7)]">
+          {/* Month navigation */}
+          <div className="mb-1.5 flex items-center justify-between gap-2">
+            <p className="text-[12px] font-semibold text-slate-900 dark:text-white">{monthLabel(viewDate)}</p>
             <div className="flex items-center gap-1">
               <button
                 type="button"
                 onClick={() => setViewDate((current) => new Date(current.getFullYear(), current.getMonth() - 1, 1))}
-                className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:border-slate-300 hover:text-slate-900 dark:border-[#2a303a] dark:text-[#8a8a93] dark:hover:text-white"
+                className="flex h-6 w-6 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition hover:border-slate-300 hover:text-slate-900 dark:border-[#2a303a] dark:text-[#8a8a93] dark:hover:text-white"
               >
-                <ChevronLeft size={14} />
+                <ChevronLeft size={12} />
               </button>
               <button
                 type="button"
                 disabled={viewingCurrentOrFutureMonth}
                 onClick={() => setViewDate((current) => new Date(current.getFullYear(), current.getMonth() + 1, 1))}
-                className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:border-slate-300 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:border-slate-200 disabled:hover:text-slate-500 dark:border-[#2a303a] dark:text-[#8a8a93] dark:hover:text-white dark:disabled:hover:text-[#8a8a93]"
+                className="flex h-6 w-6 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition hover:border-slate-300 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:border-slate-200 disabled:hover:text-slate-500 dark:border-[#2a303a] dark:text-[#8a8a93] dark:hover:text-white dark:disabled:hover:text-[#8a8a93]"
               >
-                <ChevronRight size={14} />
+                <ChevronRight size={12} />
               </button>
             </div>
           </div>
 
-          <div className="mt-3 grid grid-cols-7 gap-1 text-center text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-[#667085]">
-            {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day) => (
-              <span key={day} className="py-2">
+          {/* Day-of-week labels */}
+          <div className="grid grid-cols-7 gap-px text-center text-[9px] font-semibold uppercase tracking-[0.1em] text-slate-400 dark:text-[#667085]">
+            {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, index) => (
+              <span key={index} className="py-0.5">
                 {day}
               </span>
             ))}
           </div>
 
-          <div className="grid grid-cols-7 gap-1">
+          {/* Calendar grid */}
+          <div className="grid grid-cols-7 gap-px">
             {calendar.map((cell) => {
               const selected = sameDay(cell.date, draftDate)
               const future = isFutureDay(cell.date, now)
@@ -229,11 +236,11 @@ export function DateTimePicker({ value, onChange, className = '' }: DateTimePick
                   type="button"
                   disabled={future}
                   onClick={() => selectDay(cell.date)}
-                  className={`flex h-9 items-center justify-center rounded-lg text-[13px] transition ${
+                  className={`flex h-7 items-center justify-center rounded-md text-[12px] transition ${
                     future
                       ? 'cursor-not-allowed text-slate-300 opacity-35 dark:text-[#4b5565]'
                       : selected
-                      ? 'bg-brand-600 text-white shadow-[0_12px_30px_-22px_rgba(59,130,246,0.7)] dark:bg-brand-500 dark:text-white'
+                      ? 'bg-brand-600 text-white shadow-[0_8px_20px_-14px_rgba(59,130,246,0.7)] dark:bg-brand-500 dark:text-white'
                       : cell.inMonth
                         ? 'text-slate-700 hover:bg-slate-100 dark:text-[#e5ecf7] dark:hover:bg-[#1a2130]'
                         : 'text-slate-300 hover:bg-slate-100 dark:text-[#4b5565] dark:hover:bg-[#161b24]'
@@ -245,19 +252,13 @@ export function DateTimePicker({ value, onChange, className = '' }: DateTimePick
             })}
           </div>
 
-          <div className="mt-3 rounded-[18px] border border-slate-200 bg-slate-50/70 p-3 dark:border-[#2a303a] dark:bg-[#161b24]">
-            <div className="mb-2 flex items-center gap-2">
-              <Clock3 size={13} className="text-slate-400 dark:text-[#8a8a93]" />
-              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-[#8a8a93]">
-                Time
-              </p>
-            </div>
-
-            <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+          {/* Time + actions */}
+          <div className="mt-2 space-y-2 border-t border-slate-100 pt-2 dark:border-[#2a303a]">
+            <div className="flex items-center gap-1.5">
               <select
                 value={pad(draftDate.getHours())}
                 onChange={(event) => updateTime('hours', event.target.value)}
-                className="h-9 rounded-xl border border-slate-200 bg-white/90 px-3 text-sm text-slate-700 dark:border-[#2a303a] dark:bg-[#11151d] dark:text-[#e5ecf7]"
+                className="h-7 w-[52px] rounded-lg border border-slate-200 bg-white/90 px-1.5 text-[12px] text-slate-700 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-[#e5ecf7]"
               >
                 {Array.from({ length: 24 }, (_, index) => {
                   const disabled = selectedDayIsToday && index > now.getHours()
@@ -269,11 +270,11 @@ export function DateTimePicker({ value, onChange, className = '' }: DateTimePick
                   )
                 })}
               </select>
-              <span className="text-sm font-semibold text-slate-400 dark:text-[#8a8a93]">:</span>
+              <span className="text-[11px] font-semibold text-slate-400 dark:text-[#8a8a93]">:</span>
               <select
                 value={pad(draftDate.getMinutes())}
                 onChange={(event) => updateTime('minutes', event.target.value)}
-                className="h-9 rounded-xl border border-slate-200 bg-white/90 px-3 text-sm text-slate-700 dark:border-[#2a303a] dark:bg-[#11151d] dark:text-[#e5ecf7]"
+                className="h-7 w-[52px] rounded-lg border border-slate-200 bg-white/90 px-1.5 text-[12px] text-slate-700 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-[#e5ecf7]"
               >
                 {Array.from({ length: 60 }, (_, index) => {
                   const disabled =
@@ -288,14 +289,15 @@ export function DateTimePicker({ value, onChange, className = '' }: DateTimePick
                   )
                 })}
               </select>
+              <button
+                type="button"
+                onClick={useNow}
+                className="ml-auto text-[11px] font-medium text-brand-600 hover:underline dark:text-brand-400"
+              >
+                Now
+              </button>
             </div>
-          </div>
-
-          <div className="mt-3 flex items-center justify-between gap-2">
-            <Button size="sm" variant="ghost" onClick={useNow}>
-              Now
-            </Button>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center justify-end gap-1.5">
               <Button size="sm" variant="secondary" onClick={() => setOpen(false)}>
                 Cancel
               </Button>

--- a/website/src/pages/AuthPage.tsx
+++ b/website/src/pages/AuthPage.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import { useAuthStore, MerchantInfo } from '../store/authStore'
 import { useMerchantStore } from '../store/merchantStore'
+import { mutate } from 'swr'
 import { apiFetch } from '../lib/api'
 import { getResolvedThemePreference, persistThemePreference } from '../lib/theme'
 import { SurfaceLabel } from '../components/ui/Card'
@@ -203,6 +204,9 @@ export function AuthPage() {
         authRes.merchants,
       )
       if (authRes.merchant_id) setMerchantId(authRes.merchant_id)
+      // Clear any stale /auth/me error from a previous expired session so AuthGuard
+      // doesn't see the cached 401 and clear the fresh token before revalidating.
+      mutate('/auth/me', undefined, { revalidate: false })
 
       const pendingRaw = localStorage.getItem('pending_merchant_name')
       const pending = pendingRaw ? (() => { try { return JSON.parse(pendingRaw) } catch { return null } })() : null


### PR DESCRIPTION
## Summary

- **Analytics page**: replace HitsCards with auth-rate hero metric; grouped bar charts for gateway share and connector counts (previously stacked — made minority gateways invisible); color-coded SR score badges (green/orange/red); rule-based view shows rule match rate + recent decisions instead of paginated list; remove donut chart
- **DateTimePicker**: compact redesign (~30% shorter); 6th calendar row dropped when entirely out-of-month; time + actions split into two-line footer so Cancel/Apply no longer overflow the container
- **PaymentAuditPage**: custom date range opens as a floating dropdown (matching analytics pattern) — no layout shift; dismisses on outside-click or Escape
- **OverviewPage**: health check refactored to `useSWR`; unused imports removed
- **AuthPage / AuthGuard**: clear stale `/auth/me` error on fresh login so AuthGuard doesn't see a cached 401 and clear the new token before revalidation
- **docs/benchmarks.mdx**: add feedback-path (`/update-gateway-score`) latency table
- **scripts**: load-test and `oneclick.sh` improvements

## Test plan

- [ ] Analytics page — grouped bar charts render correctly with lopsided gateway data
- [ ] Analytics page — SR score badges show correct colour (≥85% green, ≥70% orange, <70% red)
- [ ] DateTimePicker — calendar fits within its container; Cancel/Apply visible without overflow
- [ ] DateTimePicker — 6th row trimmed for months that don't need it
- [ ] Audit page — clicking "custom" opens floating dropdown; clicking outside or pressing Escape closes it
- [ ] Auth flow — logging in after session expiry does not immediately sign out again