### PR TITLE
fix(frontend): correct penalty classification in simulation error resolver

### DIFF
--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -1179,8 +1179,8 @@ export function DecisionExplorerPage() {
 
   // Finds a real error code for `connector` that produces the desired GSM decision + penalty.
   function resolveSimErrorInfo(connector: string, gsmDecision: 'retry' | 'do_default', penalized: boolean) {
-    const penalizedMessages = new Set(['Issue with Configurations', 'Technical issue with PSP', 'Something went wrong'])
-    const notPenalizedMessages = new Set(['Issue with Payment Method details', 'Issue with Integration'])
+    const penalizedMessages = new Set(['Issue with Integration', 'Issue with Configurations', 'Technical issue with PSP', 'Something went wrong'])
+    const notPenalizedMessages = new Set(['Issue with Payment Method details'])
     const targetMessages = penalized ? penalizedMessages : notPenalizedMessages
     return gsmRules.find(r =>
       r.connector === connector &&


### PR DESCRIPTION
## Summary

- `resolveSimErrorInfo` had `'Issue with Integration'` in `notPenalizedMessages`, but `penalizedByUnifiedMessage` (the source of truth used by `ErrorInfoFields`) returns `true` (penalized) for that message
- This caused all connectors (Stripe, Adyen, Cybersource, etc.) to auto-select an error code mapped to `'Issue with Integration'` when the user chose **Penalty skipped** in Score Impact — making the Decline Error panel display a penalized unified message, contradicting the toggle
- Fix: move `'Issue with Integration'` into `penalizedMessages`, leaving only `'Issue with Payment Method details'` in `notPenalizedMessages`, consistent with `penalizedByUnifiedMessage`

## Test plan

- [ ] Open Decision Explorer → Batch Simulation tab
- [ ] Expand a gateway (Stripe, Adyen, Cybersource), set failure mode to **Decline**
- [ ] Set Score Impact to **Penalty skipped** — verify the auto-selected error code in Decline Error resolves to `Issue with Payment Method details` (green), not `Issue with Integration`
- [ ] Set Score Impact to **Penalized** — verify the auto-selected error code resolves to a penalized unified message (red)
- [ ] Manually pick an error code and confirm the Score Impact toggle syncs correctly in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)