### PR TITLE
feat(simulation): add support for multi-objective routing simulation

### DIFF
--- a/clickhouse/scripts/025_domain_events_ingestion.sh
+++ b/clickhouse/scripts/025_domain_events_ingestion.sh
@@ -17,7 +17,7 @@ if [ -n "${CLICKHOUSE_PASSWORD}" ]; then
 fi
 
 clickhouse-client ${auth_args} --multiquery <<SQL
-CREATE TABLE analytics_domain_events (
+CREATE TABLE IF NOT EXISTS analytics_domain_events (
     event_id String,
     api_flow LowCardinality(String),
     flow_type LowCardinality(String),
@@ -74,7 +74,7 @@ DROP TABLE IF EXISTS analytics_payment_audit_summary_buckets_queue;
 DROP TABLE IF EXISTS analytics_payment_audit_lookup_summaries_queue;
 DROP TABLE IF EXISTS analytics_domain_events_queue;
 
-CREATE TABLE analytics_payment_audit_summary_buckets (
+CREATE TABLE IF NOT EXISTS analytics_payment_audit_summary_buckets (
     merchant_id String,
     lookup_key String,
     summary_kind LowCardinality(String),
@@ -103,7 +103,7 @@ ORDER BY (
 )
 TTL bucket_start + INTERVAL 18 MONTH;
 
-CREATE TABLE analytics_payment_audit_lookup_summaries (
+CREATE TABLE IF NOT EXISTS analytics_payment_audit_lookup_summaries (
     merchant_id String,
     lookup_key String,
     summary_kind LowCardinality(String),
@@ -169,6 +169,9 @@ SETTINGS
     kafka_topic_list = '${ANALYTICS_KAFKA_DOMAIN_TOPIC}',
     kafka_group_name = '${DOMAIN_GROUP_NAME}',
     kafka_format = 'JSONEachRow',
+    -- Drain the topic ~2x/sec instead of the 7.5s default so score snapshots
+    -- (and the routing events derived from them) surface near real-time.
+    kafka_flush_interval_ms = 500,
     kafka_handle_error_mode = 'stream';
 
 CREATE TABLE analytics_payment_audit_summary_buckets_queue AS analytics_domain_events_queue

--- a/clickhouse/scripts/025_domain_events_ingestion.sh
+++ b/clickhouse/scripts/025_domain_events_ingestion.sh
@@ -169,9 +169,10 @@ SETTINGS
     kafka_topic_list = '${ANALYTICS_KAFKA_DOMAIN_TOPIC}',
     kafka_group_name = '${DOMAIN_GROUP_NAME}',
     kafka_format = 'JSONEachRow',
-    -- Drain the topic ~2x/sec instead of the 7.5s default so score snapshots
-    -- (and the routing events derived from them) surface near real-time.
-    kafka_flush_interval_ms = 500,
+    -- Drain the topic ~4x/sec instead of the 7.5s default so score snapshots
+    -- (and the routing events derived from them) surface near real-time and in
+    -- small batches rather than one big chunk.
+    kafka_flush_interval_ms = 250,
     kafka_handle_error_mode = 'stream';
 
 CREATE TABLE analytics_payment_audit_summary_buckets_queue AS analytics_domain_events_queue

--- a/config/development.toml
+++ b/config/development.toml
@@ -73,6 +73,7 @@ base_url = "https://eu.hyperswitch.io/cost-observability/router"
 username = "hypersense_user"
 password = "hypersense_pass"
 token_ttl_secs = 82800
+cost_cache_ttl_secs = 300    # in-process fee-rate cache; 0 disables, default 5 min
 
 [tenant_secrets]
 public = { schema = "public" }

--- a/config/development.toml
+++ b/config/development.toml
@@ -68,6 +68,12 @@ service_config_ttl = 300    # 5 minutes
 [compression_filepath]
 zstd_compression_filepath = "/tmp/extra-paths/redis-zstd-dictionaries/sbx"
 
+[hypersense]
+base_url = "https://eu.hyperswitch.io/cost-observability/router"
+username = "hypersense_user"
+password = "hypersense_pass"
+token_ttl_secs = 82800
+
 [tenant_secrets]
 public = { schema = "public" }
 

--- a/helm-charts/templates/analytics-clickhouse-configmap.yaml
+++ b/helm-charts/templates/analytics-clickhouse-configmap.yaml
@@ -223,6 +223,9 @@ data:
         kafka_group_name = '{{ .Values.analytics.clickhouse.domainConsumerGroup }}',
         kafka_format = 'JSONEachRow',
         kafka_num_consumers = 1,
+        -- Drain the topic ~2x/sec instead of the 7.5s default so score snapshots
+        -- (and the routing events derived from them) surface near real-time.
+        kafka_flush_interval_ms = 500,
         kafka_handle_error_mode = 'stream';
 
     CREATE MATERIALIZED VIEW IF NOT EXISTS {{ .Values.analytics.clickhouse.database }}.analytics_domain_events_parse_errors_mv

--- a/helm-charts/templates/analytics-clickhouse-configmap.yaml
+++ b/helm-charts/templates/analytics-clickhouse-configmap.yaml
@@ -225,7 +225,7 @@ data:
         kafka_num_consumers = 1,
         -- Drain the topic ~2x/sec instead of the 7.5s default so score snapshots
         -- (and the routing events derived from them) surface near real-time.
-        kafka_flush_interval_ms = 500,
+        kafka_flush_interval_ms = 250,
         kafka_handle_error_mode = 'stream';
 
     CREATE MATERIALIZED VIEW IF NOT EXISTS {{ .Values.analytics.clickhouse.database }}.analytics_domain_events_parse_errors_mv

--- a/oneclick.sh
+++ b/oneclick.sh
@@ -17,6 +17,7 @@ ONECLICK_AUTO_CONFIRM="${ONECLICK_AUTO_CONFIRM:-0}"
 POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
 POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 POSTGRES_USER="${POSTGRES_USER:-db_user}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-db_pass}"
 POSTGRES_DB="${POSTGRES_DB:-decision_engine_db}"
 REDIS_HOST="${REDIS_HOST:-localhost}"
 REDIS_PORT="${REDIS_PORT:-6379}"
@@ -205,6 +206,54 @@ check_clickhouse_schema() {
     done
 
     return "$missing"
+}
+
+# Seed the global SR V3 service configs the decider relies on. These were
+# previously created only by routing-config/setup.py (which targets MySQL); the
+# Postgres bring-up creates an empty service_configuration table, so without this
+# the decider can't hedge (e.g. ENABLE_MERCHANT_ON_VOLUME_DISTRIBUTION_FEATURE_SR_V3
+# is absent and route_random_traffic never runs). Idempotent via WHERE NOT EXISTS
+# since service_configuration.name has no unique constraint.
+seed_global_configs() {
+    echo "Seeding global SR V3 service configs..."
+    local sql
+    sql=$(cat <<'SQL'
+INSERT INTO service_configuration (name, value)
+SELECT v.name, v.value
+FROM (VALUES
+    ('ENABLE_MERCHANT_ON_VOLUME_DISTRIBUTION_FEATURE_SR_V3', '{"enableAll":true,"enableAllRollout":100}'),
+    ('ENABLE_RESET_ON_SR_V3',                                '{"enableAll":true,"enableAllRollout":100}'),
+    ('merchants_enabled_for_score_keys_unification',         '{"enableAll":true,"enableAllRollout":100}'),
+    ('SR_V3_INPUT_CONFIG_DEFAULT',                           '{"defaultLatencyThreshold":90,"defaultBucketSize":125,"defaultHedgingPercent":5}')
+) AS v(name, value)
+WHERE NOT EXISTS (
+    SELECT 1 FROM service_configuration sc WHERE sc.name = v.name
+);
+SQL
+)
+
+    if command_exists psql; then
+        if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+            -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c "$sql" >/dev/null 2>&1; then
+            echo "Global SR V3 configs seeded."
+            echo ""
+            return 0
+        fi
+    fi
+
+    if docker compose ps -q postgresql >/dev/null 2>&1; then
+        if echo "$sql" | docker compose exec -T postgresql \
+            psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 >/dev/null 2>&1; then
+            echo "Global SR V3 configs seeded."
+            echo ""
+            return 0
+        fi
+    fi
+
+    echo "  [warn] Could not seed global SR V3 configs (no psql and postgresql container unreachable)."
+    echo "         Hedging will not work until these service_configuration rows exist."
+    echo ""
+    return 1
 }
 
 print_service_status() {
@@ -472,6 +521,8 @@ fi
 
 echo "Running Postgres migrations..."
 just migrate-pg
+
+seed_global_configs
 
 # Start backend, npm install, and docs in parallel — none of them depend on each other.
 echo "Starting Decision Engine server, installing dashboard dependencies, and starting docs preview..."

--- a/oneclick.sh
+++ b/oneclick.sh
@@ -222,7 +222,6 @@ INSERT INTO service_configuration (name, value)
 SELECT v.name, v.value
 FROM (VALUES
     ('ENABLE_MERCHANT_ON_VOLUME_DISTRIBUTION_FEATURE_SR_V3', '{"enableAll":true,"enableAllRollout":100}'),
-    ('ENABLE_RESET_ON_SR_V3',                                '{"enableAll":true,"enableAllRollout":100}'),
     ('merchants_enabled_for_score_keys_unification',         '{"enableAll":true,"enableAllRollout":100}'),
     ('SR_V3_INPUT_CONFIG_DEFAULT',                           '{"defaultLatencyThreshold":90,"defaultBucketSize":125,"defaultHedgingPercent":5}')
 ) AS v(name, value)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "decision-engine-cypress-tests",
       "version": "1.0.0",
       "dependencies": {
+        "typescript": "^6.0.3",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -2998,6 +2999,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "test": "npm run test:all"
   },
   "devDependencies": {
-    "cypress": "^13.6.0",
-    "@cypress/grep": "^4.0.1"
+    "@cypress/grep": "^4.0.1",
+    "cypress": "^13.6.0"
   },
   "dependencies": {
+    "typescript": "^6.0.3",
     "uuid": "^9.0.1"
   }
 }

--- a/src/analytics/clickhouse/endpoints/cost_savings.rs
+++ b/src/analytics/clickhouse/endpoints/cost_savings.rs
@@ -1,4 +1,6 @@
-use crate::analytics::models::{AnalyticsCostSavingsResponse, AnalyticsCostSavingsTotals, AnalyticsQuery};
+use crate::analytics::models::{
+    AnalyticsCostSavingsResponse, AnalyticsCostSavingsTotals, AnalyticsQuery,
+};
 use crate::analytics::service::format_range;
 use crate::error::ApiError;
 
@@ -8,7 +10,8 @@ pub async fn load(
     client: &clickhouse::Client,
     query: &AnalyticsQuery,
 ) -> Result<AnalyticsCostSavingsResponse, ApiError> {
-    let available_currencies = metrics::cost_savings::load_available_currencies(client, query).await?;
+    let available_currencies =
+        metrics::cost_savings::load_available_currencies(client, query).await?;
 
     // Active currency: caller-provided wins; otherwise pick the one with the most decisions.
     let active_currency = query

--- a/src/analytics/clickhouse/endpoints/cost_savings.rs
+++ b/src/analytics/clickhouse/endpoints/cost_savings.rs
@@ -1,0 +1,45 @@
+use crate::analytics::models::{AnalyticsCostSavingsResponse, AnalyticsCostSavingsTotals, AnalyticsQuery};
+use crate::analytics::service::format_range;
+use crate::error::ApiError;
+
+use super::super::metrics;
+
+pub async fn load(
+    client: &clickhouse::Client,
+    query: &AnalyticsQuery,
+) -> Result<AnalyticsCostSavingsResponse, ApiError> {
+    let available_currencies = metrics::cost_savings::load_available_currencies(client, query).await?;
+
+    // Active currency: caller-provided wins; otherwise pick the one with the most decisions.
+    let active_currency = query
+        .currency
+        .clone()
+        .or_else(|| available_currencies.first().map(|c| c.currency.clone()));
+
+    let (trend, totals) = match active_currency.as_deref() {
+        Some(currency) => {
+            let trend =
+                metrics::cost_savings::load_cost_savings_trend(client, query, currency).await?;
+            let totals =
+                metrics::cost_savings::load_cost_savings_totals(client, query, currency).await?;
+            (trend, totals)
+        }
+        None => (
+            Vec::new(),
+            AnalyticsCostSavingsTotals {
+                saved_value: 0.0,
+                cost_won_count: 0,
+                total_decisions: 0,
+            },
+        ),
+    };
+
+    Ok(AnalyticsCostSavingsResponse {
+        merchant_id: query.merchant_id.clone(),
+        range: format_range(query),
+        currency: active_currency,
+        available_currencies,
+        trend,
+        totals,
+    })
+}

--- a/src/analytics/clickhouse/endpoints/mod.rs
+++ b/src/analytics/clickhouse/endpoints/mod.rs
@@ -1,3 +1,4 @@
+pub mod cost_savings;
 pub mod decisions;
 pub mod experiment_results;
 pub mod experiment_transactions;

--- a/src/analytics/clickhouse/endpoints/mod.rs
+++ b/src/analytics/clickhouse/endpoints/mod.rs
@@ -7,4 +7,5 @@ pub mod log_summaries;
 pub mod overview;
 pub mod payment_audit;
 pub mod preview_trace;
+pub mod routing_events;
 pub mod routing_stats;

--- a/src/analytics/clickhouse/endpoints/routing_events.rs
+++ b/src/analytics/clickhouse/endpoints/routing_events.rs
@@ -2,10 +2,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::analytics::models::{
     AnalyticsRange, RoutingEvent, RoutingEventType, RoutingEventsQuery, RoutingEventsResponse,
-    ROUTING_EVENTS_AUTH_BAND_HYSTERESIS_FLOOR, ROUTING_EVENTS_AUTH_BAND_Z,
-    ROUTING_EVENTS_SCORE_SAMPLE_SIZE, ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS,
-    ROUTING_EVENTS_SECOND_BUCKET_MS, ROUTING_EVENTS_STALENESS_BUCKETS,
-    ROUTING_EVENTS_STALENESS_FLOOR_MS,
+    ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS, ROUTING_EVENTS_SECOND_BUCKET_MS,
+    ROUTING_EVENTS_STALENESS_BUCKETS, ROUTING_EVENTS_STALENESS_FLOOR_MS,
 };
 use crate::analytics::service::now_ms;
 use crate::error::ApiError;
@@ -106,33 +104,6 @@ fn event_id(
     )
 }
 
-/// Standard error of the gap between two SR scores. Each score is a binomial
-/// proportion `p` measured over a moving window of `ROUTING_EVENTS_SCORE_SAMPLE_SIZE`
-/// transactions, so its sampling noise is `sqrt(p(1-p)/n)`; the gap between two
-/// such (independent) proportions has standard error
-/// `sqrt(p_a(1-p_a)/n + p_b(1-p_b)/n)`. The auth-band hysteresis is expressed as
-/// a multiple (`z`) of it rather than a hand-picked constant.
-fn score_gap_standard_error(score_a: f64, score_b: f64) -> f64 {
-    let variance = |p: f64| {
-        // The proportion variance is only defined on [0, 1]; clamp so an
-        // out-of-range value (e.g. test fixtures on a 0..100 scale) contributes
-        // zero noise instead of a negative that would poison the sqrt — the
-        // configured floor then takes over.
-        let p = p.clamp(0.0, 1.0);
-        p * (1.0 - p) / ROUTING_EVENTS_SCORE_SAMPLE_SIZE
-    };
-    (variance(score_a) + variance(score_b)).sqrt()
-}
-
-/// Auth-band hysteresis half-width for a gateway measured against the leader,
-/// sized to the noise of their score gap (`z * SE`). The deadband between
-/// `band_floor + h` (entry) and `band_floor - h` (exit) absorbs sub-noise wobble
-/// so a score parked on the band edge stops flapping. Like the leader margin it
-/// self-tunes to the scores' variance instead of the (policy-set) band width.
-fn auth_band_hysteresis(leader_score: f64, gateway_score: f64) -> f64 {
-    let se_gap = score_gap_standard_error(leader_score, gateway_score);
-    (ROUTING_EVENTS_AUTH_BAND_Z * se_gap).max(ROUTING_EVENTS_AUTH_BAND_HYSTERESIS_FLOOR)
-}
 
 /// Walk bucketed score points per dimension, carrying the last known score per
 /// gateway forward across sparse buckets, and emit routing events. Pure and
@@ -334,9 +305,9 @@ fn emit_auth_band_events(
                 >= query.min_transaction_count
                 && bucket_ms - former_state.last_seen_bucket_ms <= staleness_ms;
             // A demoted leader was already inside the band, so seed it as a member
-            // if it merely holds above the lenient exit floor.
-            let exit_floor = band_floor - auth_band_hysteresis(leader_score, former_state.score);
-            if eligible && former_state.score >= exit_floor {
+            // if it still holds at/above the band floor (same threshold a member is
+            // held to before exiting).
+            if eligible && former_state.score >= band_floor {
                 in_auth_band.insert(former.to_string());
             }
         }
@@ -349,15 +320,13 @@ fn emit_auth_band_events(
         let eligible = gateway_state.transaction_count.unwrap_or(0) >= query.min_transaction_count
             && bucket_ms - gateway_state.last_seen_bucket_ms <= staleness_ms;
         let was_in_band = in_auth_band.contains(gateway);
-        // Apply the strict entry threshold (band_floor + h) for a fresh crossing,
-        // the lenient exit threshold (band_floor - h) once already a member.
-        let hysteresis = auth_band_hysteresis(leader_score, gateway_state.score);
-        let threshold = if was_in_band {
-            band_floor - hysteresis
-        } else {
-            band_floor + hysteresis
-        };
-        let in_band_now = eligible && gateway_state.score >= threshold;
+        // Instantaneous, single-threshold membership: a gateway is in the cost band
+        // exactly when its score is within tolerance of the leader (>= band_floor),
+        // so both "entered" and "exited" fire the instant the score crosses the edge
+        // — no hysteresis/deadband. Flap protection instead lives downstream (the UI
+        // collapses any rapid re-crossings into one "contesting ×N" row), and the
+        // deterministic outcome scheduler keeps scores from jittering at the edge.
+        let in_band_now = eligible && gateway_state.score >= band_floor;
 
         if in_band_now && !was_in_band {
             in_auth_band.insert(gateway.clone());
@@ -783,31 +752,29 @@ mod tests {
     }
 
     #[test]
-    fn score_wobbling_on_band_edge_does_not_flap() {
-        // adyen leads at 0.95, so the raw band floor (tolerance 0.05) is 0.90. The
-        // noise-based hysteresis is z*SE ≈ 0.03 (n=125), making the band sticky
-        // roughly between 0.86 and 0.93. stripe enters once, then wobbles across the
-        // raw 0.90 floor by less than the deadband each bucket — the old single
-        // threshold fired an exit/enter on every crossing; now those wobbles stay
-        // inside the deadband and emit nothing until stripe genuinely drops out.
+    fn member_holding_in_band_does_not_re_fire() {
+        // Single instantaneous threshold at the band floor (no hysteresis). adyen
+        // leads 0.95, so floor (tolerance 0.05) is 0.90. stripe crosses in once, then
+        // wobbles while staying above the floor — membership is edge-triggered, so it
+        // emits nothing until it genuinely drops below the floor, where it exits once.
         let points = vec![
             point(0, "adyen", 0.95, 100),
-            point(0, "stripe", 0.90, 100), // below enter floor (~0.93): out of band
+            point(0, "stripe", 0.88, 100), // below floor: out of band
             point(BUCKET, "adyen", 0.95, 100),
-            point(BUCKET, "stripe", 0.94, 100), // clears enter floor: single entry
+            point(BUCKET, "stripe", 0.94, 100), // crosses floor: single entry
             point(2 * BUCKET, "adyen", 0.95, 100),
-            point(2 * BUCKET, "stripe", 0.89, 100), // under raw floor but within deadband: hold
+            point(2 * BUCKET, "stripe", 0.92, 100), // stays above floor: hold
             point(3 * BUCKET, "adyen", 0.95, 100),
-            point(3 * BUCKET, "stripe", 0.91, 100), // back above floor: hold
+            point(3 * BUCKET, "stripe", 0.91, 100), // stays above floor: hold
             point(4 * BUCKET, "adyen", 0.95, 100),
-            point(4 * BUCKET, "stripe", 0.88, 100), // still within deadband: hold
+            point(4 * BUCKET, "stripe", 0.93, 100), // stays above floor: hold
             point(5 * BUCKET, "adyen", 0.95, 100),
-            point(5 * BUCKET, "stripe", 0.85, 100), // clears exit floor (~0.863): single exit
+            point(5 * BUCKET, "stripe", 0.85, 100), // drops below floor 0.90: prompt exit
         ];
         let events = detect_routing_events(&points, &unit_scale_band_query(), 0);
 
         // Exactly one entry (the genuine crossing in) and one exit (the genuine drop
-        // out) — none of the mid-band wobble produces events.
+        // below the floor) — the in-band wobble produces nothing.
         let entered = entered_band_events(&events);
         assert_eq!(entered.len(), 1, "wobble must not re-fire entries");
         assert_eq!(entered[0].bucket_ms, BUCKET);
@@ -815,6 +782,23 @@ mod tests {
         let exited = exited_band_events(&events);
         assert_eq!(exited.len(), 1, "wobble must not re-fire exits");
         assert_eq!(exited[0].bucket_ms, 5 * BUCKET);
+    }
+
+    #[test]
+    fn exit_fires_promptly_at_the_band_floor() {
+        // Asymmetric hysteresis: a member that slips just below the floor exits on
+        // that bucket, without waiting for an extra deadband-sized drop. adyen leads
+        // 0.95 (floor 0.90); stripe is seeded in-band then dips to 0.895.
+        let points = vec![
+            point(0, "adyen", 0.95, 100),
+            point(0, "stripe", 0.94, 100), // seeded in band (clears enter floor ~0.93)
+            point(BUCKET, "adyen", 0.95, 100),
+            point(BUCKET, "stripe", 0.895, 100), // just below floor → exits now
+        ];
+        let events = detect_routing_events(&points, &unit_scale_band_query(), 0);
+        let exited = exited_band_events(&events);
+        assert_eq!(exited.len(), 1);
+        assert_eq!(exited[0].bucket_ms, BUCKET);
     }
 
     #[test]

--- a/src/analytics/clickhouse/endpoints/routing_events.rs
+++ b/src/analytics/clickhouse/endpoints/routing_events.rs
@@ -104,7 +104,6 @@ fn event_id(
     )
 }
 
-
 /// Walk bucketed score points per dimension, carrying the last known score per
 /// gateway forward across sparse buckets, and emit routing events. Pure and
 /// deterministic so event IDs are stable across polls.

--- a/src/analytics/clickhouse/endpoints/routing_events.rs
+++ b/src/analytics/clickhouse/endpoints/routing_events.rs
@@ -667,6 +667,37 @@ mod tests {
     }
 
     #[test]
+    fn psp_enters_once_holds_silently_then_exits_once() {
+        // The full contract: a PSP that enters the band fires one entered event,
+        // stays silent for every bucket it remains in the band, then fires exactly
+        // one exited event when it drops below the floor. adyen leads at 89 so the
+        // band floor is 84 throughout.
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 80.0, 100), // below floor: out of band (seeded)
+            point(BUCKET, "adyen", 89.0, 100),
+            point(BUCKET, "stripe", 86.0, 100), // crosses in → one entered
+            point(2 * BUCKET, "adyen", 89.0, 100),
+            point(2 * BUCKET, "stripe", 87.0, 100), // still in band → silent
+            point(3 * BUCKET, "adyen", 89.0, 100),
+            point(3 * BUCKET, "stripe", 88.0, 100), // still in band → silent
+            point(4 * BUCKET, "adyen", 89.0, 100),
+            point(4 * BUCKET, "stripe", 70.0, 100), // drops out → one exited
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+
+        let entered = entered_band_events(&events);
+        assert_eq!(entered.len(), 1, "exactly one entered event for the stint");
+        assert_eq!(entered[0].gateway, "stripe");
+        assert_eq!(entered[0].bucket_ms, BUCKET);
+
+        let exited = exited_band_events(&events);
+        assert_eq!(exited.len(), 1, "exactly one exited event for the stint");
+        assert_eq!(exited[0].gateway, "stripe");
+        assert_eq!(exited[0].bucket_ms, 4 * BUCKET);
+    }
+
+    #[test]
     fn multi_objective_off_suppresses_band_events_but_keeps_leader_changes() {
         // tolerance_pp = None models a merchant with multi-objective routing off:
         // the band is meaningless, so only the leader flip surfaces.

--- a/src/analytics/clickhouse/endpoints/routing_events.rs
+++ b/src/analytics/clickhouse/endpoints/routing_events.rs
@@ -140,6 +140,9 @@ fn detect_routing_events(
         // edge-triggered so an entry event fires only on a fresh crossing.
         let mut in_auth_band: HashSet<String> = HashSet::new();
         let mut previous_leader: Option<String> = None;
+        // The raw best gateway of the immediately preceding bucket, used to seed a
+        // demoted leader into the band silently when it stays within tolerance.
+        let mut prior_bucket_leader: Option<String> = None;
         let mut is_first_bucket = true;
 
         for (&bucket_ms, rows) in buckets {
@@ -174,6 +177,11 @@ fn detect_routing_events(
                 .map(|(name, gateway_state)| (name.clone(), gateway_state.score));
 
             if let Some((leader_name, leader_score)) = leader {
+                // Snapshot the prior bucket's leader before advancing it; the band
+                // detector uses it to recognise a leader that just got overtaken.
+                let former_leader = prior_bucket_leader.clone();
+                prior_bucket_leader = Some(leader_name.clone());
+
                 // Auth-band detection runs only when multi-objective routing is on
                 // (tolerance set); otherwise the band is meaningless and we emit
                 // leader changes alone.
@@ -190,6 +198,7 @@ fn detect_routing_events(
                         query,
                         staleness_ms,
                         is_first_bucket,
+                        former_leader.as_deref(),
                     );
                 }
 
@@ -258,8 +267,10 @@ fn detect_routing_events(
 /// `tolerance_pp` of the leader's; `GatewayExitedAuthBand` fires when it later
 /// drops below that floor or ages out. Membership is edge-triggered via
 /// `in_auth_band`, so each crossing fires exactly once. The leader is the band
-/// reference and never a member — a member promoted to leader exits silently,
-/// and a former leader that stays within tolerance fires a fresh entry.
+/// reference and never a member — a member promoted to leader exits silently.
+/// A leader that gets overtaken but stays within tolerance never actually left
+/// the band (only the reference moved), so it is re-seeded as a member silently
+/// via `former_leader` and does not fire a spurious entry.
 #[allow(clippy::too_many_arguments)]
 fn emit_auth_band_events(
     events: &mut Vec<RoutingEvent>,
@@ -273,11 +284,28 @@ fn emit_auth_band_events(
     query: &RoutingEventsQuery,
     staleness_ms: i64,
     is_first_bucket: bool,
+    former_leader: Option<&str>,
 ) {
     let band_floor = leader_score - tolerance_pp;
-    // The leader is the reference, never a member; clearing it silently (no exit
-    // event) means a re-entry after losing the lead counts as a fresh crossing.
+    // The leader is the reference, never a member.
     in_auth_band.remove(leader_name);
+
+    // When leadership just changed, the outgoing leader moves from "the reference"
+    // to an ordinary candidate. If it is still eligible and within tolerance of the
+    // new leader it was inside the band all along — the reference simply moved — so
+    // seed it as a member silently. Without this, the next bucket would report it as
+    // freshly entering a band it never left (e.g. two PSPs trading the lead while
+    // both stay within tolerance would each re-fire an entry on every flip-back).
+    if let Some(former) = former_leader.filter(|former| *former != leader_name) {
+        if let Some(former_state) = state.get(former) {
+            let eligible = former_state.transaction_count.unwrap_or(0)
+                >= query.min_transaction_count
+                && bucket_ms - former_state.last_seen_bucket_ms <= staleness_ms;
+            if eligible && former_state.score >= band_floor {
+                in_auth_band.insert(former.to_string());
+            }
+        }
+    }
 
     for (gateway, gateway_state) in state {
         if gateway == leader_name {
@@ -584,23 +612,57 @@ mod tests {
     }
 
     #[test]
-    fn former_leader_still_within_tolerance_enters_band_on_flip() {
+    fn former_leader_within_tolerance_does_not_re_enter_band_on_flip() {
         // adyen leads at 95 (band floor 90), stripe is out at 80. stripe then
-        // overtakes at 99 (floor 94); adyen's carried 95 lands in the new band.
+        // overtakes at 99 (floor 94); adyen's carried 95 still lands inside the new
+        // band. adyen was the reference the prior bucket and never dropped below
+        // tolerance, so the band's reference simply moved with the flip: it must not
+        // report a fresh entry, and it was never a member so it does not exit.
         let points = vec![
             point(0, "adyen", 95.0, 100),
             point(0, "stripe", 80.0, 100),
             point(BUCKET, "stripe", 99.0, 100),
         ];
         let events = detect_routing_events(&points, &query(), 0);
-        let band = entered_band_events(&events);
-        assert_eq!(band.len(), 1);
-        assert_eq!(band[0].gateway, "adyen");
-        assert_eq!(band[0].previous_gateway.as_deref(), Some("stripe"));
-        assert_eq!(band[0].score, Some(95.0));
-        assert_eq!(band[0].previous_score, Some(99.0));
-        // adyen was the leader, not a band member, so losing the lead is not an exit.
+        assert!(entered_band_events(&events).is_empty());
         assert!(exited_band_events(&events).is_empty());
+        // The leadership flip itself still surfaces.
+        assert!(events.iter().any(|event| {
+            event.event_type == RoutingEventType::LeaderChanged
+                && event.gateway == "stripe"
+                && event.previous_gateway.as_deref() == Some("adyen")
+        }));
+    }
+
+    #[test]
+    fn leaders_trading_within_tolerance_do_not_re_enter_band() {
+        // The reported bug: two PSPs swap the lead while both stay within tolerance.
+        // Each flip-back used to re-fire an entry for the gateway dropping to #2,
+        // even though it never left the band. stripe enters once on the way in; the
+        // subsequent lead swaps emit leader changes only, no further band entries.
+        let points = vec![
+            point(0, "adyen", 90.0, 100),
+            point(0, "stripe", 80.0, 100), // out of band (floor 85): seeded
+            point(BUCKET, "adyen", 90.0, 100),
+            point(BUCKET, "stripe", 88.0, 100), // crosses in → one entered
+            point(2 * BUCKET, "stripe", 91.0, 100), // stripe takes the lead
+            point(2 * BUCKET, "adyen", 90.0, 100), // adyen drops to #2, still in band
+            point(3 * BUCKET, "adyen", 92.0, 100), // adyen retakes the lead
+            point(3 * BUCKET, "stripe", 91.0, 100), // stripe drops to #2, still in band
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+
+        let entered = entered_band_events(&events);
+        assert_eq!(entered.len(), 1, "only stripe's initial crossing enters");
+        assert_eq!(entered[0].gateway, "stripe");
+        assert_eq!(entered[0].bucket_ms, BUCKET);
+        assert!(exited_band_events(&events).is_empty());
+
+        let flips = events
+            .iter()
+            .filter(|event| event.event_type == RoutingEventType::LeaderChanged)
+            .count();
+        assert_eq!(flips, 2, "both lead swaps still surface as leader changes");
     }
 
     #[test]

--- a/src/analytics/clickhouse/endpoints/routing_events.rs
+++ b/src/analytics/clickhouse/endpoints/routing_events.rs
@@ -2,8 +2,10 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::analytics::models::{
     AnalyticsRange, RoutingEvent, RoutingEventType, RoutingEventsQuery, RoutingEventsResponse,
-    ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS, ROUTING_EVENTS_SECOND_BUCKET_MS,
-    ROUTING_EVENTS_STALENESS_BUCKETS, ROUTING_EVENTS_STALENESS_FLOOR_MS,
+    ROUTING_EVENTS_AUTH_BAND_HYSTERESIS_FLOOR, ROUTING_EVENTS_AUTH_BAND_Z,
+    ROUTING_EVENTS_SCORE_SAMPLE_SIZE, ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS,
+    ROUTING_EVENTS_SECOND_BUCKET_MS, ROUTING_EVENTS_STALENESS_BUCKETS,
+    ROUTING_EVENTS_STALENESS_FLOOR_MS,
 };
 use crate::analytics::service::now_ms;
 use crate::error::ApiError;
@@ -102,6 +104,34 @@ fn event_id(
         bucket_ms,
         transition
     )
+}
+
+/// Standard error of the gap between two SR scores. Each score is a binomial
+/// proportion `p` measured over a moving window of `ROUTING_EVENTS_SCORE_SAMPLE_SIZE`
+/// transactions, so its sampling noise is `sqrt(p(1-p)/n)`; the gap between two
+/// such (independent) proportions has standard error
+/// `sqrt(p_a(1-p_a)/n + p_b(1-p_b)/n)`. The auth-band hysteresis is expressed as
+/// a multiple (`z`) of it rather than a hand-picked constant.
+fn score_gap_standard_error(score_a: f64, score_b: f64) -> f64 {
+    let variance = |p: f64| {
+        // The proportion variance is only defined on [0, 1]; clamp so an
+        // out-of-range value (e.g. test fixtures on a 0..100 scale) contributes
+        // zero noise instead of a negative that would poison the sqrt — the
+        // configured floor then takes over.
+        let p = p.clamp(0.0, 1.0);
+        p * (1.0 - p) / ROUTING_EVENTS_SCORE_SAMPLE_SIZE
+    };
+    (variance(score_a) + variance(score_b)).sqrt()
+}
+
+/// Auth-band hysteresis half-width for a gateway measured against the leader,
+/// sized to the noise of their score gap (`z * SE`). The deadband between
+/// `band_floor + h` (entry) and `band_floor - h` (exit) absorbs sub-noise wobble
+/// so a score parked on the band edge stops flapping. Like the leader margin it
+/// self-tunes to the scores' variance instead of the (policy-set) band width.
+fn auth_band_hysteresis(leader_score: f64, gateway_score: f64) -> f64 {
+    let se_gap = score_gap_standard_error(leader_score, gateway_score);
+    (ROUTING_EVENTS_AUTH_BAND_Z * se_gap).max(ROUTING_EVENTS_AUTH_BAND_HYSTERESIS_FLOOR)
 }
 
 /// Walk bucketed score points per dimension, carrying the last known score per
@@ -296,12 +326,17 @@ fn emit_auth_band_events(
     // seed it as a member silently. Without this, the next bucket would report it as
     // freshly entering a band it never left (e.g. two PSPs trading the lead while
     // both stay within tolerance would each re-fire an entry on every flip-back).
+    // Hysteresis half-width is sized per gateway to the noise of *its* gap with
+    // the leader, so the enter/exit deadband self-tunes to each score's variance.
     if let Some(former) = former_leader.filter(|former| *former != leader_name) {
         if let Some(former_state) = state.get(former) {
             let eligible = former_state.transaction_count.unwrap_or(0)
                 >= query.min_transaction_count
                 && bucket_ms - former_state.last_seen_bucket_ms <= staleness_ms;
-            if eligible && former_state.score >= band_floor {
+            // A demoted leader was already inside the band, so seed it as a member
+            // if it merely holds above the lenient exit floor.
+            let exit_floor = band_floor - auth_band_hysteresis(leader_score, former_state.score);
+            if eligible && former_state.score >= exit_floor {
                 in_auth_band.insert(former.to_string());
             }
         }
@@ -313,8 +348,16 @@ fn emit_auth_band_events(
         }
         let eligible = gateway_state.transaction_count.unwrap_or(0) >= query.min_transaction_count
             && bucket_ms - gateway_state.last_seen_bucket_ms <= staleness_ms;
-        let in_band_now = eligible && gateway_state.score >= band_floor;
         let was_in_band = in_auth_band.contains(gateway);
+        // Apply the strict entry threshold (band_floor + h) for a fresh crossing,
+        // the lenient exit threshold (band_floor - h) once already a member.
+        let hysteresis = auth_band_hysteresis(leader_score, gateway_state.score);
+        let threshold = if was_in_band {
+            band_floor - hysteresis
+        } else {
+            band_floor + hysteresis
+        };
+        let in_band_now = eligible && gateway_state.score >= threshold;
 
         if in_band_now && !was_in_band {
             in_auth_band.insert(gateway.clone());
@@ -474,6 +517,17 @@ mod tests {
         assert!(events
             .iter()
             .all(|event| event.event_type != RoutingEventType::LeaderChanged));
+    }
+
+    // 0..1 scores with the auth band on (5pp tolerance), so the noise-based band
+    // hysteresis (z * SE) produces a real deadband rather than collapsing to the
+    // floor as it does for the 0..100 fixtures.
+    fn unit_scale_band_query() -> RoutingEventsQuery {
+        RoutingEventsQuery {
+            min_score_delta: 0.001,
+            tolerance_pp: Some(0.05),
+            ..query()
+        }
     }
 
     #[test]
@@ -726,6 +780,41 @@ mod tests {
         ];
         let events = detect_routing_events(&points, &query(), 0);
         assert!(exited_band_events(&events).is_empty());
+    }
+
+    #[test]
+    fn score_wobbling_on_band_edge_does_not_flap() {
+        // adyen leads at 0.95, so the raw band floor (tolerance 0.05) is 0.90. The
+        // noise-based hysteresis is z*SE ≈ 0.03 (n=125), making the band sticky
+        // roughly between 0.86 and 0.93. stripe enters once, then wobbles across the
+        // raw 0.90 floor by less than the deadband each bucket — the old single
+        // threshold fired an exit/enter on every crossing; now those wobbles stay
+        // inside the deadband and emit nothing until stripe genuinely drops out.
+        let points = vec![
+            point(0, "adyen", 0.95, 100),
+            point(0, "stripe", 0.90, 100), // below enter floor (~0.93): out of band
+            point(BUCKET, "adyen", 0.95, 100),
+            point(BUCKET, "stripe", 0.94, 100), // clears enter floor: single entry
+            point(2 * BUCKET, "adyen", 0.95, 100),
+            point(2 * BUCKET, "stripe", 0.89, 100), // under raw floor but within deadband: hold
+            point(3 * BUCKET, "adyen", 0.95, 100),
+            point(3 * BUCKET, "stripe", 0.91, 100), // back above floor: hold
+            point(4 * BUCKET, "adyen", 0.95, 100),
+            point(4 * BUCKET, "stripe", 0.88, 100), // still within deadband: hold
+            point(5 * BUCKET, "adyen", 0.95, 100),
+            point(5 * BUCKET, "stripe", 0.85, 100), // clears exit floor (~0.863): single exit
+        ];
+        let events = detect_routing_events(&points, &unit_scale_band_query(), 0);
+
+        // Exactly one entry (the genuine crossing in) and one exit (the genuine drop
+        // out) — none of the mid-band wobble produces events.
+        let entered = entered_band_events(&events);
+        assert_eq!(entered.len(), 1, "wobble must not re-fire entries");
+        assert_eq!(entered[0].bucket_ms, BUCKET);
+
+        let exited = exited_band_events(&events);
+        assert_eq!(exited.len(), 1, "wobble must not re-fire exits");
+        assert_eq!(exited[0].bucket_ms, 5 * BUCKET);
     }
 
     #[test]

--- a/src/analytics/clickhouse/endpoints/routing_events.rs
+++ b/src/analytics/clickhouse/endpoints/routing_events.rs
@@ -1,0 +1,740 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::analytics::models::{
+    AnalyticsRange, RoutingEvent, RoutingEventType, RoutingEventsQuery, RoutingEventsResponse,
+    ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS, ROUTING_EVENTS_SECOND_BUCKET_MS,
+    ROUTING_EVENTS_STALENESS_BUCKETS, ROUTING_EVENTS_STALENESS_FLOOR_MS,
+};
+use crate::analytics::service::now_ms;
+use crate::error::ApiError;
+
+use super::super::metrics;
+use super::super::metrics::score_bucket_series::ScoreBucketPoint;
+
+pub async fn load(
+    client: &clickhouse::Client,
+    query: &RoutingEventsQuery,
+) -> Result<RoutingEventsResponse, ApiError> {
+    let (start_ms, end_ms) = effective_window_bounds(query);
+    // Fetch one staleness horizon before the window so the leader baseline is
+    // known and the first in-window bucket does not fire spurious events.
+    let lookback_start_ms = start_ms.saturating_sub(staleness_horizon_ms(query.bucket_ms));
+    let points =
+        metrics::score_bucket_series::load(client, query, lookback_start_ms, end_ms).await?;
+    let events = detect_routing_events(&points, query, start_ms);
+
+    Ok(RoutingEventsResponse {
+        merchant_id: query.merchant_id.clone(),
+        range: format_range(query),
+        events,
+        generated_at_ms: now_ms(),
+    })
+}
+
+fn effective_window_bounds(query: &RoutingEventsQuery) -> (i64, i64) {
+    let now = now_ms();
+    let end_ms = query.end_ms.unwrap_or(now).min(now);
+    // Snapshot rows are per-transaction; cap the window to bound scan volume —
+    // one week normally, one hour in second-granularity mode.
+    let max_window_ms = if query.bucket_ms == ROUTING_EVENTS_SECOND_BUCKET_MS {
+        ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS
+    } else {
+        AnalyticsRange::W1.window_ms()
+    };
+    let min_start_ms = end_ms.saturating_sub(max_window_ms);
+    let start_ms = query
+        .start_ms
+        .filter(|start_ms| *start_ms >= 0 && *start_ms < end_ms)
+        .unwrap_or_else(|| end_ms.saturating_sub(query.range.window_ms()))
+        .max(min_start_ms);
+    (start_ms, end_ms)
+}
+
+fn staleness_horizon_ms(bucket_ms: i64) -> i64 {
+    (ROUTING_EVENTS_STALENESS_BUCKETS * bucket_ms).max(ROUTING_EVENTS_STALENESS_FLOOR_MS)
+}
+
+fn format_range(query: &RoutingEventsQuery) -> String {
+    if query.start_ms.is_some() && query.end_ms.is_some() {
+        return "custom".to_string();
+    }
+
+    match query.range {
+        AnalyticsRange::M15 => "15m".to_string(),
+        AnalyticsRange::H1 => "1h".to_string(),
+        AnalyticsRange::H12 => "12h".to_string(),
+        AnalyticsRange::D1 => "1d".to_string(),
+        AnalyticsRange::W1 => "1w".to_string(),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GatewayState {
+    score: f64,
+    transaction_count: Option<i64>,
+    last_seen_bucket_ms: i64,
+}
+
+type DimensionKey = (Option<String>, Option<String>);
+
+fn dimension_part(value: &Option<String>) -> &str {
+    value.as_deref().unwrap_or("-")
+}
+
+fn event_id(
+    event_type: RoutingEventType,
+    merchant_id: &str,
+    dimension: &DimensionKey,
+    bucket_ms: i64,
+    previous_gateway: Option<&str>,
+    gateway: &str,
+) -> String {
+    let transition = match previous_gateway {
+        Some(previous) => format!("{previous}>{gateway}"),
+        None => gateway.to_string(),
+    };
+    format!(
+        "{}:{}:{}:{}:{}:{}",
+        event_type.as_str(),
+        merchant_id,
+        dimension_part(&dimension.0),
+        dimension_part(&dimension.1),
+        bucket_ms,
+        transition
+    )
+}
+
+/// Walk bucketed score points per dimension, carrying the last known score per
+/// gateway forward across sparse buckets, and emit routing events. Pure and
+/// deterministic so event IDs are stable across polls.
+fn detect_routing_events(
+    points: &[ScoreBucketPoint],
+    query: &RoutingEventsQuery,
+    window_start_ms: i64,
+) -> Vec<RoutingEvent> {
+    let staleness_ms = staleness_horizon_ms(query.bucket_ms);
+
+    // dimension -> bucket -> rows, ordered for deterministic iteration.
+    let mut dimensions: BTreeMap<DimensionKey, BTreeMap<i64, Vec<&ScoreBucketPoint>>> =
+        BTreeMap::new();
+    for point in points {
+        if point.gateway.is_none() || point.score_value.is_none() {
+            continue;
+        }
+        dimensions
+            .entry((
+                point.payment_method_type.clone(),
+                point.payment_method.clone(),
+            ))
+            .or_default()
+            .entry(point.bucket_ms)
+            .or_default()
+            .push(point);
+    }
+
+    let mut events = Vec::new();
+
+    for (dimension, buckets) in &dimensions {
+        let mut state: HashMap<String, GatewayState> = HashMap::new();
+        // Gateways currently inside the leader's auth band; membership is
+        // edge-triggered so an entry event fires only on a fresh crossing.
+        let mut in_auth_band: HashSet<String> = HashSet::new();
+        let mut previous_leader: Option<String> = None;
+        let mut is_first_bucket = true;
+
+        for (&bucket_ms, rows) in buckets {
+            for row in rows {
+                let gateway = row.gateway.clone().unwrap_or_default();
+                let score = row.score_value.unwrap_or_default();
+                state.insert(
+                    gateway,
+                    GatewayState {
+                        score,
+                        transaction_count: row.transaction_count,
+                        last_seen_bucket_ms: bucket_ms,
+                    },
+                );
+            }
+
+            // Leader = best eligible score; ties break to the lexicographically
+            // smaller gateway so the outcome is deterministic.
+            let leader = state
+                .iter()
+                .filter(|(_, gateway_state)| {
+                    gateway_state.transaction_count.unwrap_or(0) >= query.min_transaction_count
+                        && bucket_ms - gateway_state.last_seen_bucket_ms <= staleness_ms
+                })
+                .max_by(|(name_a, state_a), (name_b, state_b)| {
+                    state_a
+                        .score
+                        .partial_cmp(&state_b.score)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| name_b.cmp(name_a))
+                })
+                .map(|(name, gateway_state)| (name.clone(), gateway_state.score));
+
+            if let Some((leader_name, leader_score)) = leader {
+                // Auth-band detection runs only when multi-objective routing is on
+                // (tolerance set); otherwise the band is meaningless and we emit
+                // leader changes alone.
+                if let Some(tolerance_pp) = query.tolerance_pp {
+                    emit_auth_band_events(
+                        &mut events,
+                        &mut in_auth_band,
+                        &state,
+                        &leader_name,
+                        leader_score,
+                        tolerance_pp,
+                        bucket_ms,
+                        dimension,
+                        query,
+                        staleness_ms,
+                        is_first_bucket,
+                    );
+                }
+
+                match &previous_leader {
+                    Some(previous) if *previous != leader_name => {
+                        let previous_state = state.get(previous);
+                        let previous_still_eligible = previous_state.is_some_and(|gateway_state| {
+                            gateway_state.transaction_count.unwrap_or(0)
+                                >= query.min_transaction_count
+                                && bucket_ms - gateway_state.last_seen_bucket_ms <= staleness_ms
+                        });
+                        let previous_score =
+                            previous_state.map(|gateway_state| gateway_state.score);
+                        // A still-eligible incumbent must be beaten by a real
+                        // margin; an aged-out incumbent loses the crown outright.
+                        let is_decisive_flip = !previous_still_eligible
+                            || previous_score
+                                .is_none_or(|score| leader_score > score + query.min_score_delta);
+
+                        if is_decisive_flip {
+                            events.push(RoutingEvent {
+                                id: event_id(
+                                    RoutingEventType::LeaderChanged,
+                                    &query.merchant_id,
+                                    dimension,
+                                    bucket_ms,
+                                    Some(previous),
+                                    &leader_name,
+                                ),
+                                event_type: RoutingEventType::LeaderChanged,
+                                merchant_id: query.merchant_id.clone(),
+                                payment_method_type: dimension.0.clone(),
+                                payment_method: dimension.1.clone(),
+                                bucket_ms,
+                                gateway: leader_name.clone(),
+                                previous_gateway: Some(previous.clone()),
+                                score: Some(leader_score),
+                                previous_score,
+                                transaction_count: state
+                                    .get(&leader_name)
+                                    .and_then(|gateway_state| gateway_state.transaction_count),
+                            });
+                            previous_leader = Some(leader_name);
+                        }
+                    }
+                    Some(_) => {}
+                    None => {
+                        previous_leader = Some(leader_name);
+                    }
+                }
+            }
+
+            is_first_bucket = false;
+        }
+    }
+
+    // Drop events from the lookback prefix; newest first; deterministic order.
+    events.retain(|event| event.bucket_ms >= window_start_ms);
+    events.sort_by(|a, b| b.bucket_ms.cmp(&a.bucket_ms).then_with(|| a.id.cmp(&b.id)));
+    events.truncate(query.limit);
+    events
+}
+
+/// Emit auth-band crossing events for every eligible non-leader gateway.
+/// `GatewayEnteredAuthBand` fires when a gateway's score first rises to within
+/// `tolerance_pp` of the leader's; `GatewayExitedAuthBand` fires when it later
+/// drops below that floor or ages out. Membership is edge-triggered via
+/// `in_auth_band`, so each crossing fires exactly once. The leader is the band
+/// reference and never a member — a member promoted to leader exits silently,
+/// and a former leader that stays within tolerance fires a fresh entry.
+#[allow(clippy::too_many_arguments)]
+fn emit_auth_band_events(
+    events: &mut Vec<RoutingEvent>,
+    in_auth_band: &mut HashSet<String>,
+    state: &HashMap<String, GatewayState>,
+    leader_name: &str,
+    leader_score: f64,
+    tolerance_pp: f64,
+    bucket_ms: i64,
+    dimension: &DimensionKey,
+    query: &RoutingEventsQuery,
+    staleness_ms: i64,
+    is_first_bucket: bool,
+) {
+    let band_floor = leader_score - tolerance_pp;
+    // The leader is the reference, never a member; clearing it silently (no exit
+    // event) means a re-entry after losing the lead counts as a fresh crossing.
+    in_auth_band.remove(leader_name);
+
+    for (gateway, gateway_state) in state {
+        if gateway == leader_name {
+            continue;
+        }
+        let eligible = gateway_state.transaction_count.unwrap_or(0) >= query.min_transaction_count
+            && bucket_ms - gateway_state.last_seen_bucket_ms <= staleness_ms;
+        let in_band_now = eligible && gateway_state.score >= band_floor;
+        let was_in_band = in_auth_band.contains(gateway);
+
+        if in_band_now && !was_in_band {
+            in_auth_band.insert(gateway.clone());
+            // Seed membership silently at the window start so an already-tight
+            // field does not fire a storm of entries on the first bucket.
+            if !is_first_bucket {
+                events.push(auth_band_event(
+                    RoutingEventType::GatewayEnteredAuthBand,
+                    query,
+                    dimension,
+                    bucket_ms,
+                    leader_name,
+                    leader_score,
+                    gateway,
+                    gateway_state,
+                ));
+            }
+        } else if !in_band_now && was_in_band {
+            in_auth_band.remove(gateway);
+            events.push(auth_band_event(
+                RoutingEventType::GatewayExitedAuthBand,
+                query,
+                dimension,
+                bucket_ms,
+                leader_name,
+                leader_score,
+                gateway,
+                gateway_state,
+            ));
+        }
+    }
+}
+
+/// Build an auth-band entry/exit event. The gateway's own score and txn count
+/// describe the crossing; `previous_gateway`/`previous_score` carry the leader it
+/// is measured against, so the band reference travels with the event.
+#[allow(clippy::too_many_arguments)]
+fn auth_band_event(
+    event_type: RoutingEventType,
+    query: &RoutingEventsQuery,
+    dimension: &DimensionKey,
+    bucket_ms: i64,
+    leader_name: &str,
+    leader_score: f64,
+    gateway: &str,
+    gateway_state: &GatewayState,
+) -> RoutingEvent {
+    RoutingEvent {
+        id: event_id(
+            event_type,
+            &query.merchant_id,
+            dimension,
+            bucket_ms,
+            Some(leader_name),
+            gateway,
+        ),
+        event_type,
+        merchant_id: query.merchant_id.clone(),
+        payment_method_type: dimension.0.clone(),
+        payment_method: dimension.1.clone(),
+        bucket_ms,
+        gateway: gateway.to_string(),
+        previous_gateway: Some(leader_name.to_string()),
+        score: Some(gateway_state.score),
+        previous_score: Some(leader_score),
+        transaction_count: gateway_state.transaction_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::models::{RoutingEventsQuery, ROUTING_EVENTS_BUCKET_MS};
+
+    const BUCKET: i64 = ROUTING_EVENTS_BUCKET_MS;
+
+    fn query() -> RoutingEventsQuery {
+        RoutingEventsQuery {
+            merchant_id: "m_123".to_string(),
+            range: AnalyticsRange::H12,
+            start_ms: None,
+            end_ms: None,
+            payment_method_type: None,
+            payment_method: None,
+            min_transaction_count: 10,
+            min_score_delta: 0.5,
+            // Test scores are on a 0..100 scale, so a 5-point band is workable.
+            // Some(..) = multi-objective on; None disables auth-band detection.
+            tolerance_pp: Some(5.0),
+            limit: 50,
+            bucket_ms: ROUTING_EVENTS_BUCKET_MS,
+        }
+    }
+
+    fn point(
+        bucket_ms: i64,
+        gateway: &str,
+        score: f64,
+        transaction_count: i64,
+    ) -> ScoreBucketPoint {
+        ScoreBucketPoint {
+            bucket_ms,
+            merchant_id: Some("m_123".to_string()),
+            payment_method_type: Some("card".to_string()),
+            payment_method: Some("credit".to_string()),
+            gateway: Some(gateway.to_string()),
+            score_value: Some(score),
+            transaction_count: Some(transaction_count),
+        }
+    }
+
+    #[test]
+    fn leader_flip_emits_event_with_stable_id() {
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 87.0, 100),
+            point(BUCKET, "stripe", 90.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        let flips: Vec<_> = events
+            .iter()
+            .filter(|event| event.event_type == RoutingEventType::LeaderChanged)
+            .collect();
+        assert_eq!(flips.len(), 1);
+        let flip = flips[0];
+        assert_eq!(flip.gateway, "stripe");
+        assert_eq!(flip.previous_gateway.as_deref(), Some("adyen"));
+        assert_eq!(flip.score, Some(90.0));
+        assert_eq!(flip.previous_score, Some(89.0));
+        assert_eq!(
+            flip.id,
+            format!("leader_changed:m_123:card:credit:{BUCKET}:adyen>stripe")
+        );
+
+        // Identical input yields identical IDs across polls.
+        let rerun = detect_routing_events(&points, &query(), 0);
+        assert_eq!(
+            rerun
+                .iter()
+                .map(|event| event.id.clone())
+                .collect::<Vec<_>>(),
+            events
+                .iter()
+                .map(|event| event.id.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn flip_below_min_score_delta_is_suppressed() {
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 87.0, 100),
+            point(BUCKET, "stripe", 89.3, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(events
+            .iter()
+            .all(|event| event.event_type != RoutingEventType::LeaderChanged));
+    }
+
+    #[test]
+    fn tied_scores_do_not_flip_leader() {
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 87.0, 100),
+            point(BUCKET, "stripe", 89.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(events
+            .iter()
+            .all(|event| event.event_type != RoutingEventType::LeaderChanged));
+    }
+
+    #[test]
+    fn carry_forward_keeps_absent_leader_on_top() {
+        // adyen has no snapshot in bucket 1 but its carried score still leads.
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 80.0, 100),
+            point(BUCKET, "stripe", 85.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(events
+            .iter()
+            .all(|event| event.event_type != RoutingEventType::LeaderChanged));
+    }
+
+    #[test]
+    fn stale_leader_loses_crown_without_delta_requirement() {
+        let stale_bucket = (ROUTING_EVENTS_STALENESS_BUCKETS + 1) * BUCKET;
+        let mut points = vec![point(0, "adyen", 95.0, 100), point(0, "stripe", 80.0, 100)];
+        // stripe keeps reporting, adyen goes silent past the staleness horizon.
+        for bucket_index in 1..=(ROUTING_EVENTS_STALENESS_BUCKETS + 1) {
+            points.push(point(bucket_index * BUCKET, "stripe", 80.0, 100));
+        }
+        let events = detect_routing_events(&points, &query(), 0);
+        let flips: Vec<_> = events
+            .iter()
+            .filter(|event| event.event_type == RoutingEventType::LeaderChanged)
+            .collect();
+        assert_eq!(flips.len(), 1);
+        assert_eq!(flips[0].gateway, "stripe");
+        assert_eq!(flips[0].previous_gateway.as_deref(), Some("adyen"));
+        assert_eq!(flips[0].bucket_ms, stale_bucket);
+    }
+
+    #[test]
+    fn low_transaction_count_gateways_are_ignored() {
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 87.0, 100),
+            // Beats adyen on score but is below the txn gate: no flip, no entry.
+            point(BUCKET, "newpay", 99.0, 3),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(events.is_empty());
+    }
+
+    fn entered_band_events(events: &[RoutingEvent]) -> Vec<&RoutingEvent> {
+        events
+            .iter()
+            .filter(|event| event.event_type == RoutingEventType::GatewayEnteredAuthBand)
+            .collect()
+    }
+
+    fn exited_band_events(events: &[RoutingEvent]) -> Vec<&RoutingEvent> {
+        events
+            .iter()
+            .filter(|event| event.event_type == RoutingEventType::GatewayExitedAuthBand)
+            .collect()
+    }
+
+    #[test]
+    fn gateway_crossing_into_auth_band_emits_once() {
+        // adyen leads at 89, so the band floor is 84. stripe starts below it and
+        // rises into the band, then holds — one entry, no re-fire.
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 80.0, 100),
+            point(BUCKET, "adyen", 89.0, 100),
+            point(BUCKET, "stripe", 86.0, 100),
+            point(2 * BUCKET, "adyen", 89.0, 100),
+            point(2 * BUCKET, "stripe", 87.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        let band = entered_band_events(&events);
+        assert_eq!(band.len(), 1);
+        assert_eq!(band[0].gateway, "stripe");
+        assert_eq!(band[0].previous_gateway.as_deref(), Some("adyen"));
+        assert_eq!(band[0].score, Some(86.0));
+        assert_eq!(band[0].previous_score, Some(89.0));
+        assert_eq!(band[0].bucket_ms, BUCKET);
+        assert_eq!(
+            band[0].id,
+            format!("gateway_entered_auth_band:m_123:card:credit:{BUCKET}:adyen>stripe")
+        );
+        // stripe never falls back out, so no exit fires.
+        assert!(exited_band_events(&events).is_empty());
+    }
+
+    #[test]
+    fn gateway_leaving_and_reentering_band_emits_exit_then_entry() {
+        let points = vec![
+            // Seeds inside the band at the window start: silent.
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 86.0, 100),
+            // Drops out of the band: exit event.
+            point(BUCKET, "adyen", 89.0, 100),
+            point(BUCKET, "stripe", 80.0, 100),
+            // Crosses back in: fresh entry event.
+            point(2 * BUCKET, "adyen", 89.0, 100),
+            point(2 * BUCKET, "stripe", 86.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+
+        let exited = exited_band_events(&events);
+        assert_eq!(exited.len(), 1);
+        assert_eq!(exited[0].gateway, "stripe");
+        assert_eq!(exited[0].bucket_ms, BUCKET);
+
+        let entered = entered_band_events(&events);
+        assert_eq!(entered.len(), 1);
+        assert_eq!(entered[0].gateway, "stripe");
+        assert_eq!(entered[0].bucket_ms, 2 * BUCKET);
+    }
+
+    #[test]
+    fn already_tight_field_does_not_storm_at_window_start() {
+        // stripe is already inside adyen's band on the first bucket: seeded, not fired.
+        let points = vec![point(0, "adyen", 89.0, 100), point(0, "stripe", 86.0, 100)];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(entered_band_events(&events).is_empty());
+        assert!(exited_band_events(&events).is_empty());
+    }
+
+    #[test]
+    fn former_leader_still_within_tolerance_enters_band_on_flip() {
+        // adyen leads at 95 (band floor 90), stripe is out at 80. stripe then
+        // overtakes at 99 (floor 94); adyen's carried 95 lands in the new band.
+        let points = vec![
+            point(0, "adyen", 95.0, 100),
+            point(0, "stripe", 80.0, 100),
+            point(BUCKET, "stripe", 99.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        let band = entered_band_events(&events);
+        assert_eq!(band.len(), 1);
+        assert_eq!(band[0].gateway, "adyen");
+        assert_eq!(band[0].previous_gateway.as_deref(), Some("stripe"));
+        assert_eq!(band[0].score, Some(95.0));
+        assert_eq!(band[0].previous_score, Some(99.0));
+        // adyen was the leader, not a band member, so losing the lead is not an exit.
+        assert!(exited_band_events(&events).is_empty());
+    }
+
+    #[test]
+    fn out_of_band_gateway_never_enters() {
+        // stripe trails far behind adyen's band the whole time.
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 60.0, 100),
+            point(BUCKET, "adyen", 89.0, 100),
+            point(BUCKET, "stripe", 70.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(entered_band_events(&events).is_empty());
+        assert!(exited_band_events(&events).is_empty());
+    }
+
+    #[test]
+    fn low_transaction_count_gateway_does_not_enter_band() {
+        // newpay sits inside the band but stays below the txn gate: no entry.
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 80.0, 100),
+            point(BUCKET, "adyen", 89.0, 100),
+            point(BUCKET, "newpay", 88.0, 3),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(entered_band_events(&events).is_empty());
+    }
+
+    #[test]
+    fn gateway_dropping_out_of_band_emits_exit() {
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            // stripe seeded inside the band (floor 84).
+            point(0, "stripe", 86.0, 100),
+            point(BUCKET, "adyen", 89.0, 100),
+            // stripe falls below the floor: a single exit event.
+            point(BUCKET, "stripe", 80.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        let exited = exited_band_events(&events);
+        assert_eq!(exited.len(), 1);
+        assert_eq!(exited[0].gateway, "stripe");
+        assert_eq!(exited[0].previous_gateway.as_deref(), Some("adyen"));
+        assert_eq!(exited[0].score, Some(80.0));
+        assert_eq!(exited[0].previous_score, Some(89.0));
+        assert_eq!(exited[0].bucket_ms, BUCKET);
+        assert_eq!(
+            exited[0].id,
+            format!("gateway_exited_auth_band:m_123:card:credit:{BUCKET}:adyen>stripe")
+        );
+    }
+
+    #[test]
+    fn band_member_promoted_to_leader_does_not_emit_exit() {
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            // stripe seeded inside the band, then overtakes adyen as leader.
+            point(0, "stripe", 86.0, 100),
+            point(BUCKET, "stripe", 95.0, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(exited_band_events(&events).is_empty());
+    }
+
+    #[test]
+    fn multi_objective_off_suppresses_band_events_but_keeps_leader_changes() {
+        // tolerance_pp = None models a merchant with multi-objective routing off:
+        // the band is meaningless, so only the leader flip surfaces.
+        let mut mo_off = query();
+        mo_off.tolerance_pp = None;
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 80.0, 100),
+            // stripe would enter the band here and overtake at the next bucket.
+            point(BUCKET, "adyen", 89.0, 100),
+            point(BUCKET, "stripe", 86.0, 100),
+            point(2 * BUCKET, "stripe", 95.0, 100),
+        ];
+        let events = detect_routing_events(&points, &mo_off, 0);
+        assert!(entered_band_events(&events).is_empty());
+        assert!(exited_band_events(&events).is_empty());
+        // The SR leader flip is independent of multi-objective and still fires.
+        assert!(events
+            .iter()
+            .any(|event| event.event_type == RoutingEventType::LeaderChanged));
+    }
+
+    #[test]
+    fn lookback_prefix_events_are_dropped() {
+        let window_start = 2 * BUCKET;
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 87.0, 100),
+            // Flip happens before the requested window: used as baseline only.
+            point(BUCKET, "stripe", 95.0, 100),
+            point(window_start, "stripe", 95.5, 100),
+        ];
+        let events = detect_routing_events(&points, &query(), window_start);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn dimensions_are_tracked_independently() {
+        let mut upi = point(BUCKET, "stripe", 99.0, 100);
+        upi.payment_method_type = Some("upi".to_string());
+        upi.payment_method = Some("collect".to_string());
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 87.0, 100),
+            // A high stripe score in another dimension must not flip card/credit.
+            upi,
+        ];
+        let events = detect_routing_events(&points, &query(), 0);
+        assert!(events
+            .iter()
+            .all(|event| event.event_type != RoutingEventType::LeaderChanged));
+    }
+
+    #[test]
+    fn events_are_sorted_newest_first_and_limited() {
+        let points = vec![
+            point(0, "adyen", 89.0, 100),
+            point(0, "stripe", 87.0, 100),
+            point(BUCKET, "stripe", 90.0, 100),
+            // adyen retakes the lead by a wide margin so stripe drops out of the
+            // band — the newest bucket holds a single, unambiguous event.
+            point(2 * BUCKET, "adyen", 100.0, 100),
+        ];
+        let mut limited_query = query();
+        limited_query.limit = 1;
+        let events = detect_routing_events(&points, &limited_query, 0);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].bucket_ms, 2 * BUCKET);
+        assert_eq!(events[0].gateway, "adyen");
+    }
+}

--- a/src/analytics/clickhouse/metrics/cost_savings.rs
+++ b/src/analytics/clickhouse/metrics/cost_savings.rs
@@ -1,0 +1,165 @@
+use clickhouse::Row;
+use serde::Deserialize;
+
+use crate::analytics::flow::FlowType;
+use crate::analytics::models::{
+    AnalyticsAvailableCurrency, AnalyticsCostSavingsTotals, AnalyticsCostSavingsTrendPoint,
+    AnalyticsQuery,
+};
+use crate::error::ApiError;
+
+use super::super::common::{fetch_all, fetch_one, DOMAIN_TABLE};
+use super::super::filters::{analytics_dimension_filters, base_window_filters, merchant_filter};
+use super::super::query::{BoundQueryBuilder, FilterClause, OrderClause};
+use super::super::time::{effective_window_bounds, query_bucket_select_expr};
+
+const COST_SAVED_BPS_EXPR: &str =
+    "JSONExtractFloat(assumeNotNull(details), 'response', 'multi_objective_info', 'costSavedBps')";
+const MO_OUTCOME_EXPR: &str =
+    "JSONExtractString(assumeNotNull(details), 'response', 'multi_objective_info', 'outcome')";
+const PAYMENT_AMOUNT_EXPR: &str =
+    "JSONExtractFloat(assumeNotNull(details), 'request', 'paymentInfo', 'amount')";
+// Currency lives in the request JSON, not the top-level `currency` column (which is NULL for
+// /decide-gateway events).
+const PAYMENT_CURRENCY_EXPR: &str =
+    "JSONExtractString(assumeNotNull(details), 'request', 'paymentInfo', 'currency')";
+
+fn decision_flow_filter() -> FilterClause {
+    FilterClause::raw(format!(
+        "flow_type = '{}'",
+        FlowType::DecideGatewayDecision.as_str()
+    ))
+}
+
+#[derive(Debug, Deserialize, Row)]
+struct AvailableCurrencyRow {
+    // JSONExtractString returns non-nullable String (empty when key absent).
+    currency: String,
+    decision_count: u64,
+}
+
+/// Currencies seen in the window for decisions that ran multi-objective and had a positive saving.
+/// Used to populate the chart's currency dropdown and pick a default ("top currency").
+///
+/// We intentionally bypass `analytics_dimension_filters` here — the dropdown should list every
+/// available currency regardless of what's already selected.
+pub async fn load_available_currencies(
+    client: &clickhouse::Client,
+    query: &AnalyticsQuery,
+) -> Result<Vec<AnalyticsAvailableCurrency>, ApiError> {
+    let (start_ms, end_ms) = effective_window_bounds(query);
+    let mut builder = BoundQueryBuilder::new(DOMAIN_TABLE);
+    builder.extend_selects([
+        format!("{PAYMENT_CURRENCY_EXPR} AS currency"),
+        "count() AS decision_count".to_string(),
+    ]);
+    builder.extend_filters(base_window_filters(start_ms, end_ms));
+    builder.extend_filters(merchant_filter(&query.merchant_id));
+    builder.add_filter(decision_flow_filter());
+    builder.add_filter(FilterClause::raw(format!("{MO_OUTCOME_EXPR} = 'COST_WON'")));
+    builder.add_filter(FilterClause::raw(format!("{COST_SAVED_BPS_EXPR} > 0")));
+    builder.extend_group_bys(["currency"]);
+    builder.add_order_by(OrderClause::desc("decision_count"));
+    builder.set_limit(Some(20));
+
+    let rows = fetch_all::<AvailableCurrencyRow>(builder.build(client)).await?;
+    Ok(rows
+        .into_iter()
+        .filter(|row| !row.currency.is_empty())
+        .map(|row| AnalyticsAvailableCurrency {
+            currency: row.currency,
+            decision_count: row.decision_count,
+        })
+        .collect())
+}
+
+#[derive(Debug, Deserialize, Row)]
+struct TrendRow {
+    bucket_ms: i64,
+    saved_value: f64,
+}
+
+/// Time-bucketed cost savings in the active currency: sum of (cost_saved_bps / 10000) * amount.
+///
+/// Currency is JSON-extracted (not filtered through `query.currency` / dimension filters)
+/// because the top-level `currency` column is NULL for /decide-gateway events.
+pub async fn load_cost_savings_trend(
+    client: &clickhouse::Client,
+    query: &AnalyticsQuery,
+    currency: &str,
+) -> Result<Vec<AnalyticsCostSavingsTrendPoint>, ApiError> {
+    let (start_ms, end_ms) = effective_window_bounds(query);
+    let mut scoped = query.clone();
+    scoped.currency = None;
+    let mut builder = BoundQueryBuilder::new(DOMAIN_TABLE);
+    builder.extend_selects([
+        query_bucket_select_expr(query, start_ms, end_ms),
+        format!(
+            "sum(({COST_SAVED_BPS_EXPR} / 10000.0) * {PAYMENT_AMOUNT_EXPR}) AS saved_value"
+        ),
+    ]);
+    builder.extend_filters(base_window_filters(start_ms, end_ms));
+    builder.extend_filters(merchant_filter(&query.merchant_id));
+    builder.extend_filters(analytics_dimension_filters(&scoped));
+    builder.add_filter(decision_flow_filter());
+    builder.add_filter(FilterClause::raw(format!("{MO_OUTCOME_EXPR} = 'COST_WON'")));
+    builder.add_filter(FilterClause::raw(format!("{COST_SAVED_BPS_EXPR} > 0")));
+    builder.add_filter(FilterClause::new(
+        format!("{PAYMENT_CURRENCY_EXPR} = ?"),
+        vec![currency.to_string().into()],
+    ));
+    builder.extend_group_bys(["bucket_ms"]);
+    builder.add_order_by(OrderClause::asc("bucket_ms"));
+
+    let rows = fetch_all::<TrendRow>(builder.build(client)).await?;
+    Ok(rows
+        .into_iter()
+        .map(|row| AnalyticsCostSavingsTrendPoint {
+            bucket_ms: row.bucket_ms,
+            saved_value: row.saved_value,
+        })
+        .collect())
+}
+
+#[derive(Debug, Deserialize, Row)]
+struct TotalsRow {
+    saved_value: f64,
+    cost_won_count: u64,
+    total_decisions: u64,
+}
+
+/// Aggregate totals for the KPI tile.
+/// `total_decisions` counts every multi-objective decision (where `cost_saved_bps` was computed),
+/// `cost_won_count` is the subset where the cheaper PSP was picked.
+pub async fn load_cost_savings_totals(
+    client: &clickhouse::Client,
+    query: &AnalyticsQuery,
+    currency: &str,
+) -> Result<AnalyticsCostSavingsTotals, ApiError> {
+    let (start_ms, end_ms) = effective_window_bounds(query);
+    let mut scoped = query.clone();
+    scoped.currency = None;
+    let mut builder = BoundQueryBuilder::new(DOMAIN_TABLE);
+    builder.extend_selects([
+        format!(
+            "sumIf(({COST_SAVED_BPS_EXPR} / 10000.0) * {PAYMENT_AMOUNT_EXPR}, {MO_OUTCOME_EXPR} = 'COST_WON') AS saved_value"
+        ),
+        format!("countIf({MO_OUTCOME_EXPR} = 'COST_WON') AS cost_won_count"),
+        format!("countIf({MO_OUTCOME_EXPR} != '') AS total_decisions"),
+    ]);
+    builder.extend_filters(base_window_filters(start_ms, end_ms));
+    builder.extend_filters(merchant_filter(&query.merchant_id));
+    builder.extend_filters(analytics_dimension_filters(&scoped));
+    builder.add_filter(decision_flow_filter());
+    builder.add_filter(FilterClause::new(
+        format!("{PAYMENT_CURRENCY_EXPR} = ?"),
+        vec![currency.to_string().into()],
+    ));
+
+    let row = fetch_one::<TotalsRow>(builder.build(client)).await?;
+    Ok(AnalyticsCostSavingsTotals {
+        saved_value: row.saved_value,
+        cost_won_count: row.cost_won_count,
+        total_decisions: row.total_decisions,
+    })
+}

--- a/src/analytics/clickhouse/metrics/cost_savings.rs
+++ b/src/analytics/clickhouse/metrics/cost_savings.rs
@@ -94,9 +94,7 @@ pub async fn load_cost_savings_trend(
     let mut builder = BoundQueryBuilder::new(DOMAIN_TABLE);
     builder.extend_selects([
         query_bucket_select_expr(query, start_ms, end_ms),
-        format!(
-            "sum(({COST_SAVED_BPS_EXPR} / 10000.0) * {PAYMENT_AMOUNT_EXPR}) AS saved_value"
-        ),
+        format!("sum(({COST_SAVED_BPS_EXPR} / 10000.0) * {PAYMENT_AMOUNT_EXPR}) AS saved_value"),
     ]);
     builder.extend_filters(base_window_filters(start_ms, end_ms));
     builder.extend_filters(merchant_filter(&query.merchant_id));

--- a/src/analytics/clickhouse/metrics/mod.rs
+++ b/src/analytics/clickhouse/metrics/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit_summaries;
 pub mod audit_timeline;
+pub mod cost_savings;
 pub mod decision_approaches;
 pub mod decision_series;
 pub mod decision_tiles;

--- a/src/analytics/clickhouse/metrics/mod.rs
+++ b/src/analytics/clickhouse/metrics/mod.rs
@@ -11,6 +11,7 @@ pub mod log_samples;
 pub mod overview_counts;
 pub mod route_hits;
 pub mod rule_hits;
+pub mod score_bucket_series;
 pub mod score_series;
 pub mod score_snapshots;
 pub mod smart_retry_stats;

--- a/src/analytics/clickhouse/metrics/score_bucket_series.rs
+++ b/src/analytics/clickhouse/metrics/score_bucket_series.rs
@@ -1,0 +1,74 @@
+use clickhouse::Row;
+use serde::Deserialize;
+
+use crate::analytics::models::{
+    RoutingEventsQuery, ROUTING_EVENTS_FAST_BUCKET_MS, ROUTING_EVENTS_SECOND_BUCKET_MS,
+};
+use crate::error::ApiError;
+
+use super::super::common::{
+    fetch_all, static_flow_type_in_sql, DOMAIN_TABLE, OVERVIEW_SCORE_FLOW_TYPES,
+};
+use super::super::filters::base_window_filters;
+use super::super::query::{BoundQueryBuilder, FilterClause, OrderClause};
+
+/// Latest score per gateway per fixed five-minute bucket. Buckets are
+/// wall-clock aligned so downstream event IDs stay stable across polls.
+#[derive(Debug, Clone, Deserialize, Row)]
+pub struct ScoreBucketPoint {
+    pub bucket_ms: i64,
+    pub merchant_id: Option<String>,
+    pub payment_method_type: Option<String>,
+    pub payment_method: Option<String>,
+    pub gateway: Option<String>,
+    pub score_value: Option<f64>,
+    pub transaction_count: Option<i64>,
+}
+
+pub async fn load(
+    client: &clickhouse::Client,
+    query: &RoutingEventsQuery,
+    start_ms: i64,
+    end_ms: i64,
+) -> Result<Vec<ScoreBucketPoint>, ApiError> {
+    let bucket_expr = if query.bucket_ms == ROUTING_EVENTS_SECOND_BUCKET_MS {
+        "toUnixTimestamp(created_at) * 1000 AS bucket_ms"
+    } else if query.bucket_ms == ROUTING_EVENTS_FAST_BUCKET_MS {
+        "toUnixTimestamp(toStartOfMinute(created_at)) * 1000 AS bucket_ms"
+    } else {
+        "toUnixTimestamp(toStartOfFiveMinutes(created_at)) * 1000 AS bucket_ms"
+    };
+    let mut builder = BoundQueryBuilder::new(DOMAIN_TABLE);
+    builder.extend_selects([
+        bucket_expr,
+        "merchant_id",
+        "payment_method_type",
+        "payment_method",
+        "gateway",
+        "argMax(score_value, created_at_ms) AS score_value",
+        "argMax(transaction_count, created_at_ms) AS transaction_count",
+    ]);
+    builder.extend_filters(base_window_filters(start_ms, end_ms));
+    builder.add_filter(FilterClause::eq("merchant_id", query.merchant_id.clone()));
+    builder.add_filter(FilterClause::raw(format!(
+        "flow_type IN {}",
+        static_flow_type_in_sql(OVERVIEW_SCORE_FLOW_TYPES)
+    )));
+    if let Some(value) = &query.payment_method_type {
+        builder.add_filter(FilterClause::eq("payment_method_type", value.clone()));
+    }
+    if let Some(value) = &query.payment_method {
+        builder.add_filter(FilterClause::eq("payment_method", value.clone()));
+    }
+    builder.extend_group_bys([
+        "bucket_ms",
+        "merchant_id",
+        "payment_method_type",
+        "payment_method",
+        "gateway",
+    ]);
+    builder.add_order_by(OrderClause::asc("bucket_ms"));
+    builder.add_order_by(OrderClause::asc("gateway"));
+
+    fetch_all::<ScoreBucketPoint>(builder.build(client)).await
+}

--- a/src/analytics/clickhouse/mod.rs
+++ b/src/analytics/clickhouse/mod.rs
@@ -137,4 +137,11 @@ impl AnalyticsReadStore for ClickHouseAnalyticsStore {
     ) -> Result<ExperimentTransactionsResponse, ApiError> {
         endpoints::experiment_transactions::load(&self.client, query).await
     }
+
+    async fn routing_events(
+        &self,
+        query: &RoutingEventsQuery,
+    ) -> Result<RoutingEventsResponse, ApiError> {
+        endpoints::routing_events::load(&self.client, query).await
+    }
 }

--- a/src/analytics/clickhouse/mod.rs
+++ b/src/analytics/clickhouse/mod.rs
@@ -96,6 +96,13 @@ impl AnalyticsReadStore for ClickHouseAnalyticsStore {
         endpoints::routing_stats::load(&self.client, query).await
     }
 
+    async fn cost_savings(
+        &self,
+        query: &AnalyticsQuery,
+    ) -> Result<AnalyticsCostSavingsResponse, ApiError> {
+        endpoints::cost_savings::load(&self.client, query).await
+    }
+
     async fn log_summaries(
         &self,
         query: &AnalyticsQuery,

--- a/src/analytics/models.rs
+++ b/src/analytics/models.rs
@@ -569,6 +569,21 @@ pub const ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS: i64 = 60 * 60 * 1000;
 pub const DEFAULT_ROUTING_EVENTS_MIN_TXN_COUNT: i64 = 10;
 // SR scores are on a 0..1 scale (see gateway_scoring_service success_rate).
 pub const DEFAULT_ROUTING_EVENTS_MIN_SCORE_DELTA: f64 = 0.01;
+// Effective number of samples behind each SR score — the moving window the score
+// is averaged over (mirrors DEFAULT_SR_V3_BASED_BUCKET_SIZE). Used as `n` in the
+// binomial standard error sqrt(p(1-p)/n) that sizes the auth-band hysteresis.
+pub const ROUTING_EVENTS_SCORE_SAMPLE_SIZE: f64 = 125.0;
+// Hysteresis (deadband) for auth-band membership, sized to the *noise* of the
+// score gap rather than the band width: half-width = z * SE(gap), the same
+// binomial standard error used for leader changes. A gateway must clear
+// `band_floor + h` to be reported entering and fall below `band_floor - h` to
+// be reported exiting, so a score sitting on the edge stops re-crossing on every
+// sub-pp wobble (band "flapping"). z is smaller than the leader-change z because
+// this only suppresses chatter, it is not a confidence claim.
+pub const ROUTING_EVENTS_AUTH_BAND_Z: f64 = 1.0;
+// Hard minimum band-hysteresis half-width, so an extreme (near 0/1) score whose
+// variance collapses to ~0 still keeps a small deadband.
+pub const ROUTING_EVENTS_AUTH_BAND_HYSTERESIS_FLOOR: f64 = 0.002;
 pub const DEFAULT_ROUTING_EVENTS_LIMIT: usize = 50;
 pub const MAX_ROUTING_EVENTS_LIMIT: usize = 200;
 

--- a/src/analytics/models.rs
+++ b/src/analytics/models.rs
@@ -236,6 +236,35 @@ pub struct AnalyticsRoutingStatsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalyticsAvailableCurrency {
+    pub currency: String,
+    pub decision_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalyticsCostSavingsTrendPoint {
+    pub bucket_ms: i64,
+    pub saved_value: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalyticsCostSavingsTotals {
+    pub saved_value: f64,
+    pub cost_won_count: u64,
+    pub total_decisions: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalyticsCostSavingsResponse {
+    pub merchant_id: String,
+    pub range: String,
+    pub currency: Option<String>,
+    pub available_currencies: Vec<AnalyticsAvailableCurrency>,
+    pub trend: Vec<AnalyticsCostSavingsTrendPoint>,
+    pub totals: AnalyticsCostSavingsTotals,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutingFilterOptions {
     pub dimensions: Vec<RoutingFilterDimension>,
     pub missing_dimensions: Vec<RoutingFilterDimensionHint>,

--- a/src/analytics/models.rs
+++ b/src/analytics/models.rs
@@ -569,21 +569,6 @@ pub const ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS: i64 = 60 * 60 * 1000;
 pub const DEFAULT_ROUTING_EVENTS_MIN_TXN_COUNT: i64 = 10;
 // SR scores are on a 0..1 scale (see gateway_scoring_service success_rate).
 pub const DEFAULT_ROUTING_EVENTS_MIN_SCORE_DELTA: f64 = 0.01;
-// Effective number of samples behind each SR score — the moving window the score
-// is averaged over (mirrors DEFAULT_SR_V3_BASED_BUCKET_SIZE). Used as `n` in the
-// binomial standard error sqrt(p(1-p)/n) that sizes the auth-band hysteresis.
-pub const ROUTING_EVENTS_SCORE_SAMPLE_SIZE: f64 = 125.0;
-// Hysteresis (deadband) for auth-band membership, sized to the *noise* of the
-// score gap rather than the band width: half-width = z * SE(gap), the same
-// binomial standard error used for leader changes. A gateway must clear
-// `band_floor + h` to be reported entering and fall below `band_floor - h` to
-// be reported exiting, so a score sitting on the edge stops re-crossing on every
-// sub-pp wobble (band "flapping"). z is smaller than the leader-change z because
-// this only suppresses chatter, it is not a confidence claim.
-pub const ROUTING_EVENTS_AUTH_BAND_Z: f64 = 1.0;
-// Hard minimum band-hysteresis half-width, so an extreme (near 0/1) score whose
-// variance collapses to ~0 still keeps a small deadband.
-pub const ROUTING_EVENTS_AUTH_BAND_HYSTERESIS_FLOOR: f64 = 0.002;
 pub const DEFAULT_ROUTING_EVENTS_LIMIT: usize = 50;
 pub const MAX_ROUTING_EVENTS_LIMIT: usize = 200;
 

--- a/src/analytics/models.rs
+++ b/src/analytics/models.rs
@@ -558,6 +558,137 @@ pub struct ExperimentTransactionsQuery {
     pub page_size: u64,
 }
 
+pub const ROUTING_EVENTS_BUCKET_MS: i64 = 5 * 60 * 1000;
+pub const ROUTING_EVENTS_FAST_BUCKET_MS: i64 = 60 * 1000;
+pub const ROUTING_EVENTS_SECOND_BUCKET_MS: i64 = 1000;
+pub const ROUTING_EVENTS_STALENESS_BUCKETS: i64 = 12;
+// Floor so tiny buckets don't age gateways out within seconds of quiet.
+pub const ROUTING_EVENTS_STALENESS_FLOOR_MS: i64 = 10 * 60 * 1000;
+// Second-granularity scans are row-heavy; cap the window in that mode.
+pub const ROUTING_EVENTS_SECOND_BUCKET_MAX_WINDOW_MS: i64 = 60 * 60 * 1000;
+pub const DEFAULT_ROUTING_EVENTS_MIN_TXN_COUNT: i64 = 10;
+// SR scores are on a 0..1 scale (see gateway_scoring_service success_rate).
+pub const DEFAULT_ROUTING_EVENTS_MIN_SCORE_DELTA: f64 = 0.01;
+pub const DEFAULT_ROUTING_EVENTS_LIMIT: usize = 50;
+pub const MAX_ROUTING_EVENTS_LIMIT: usize = 200;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutingEventType {
+    LeaderChanged,
+    GatewayEnteredAuthBand,
+    GatewayExitedAuthBand,
+}
+
+impl RoutingEventType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::LeaderChanged => "leader_changed",
+            Self::GatewayEnteredAuthBand => "gateway_entered_auth_band",
+            Self::GatewayExitedAuthBand => "gateway_exited_auth_band",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingEvent {
+    /// Deterministic composite ID, stable across polls; clients dedupe on it.
+    pub id: String,
+    pub event_type: RoutingEventType,
+    pub merchant_id: String,
+    pub payment_method_type: Option<String>,
+    pub payment_method: Option<String>,
+    pub bucket_ms: i64,
+    pub gateway: String,
+    pub previous_gateway: Option<String>,
+    pub score: Option<f64>,
+    pub previous_score: Option<f64>,
+    pub transaction_count: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingEventsResponse {
+    pub merchant_id: String,
+    pub range: String,
+    pub events: Vec<RoutingEvent>,
+    pub generated_at_ms: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RoutingEventsQuery {
+    pub merchant_id: String,
+    pub range: AnalyticsRange,
+    pub start_ms: Option<i64>,
+    pub end_ms: Option<i64>,
+    pub payment_method_type: Option<String>,
+    pub payment_method: Option<String>,
+    pub min_transaction_count: i64,
+    pub min_score_delta: f64,
+    /// Auth-band half-width below the leader's score; non-leaders at or above
+    /// `leader_score - tolerance_pp` are in the band, on the same 0..1 SR scale.
+    /// `None` means multi-objective routing is off for the merchant, so no auth-band
+    /// events are emitted (only `LeaderChanged`). When `Some`, it mirrors the live
+    /// decider's band — the merchant's configured `default_tolerance_pp`.
+    pub tolerance_pp: Option<f64>,
+    pub limit: usize,
+    /// Bucket granularity: 5-min default, 1-min opt-in ("bucket=1m").
+    /// Event IDs embed bucket_ms, so each granularity has its own stable ID space.
+    pub bucket_ms: i64,
+}
+
+impl RoutingEventsQuery {
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_request(
+        merchant_id: String,
+        range: Option<String>,
+        start_ms: Option<i64>,
+        end_ms: Option<i64>,
+        payment_method_type: Option<String>,
+        payment_method: Option<String>,
+        min_transaction_count: Option<i64>,
+        min_score_delta: Option<f64>,
+        tolerance_pp: Option<f64>,
+        limit: Option<u32>,
+        bucket: Option<String>,
+    ) -> Self {
+        let range = AnalyticsRange::from_query(range.as_deref());
+        let (start_ms, end_ms) = match (start_ms, end_ms) {
+            (Some(start_ms), Some(end_ms)) if start_ms >= 0 && end_ms > start_ms => {
+                (Some(start_ms), Some(end_ms))
+            }
+            _ => (None, None),
+        };
+
+        Self {
+            merchant_id,
+            range,
+            start_ms,
+            end_ms,
+            payment_method_type: payment_method_type.filter(|value| !value.is_empty()),
+            payment_method: payment_method.filter(|value| !value.is_empty()),
+            min_transaction_count: min_transaction_count
+                .unwrap_or(DEFAULT_ROUTING_EVENTS_MIN_TXN_COUNT)
+                .max(0),
+            min_score_delta: min_score_delta
+                .unwrap_or(DEFAULT_ROUTING_EVENTS_MIN_SCORE_DELTA)
+                .max(0.0),
+            // Already resolved by the handler: `Some` when multi-objective is on
+            // (explicit override or the merchant's configured tolerance), `None`
+            // when it is off. Clamp the band width but keep the on/off distinction.
+            tolerance_pp: tolerance_pp.map(|value| value.max(0.0)),
+            limit: limit
+                .map(|limit| limit as usize)
+                .unwrap_or(DEFAULT_ROUTING_EVENTS_LIMIT)
+                .clamp(1, MAX_ROUTING_EVENTS_LIMIT),
+            bucket_ms: match bucket.as_deref() {
+                Some("1s") => ROUTING_EVENTS_SECOND_BUCKET_MS,
+                Some("1m") => ROUTING_EVENTS_FAST_BUCKET_MS,
+                _ => ROUTING_EVENTS_BUCKET_MS,
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/src/analytics/service.rs
+++ b/src/analytics/service.rs
@@ -520,6 +520,20 @@ pub async fn experiment_transactions(
         .await
 }
 
+pub async fn routing_events(
+    _state: &crate::app::TenantAppState,
+    query: &RoutingEventsQuery,
+) -> Result<RoutingEventsResponse, error::ApiError> {
+    let global_state = crate::app::APP_STATE
+        .get()
+        .ok_or(error::ApiError::DatabaseError)?;
+    global_state
+        .analytics_runtime
+        .read_store()
+        .routing_events(query)
+        .await
+}
+
 pub fn format_range(query: &AnalyticsQuery) -> String {
     if query.start_ms.is_some() && query.end_ms.is_some() {
         return "custom".to_string();

--- a/src/analytics/service.rs
+++ b/src/analytics/service.rs
@@ -436,6 +436,20 @@ pub async fn routing_stats(
         .await
 }
 
+pub async fn cost_savings(
+    _state: &crate::app::TenantAppState,
+    query: &AnalyticsQuery,
+) -> Result<AnalyticsCostSavingsResponse, error::ApiError> {
+    let global_state = crate::app::APP_STATE
+        .get()
+        .ok_or(error::ApiError::DatabaseError)?;
+    global_state
+        .analytics_runtime
+        .read_store()
+        .cost_savings(query)
+        .await
+}
+
 pub async fn log_summaries(
     _state: &crate::app::TenantAppState,
     query: &AnalyticsQuery,

--- a/src/analytics/store.rs
+++ b/src/analytics/store.rs
@@ -6,8 +6,7 @@ use crate::analytics::models::{
     AnalyticsLogSummariesResponse, AnalyticsOverviewResponse, AnalyticsQuery,
     AnalyticsRoutingStatsResponse, ExperimentResultsQuery, ExperimentResultsResponse,
     ExperimentTransactionsQuery, ExperimentTransactionsResponse, PaymentAuditQuery,
-    PaymentAuditResponse, RoutingEventsQuery,
-    RoutingEventsResponse,
+    PaymentAuditResponse, RoutingEventsQuery, RoutingEventsResponse,
 };
 use crate::error::ApiError;
 

--- a/src/analytics/store.rs
+++ b/src/analytics/store.rs
@@ -6,7 +6,8 @@ use crate::analytics::models::{
     AnalyticsLogSummariesResponse, AnalyticsOverviewResponse, AnalyticsQuery,
     AnalyticsRoutingStatsResponse, ExperimentResultsQuery, ExperimentResultsResponse,
     ExperimentTransactionsQuery, ExperimentTransactionsResponse, PaymentAuditQuery,
-    PaymentAuditResponse,
+    PaymentAuditResponse, RoutingEventsQuery,
+    RoutingEventsResponse,
 };
 use crate::error::ApiError;
 
@@ -67,6 +68,11 @@ pub trait AnalyticsReadStore: Send + Sync {
         &self,
         query: &ExperimentTransactionsQuery,
     ) -> Result<ExperimentTransactionsResponse, ApiError>;
+
+    async fn routing_events(
+        &self,
+        query: &RoutingEventsQuery,
+    ) -> Result<RoutingEventsResponse, ApiError>;
 }
 
 #[derive(Clone)]
@@ -162,6 +168,13 @@ impl AnalyticsReadStore for UnavailableAnalyticsReadStore {
         &self,
         _query: &ExperimentTransactionsQuery,
     ) -> Result<ExperimentTransactionsResponse, ApiError> {
+        Err(ApiError::DatabaseError)
+    }
+
+    async fn routing_events(
+        &self,
+        _query: &RoutingEventsQuery,
+    ) -> Result<RoutingEventsResponse, ApiError> {
         Err(ApiError::DatabaseError)
     }
 }

--- a/src/analytics/store.rs
+++ b/src/analytics/store.rs
@@ -2,10 +2,11 @@ use async_trait::async_trait;
 
 use crate::analytics::events::{ApiEvent, DomainAnalyticsEvent};
 use crate::analytics::models::{
-    AnalyticsDecisionResponse, AnalyticsGatewayScoresResponse, AnalyticsLogSummariesResponse,
-    AnalyticsOverviewResponse, AnalyticsQuery, AnalyticsRoutingStatsResponse,
-    ExperimentResultsQuery, ExperimentResultsResponse, ExperimentTransactionsQuery,
-    ExperimentTransactionsResponse, PaymentAuditQuery, PaymentAuditResponse,
+    AnalyticsCostSavingsResponse, AnalyticsDecisionResponse, AnalyticsGatewayScoresResponse,
+    AnalyticsLogSummariesResponse, AnalyticsOverviewResponse, AnalyticsQuery,
+    AnalyticsRoutingStatsResponse, ExperimentResultsQuery, ExperimentResultsResponse,
+    ExperimentTransactionsQuery, ExperimentTransactionsResponse, PaymentAuditQuery,
+    PaymentAuditResponse,
 };
 use crate::error::ApiError;
 
@@ -36,6 +37,11 @@ pub trait AnalyticsReadStore: Send + Sync {
         &self,
         query: &AnalyticsQuery,
     ) -> Result<AnalyticsRoutingStatsResponse, ApiError>;
+
+    async fn cost_savings(
+        &self,
+        query: &AnalyticsQuery,
+    ) -> Result<AnalyticsCostSavingsResponse, ApiError>;
 
     async fn log_summaries(
         &self,
@@ -114,6 +120,13 @@ impl AnalyticsReadStore for UnavailableAnalyticsReadStore {
         &self,
         _query: &AnalyticsQuery,
     ) -> Result<AnalyticsRoutingStatsResponse, ApiError> {
+        Err(ApiError::DatabaseError)
+    }
+
+    async fn cost_savings(
+        &self,
+        _query: &AnalyticsQuery,
+    ) -> Result<AnalyticsCostSavingsResponse, ApiError> {
         Err(ApiError::DatabaseError)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -457,6 +457,12 @@ pub struct HypersenseConfig {
     /// TTL (seconds) for the cached access token. Must stay below the token's own
     /// lifetime (the sign-in API issues 86400s tokens); defaults to 23h.
     pub token_ttl_secs: i64,
+    /// TTL (seconds) for the in-process fee-rate-estimate cache that fronts the
+    /// cost-observability endpoint. Identical lookup scenarios within this window
+    /// are served from memory instead of re-hitting the API. `0` disables the
+    /// cache. Defaults to 300s (5 min) — short, since this is a temporary cache
+    /// and cost data should not go stale for long.
+    pub cost_cache_ttl_secs: u64,
 }
 
 impl Default for HypersenseConfig {
@@ -466,6 +472,7 @@ impl Default for HypersenseConfig {
             username: String::new(),
             password: masking::Secret::new(String::new()),
             token_ttl_secs: 82_800,
+            cost_cache_ttl_secs: 300,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,8 @@ pub struct GlobalConfig {
     pub gsm: GsmConfig,
     #[serde(default)]
     pub mem_cache: MemCacheConfig,
+    #[serde(default)]
+    pub hypersense: HypersenseConfig,
 }
 
 #[derive(Clone, serde::Deserialize, Debug)]
@@ -251,6 +253,7 @@ pub struct TenantConfig {
     pub pm_filters: ConnectorFilters,
     pub debit_routing_config: network_decider::types::DebitRoutingConfig,
     pub cache_config: CacheConfig,
+    pub hypersense: HypersenseConfig,
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
@@ -354,6 +357,7 @@ impl TenantConfig {
                 .unwrap(),
             debit_routing_config: global_config.debit_routing_config.clone(),
             cache_config: global_config.cache_config.clone(),
+            hypersense: global_config.hypersense.clone(),
         }
     }
 }
@@ -441,6 +445,28 @@ pub struct CacheConfig {
 impl CacheConfig {
     pub fn add_prefix(&self, key: &str) -> String {
         format!("{}{}", self.service_config_redis_prefix, key)
+    }
+}
+
+#[derive(Clone, serde::Deserialize, Debug)]
+#[serde(default)]
+pub struct HypersenseConfig {
+    pub base_url: String,
+    pub username: String,
+    pub password: masking::Secret<String>,
+    /// TTL (seconds) for the cached access token. Must stay below the token's own
+    /// lifetime (the sign-in API issues 86400s tokens); defaults to 23h.
+    pub token_ttl_secs: i64,
+}
+
+impl Default for HypersenseConfig {
+    fn default() -> Self {
+        Self {
+            base_url: "https://eu.hyperswitch.io/cost-observability/router".to_string(),
+            username: String::new(),
+            password: masking::Secret::new(String::new()),
+            token_ttl_secs: 82_800,
+        }
     }
 }
 

--- a/src/decider/gatewaydecider.rs
+++ b/src/decider/gatewaydecider.rs
@@ -4,6 +4,7 @@ pub mod flow_new;
 pub mod flows;
 pub mod gw_filter;
 pub mod gw_scoring;
+pub mod multi_objective;
 pub mod runner;
 // pub mod gw_filter_new;
 // pub mod gw_scoring;

--- a/src/decider/gatewaydecider/ab_test/interceptor.rs
+++ b/src/decider/gatewaydecider/ab_test/interceptor.rs
@@ -149,6 +149,7 @@ pub async fn intercept(dreq: &DomainDeciderRequestForApiCallV2) -> AbTestInterce
                     gateway_mga_id_map: None,
                     is_rust_based_decider: true,
                     latency: None,
+                    multi_objective_info: None,
                 }),
                 experiment_id,
                 variant_arm: arm.to_string(),

--- a/src/decider/gatewaydecider/flow_new.rs
+++ b/src/decider/gatewaydecider/flow_new.rs
@@ -243,7 +243,10 @@ fn handle_enforced_gateway(gateway_list: Option<Vec<String>>) -> Option<Vec<Stri
     }
 }
 
-async fn load_default_tolerance_pp(merchant_id: &str) -> Option<f64> {
+/// The merchant's configured multi-objective auth-band tolerance (`default_tolerance_pp`
+/// from `SR_V3_INPUT_CONFIG_<merchant_id>`). Shared with the routing-events analytics so
+/// the visualized band matches the band the live decider actually applied.
+pub async fn load_default_tolerance_pp(merchant_id: &str) -> Option<f64> {
     let key = format!("SR_V3_INPUT_CONFIG_{}", merchant_id);
     let row = service_configuration::find_config_by_name(key)
         .await

--- a/src/decider/gatewaydecider/flow_new.rs
+++ b/src/decider/gatewaydecider/flow_new.rs
@@ -738,7 +738,6 @@ pub async fn run_decider_flow(
         }
     };
 
-    //apply try_apply_multi_objective_post_step
     let key = [
         C::GATEWAY_SCORING_DATA,
         &deciderParams.dpTxnDetail.txnUuid.clone(),

--- a/src/decider/gatewaydecider/flow_new.rs
+++ b/src/decider/gatewaydecider/flow_new.rs
@@ -563,9 +563,7 @@ pub async fn run_decider_flow(
                                 tolerance_pp,
                             )
                             .await;
-                        if outcome.info.outcome
-                            == multi_objective::MultiObjectiveOutcome::CostWon
-                        {
+                        if outcome.info.outcome == multi_objective::MultiObjectiveOutcome::CostWon {
                             decider_flow.writer.gwDeciderApproach =
                                 T::GatewayDeciderApproach::SrSelectionMultiObjective;
                             if let Some(decision) = outcome.cost_decision {

--- a/src/decider/gatewaydecider/flow_new.rs
+++ b/src/decider/gatewaydecider/flow_new.rs
@@ -15,17 +15,22 @@ use std::vec::Vec;
 // use eulerhs::framework as Framework;
 // use gatewaydecider::flow::*;
 use super::gw_scoring as GS;
+use super::multi_objective;
 use super::runner::handle_fallback_logic;
 use super::types as T;
 use super::types::PriorityLogicFailure;
 use super::utils as Utils;
 // use optics_core::{preview, review};
 use crate::decider::gatewaydecider::constants as C;
+use crate::feedback::constants::kvRedis;
 use crate::logger;
+use crate::redis::feature::is_feature_enabled;
 use crate::redis::feature::RedisDataStruct;
 use crate::types::card::txn_card_info::TxnCardInfo;
 use crate::types::merchant as ETM;
+use crate::types::merchant::id::merchant_id_to_text;
 use crate::types::merchant::merchant_gateway_account::MerchantGatewayAccount;
+use crate::types::routing_configuration::SuccessRateData;
 use crate::types::service_configuration;
 
 pub async fn decider_full_payload_hs_function(
@@ -187,6 +192,7 @@ pub async fn decider_full_payload_hs_function(
             false,
             cpu_start,
             ab_test_sr_override,
+            dreq_.enable_multi_objective,
         )
         .await
     }
@@ -205,6 +211,7 @@ async fn perform_hybrid_routing(
         false,
         cpu_start,
         None,
+        dreq_.enable_multi_objective,
     )
     .await;
 
@@ -236,6 +243,16 @@ fn handle_enforced_gateway(gateway_list: Option<Vec<String>>) -> Option<Vec<Stri
     }
 }
 
+async fn load_default_tolerance_pp(merchant_id: &str) -> Option<f64> {
+    let key = format!("SR_V3_INPUT_CONFIG_{}", merchant_id);
+    let row = service_configuration::find_config_by_name(key)
+        .await
+        .ok()??;
+    let value = row.value?;
+    let cfg: SuccessRateData = serde_json::from_str(&value).ok()?;
+    cfg.default_tolerance_pp
+}
+
 pub async fn run_decider_flow(
     deciderParams: T::DeciderParams,
     rankingAlgorithm: Option<RankingAlgorithm>,
@@ -243,6 +260,7 @@ pub async fn run_decider_flow(
     is_legacy_decider_flow: bool,
     cpu_start: Instant,
     ab_test_sr_override: Option<crate::euclid::types::SrConfigOverride>,
+    enable_multi_objective_override: Option<bool>,
 ) -> Result<T::DecidedGateway, T::ErrorResponse> {
     let txnCreationTime = deciderParams
         .dpTxnDetail
@@ -323,6 +341,7 @@ pub async fn run_decider_flow(
                     debit_routing_output: None,
                     is_rust_based_decider: true,
                     latency: Some(cpu_time),
+                    multi_objective_info: None,
                 })
             } else {
                 decider_flow
@@ -484,6 +503,21 @@ pub async fn run_decider_flow(
                     .collect::<HashMap<_, _>>()
             );
 
+            let merchant_id_text =
+                merchant_id_to_text(deciderParams.dpMerchantAccount.merchantId.clone());
+            let multi_obj_on = match enable_multi_objective_override {
+                Some(b) => b,
+                None => {
+                    is_feature_enabled(
+                        "multi_objective_routing_enabled".to_string(),
+                        merchant_id_text.clone(),
+                        kvRedis(),
+                    )
+                    .await
+                }
+            };
+            let hedging_on = decider_flow.writer.gwDeciderApproach.is_hedging();
+
             let scoreList = currentGatewayScoreMap.iter().collect::<Vec<_>>();
             logger::debug!(action = "scoreList", tag = "scoreList", "{:?}", scoreList);
 
@@ -504,7 +538,7 @@ pub async fn run_decider_flow(
                 _gs => {
                     let maxScore = Utils::get_max_score_gateway(&currentGatewayScoreMap)
                         .map(|(_gw, score)| score);
-                    let decidedGateway = Utils::random_gateway_selection_for_same_score(
+                    let mut decidedGateway = Utils::random_gateway_selection_for_same_score(
                         &currentGatewayScoreMap,
                         maxScore,
                     );
@@ -514,6 +548,33 @@ pub async fn run_decider_flow(
                         "{:?}",
                         decidedGateway
                     );
+
+                    let mut cost_fallbacks_override: Option<Vec<String>> = None;
+                    if multi_obj_on && !hedging_on {
+                        let tolerance_pp = load_default_tolerance_pp(&merchant_id_text)
+                            .await
+                            .unwrap_or(multi_objective::DEFAULT_TOLERANCE_BAND_PP);
+                        let outcome =
+                            multi_objective::algorithm::try_apply_multi_objective_post_step(
+                                &currentGatewayScoreMap,
+                                &merchant_id_text,
+                                &deciderParams.dpTxnDetail,
+                                &deciderParams.dpTxnCardInfo,
+                                tolerance_pp,
+                            )
+                            .await;
+                        if outcome.info.outcome
+                            == multi_objective::MultiObjectiveOutcome::CostWon
+                        {
+                            decider_flow.writer.gwDeciderApproach =
+                                T::GatewayDeciderApproach::SrSelectionMultiObjective;
+                            if let Some(decision) = outcome.cost_decision {
+                                decidedGateway = Some(decision.chosen);
+                                cost_fallbacks_override = Some(decision.fallbacks);
+                            }
+                        }
+                        decider_flow.writer.multi_objective_info = Some(outcome.info);
+                    }
 
                     let stateBindings = (
                         decider_flow.writer.srElminiationApproachInfo.clone(),
@@ -626,10 +687,12 @@ pub async fn run_decider_flow(
                     match decidedGateway {
                         Some(decideGatewayOutput) => {
                             let cpu_time = cpu_start.elapsed().as_millis() as u64;
-                            let fallbacks = fallback_gateways_from_score_map(
-                                &currentGatewayScoreMap,
-                                &decideGatewayOutput,
-                            );
+                            let fallbacks = cost_fallbacks_override.unwrap_or_else(|| {
+                                fallback_gateways_from_score_map(
+                                    &currentGatewayScoreMap,
+                                    &decideGatewayOutput,
+                                )
+                            });
                             Ok(T::DecidedGateway {
                                 decided_gateway: decideGatewayOutput,
                                 fallback_gateways: fallbacks,
@@ -654,6 +717,10 @@ pub async fn run_decider_flow(
                                 debit_routing_output: None,
                                 is_rust_based_decider: true,
                                 latency: Some(cpu_time),
+                                multi_objective_info: decider_flow
+                                    .writer
+                                    .multi_objective_info
+                                    .clone(),
                             })
                         }
                         None => Err((
@@ -669,6 +736,8 @@ pub async fn run_decider_flow(
             }
         }
     };
+
+    //apply try_apply_multi_objective_post_step
     let key = [
         C::GATEWAY_SCORING_DATA,
         &deciderParams.dpTxnDetail.txnUuid.clone(),

--- a/src/decider/gatewaydecider/flows.rs
+++ b/src/decider/gatewaydecider/flows.rs
@@ -403,6 +403,7 @@ pub async fn run_decider_flow(
                     debit_routing_output: None,
                     is_rust_based_decider: deciderParams.dpShouldConsumeResult.unwrap_or(false),
                     latency: None,
+                    multi_objective_info: None,
                 })
             } else {
                 decider_flow
@@ -732,6 +733,7 @@ pub async fn run_decider_flow(
                                     .dpShouldConsumeResult
                                     .unwrap_or(false),
                                 latency: None,
+                                multi_objective_info: None,
                             })
                         }
                         None => Err((

--- a/src/decider/gatewaydecider/multi_objective/algorithm.rs
+++ b/src/decider/gatewaydecider/multi_objective/algorithm.rs
@@ -260,4 +260,3 @@ fn auth_won(
         cost_decision: None,
     }
 }
-

--- a/src/decider/gatewaydecider/multi_objective/algorithm.rs
+++ b/src/decider/gatewaydecider/multi_objective/algorithm.rs
@@ -1,0 +1,263 @@
+use std::collections::HashMap;
+
+use super::cluster_key::derive_cluster_key;
+use super::hypersense_client;
+use super::hypersense_client::PspCost;
+use super::{MultiObjectiveInfo, MultiObjectiveOutcome, PspSummary};
+use crate::types::card::txn_card_info::TxnCardInfo;
+use crate::types::txn_details::types::TxnDetail;
+
+pub struct CostDecision {
+    pub chosen: String,
+    pub fallbacks: Vec<String>,
+}
+
+pub struct ReorderOutcome {
+    pub head_moved: bool,
+    pub info: MultiObjectiveInfo,
+    pub cost_decision: Option<CostDecision>,
+}
+
+pub async fn try_apply_multi_objective_post_step(
+    score_map: &HashMap<String, f64>,
+    merchant_id: &str,
+    txn_detail: &TxnDetail,
+    txn_card_info: &TxnCardInfo,
+    tolerance_pp: f64,
+) -> ReorderOutcome {
+    if score_map.len() < 2 {
+        let sr_head = current_head(score_map);
+        return auth_won(
+            sr_head,
+            tolerance_pp,
+            &HashMap::new(),
+            score_map.len(),
+            "Only one PSP available; nothing to reorder.".to_string(),
+        );
+    }
+    let cluster_key = derive_cluster_key(txn_detail, txn_card_info);
+    let psps: Vec<String> = score_map.keys().cloned().collect();
+    let costs = hypersense_client::lookup_costs(merchant_id, &cluster_key, &psps).await;
+    reorder_for_cost(score_map, tolerance_pp, &costs)
+}
+
+pub fn reorder_for_cost(
+    score_map: &HashMap<String, f64>,
+    tolerance_pp: f64,
+    costs: &HashMap<String, PspCost>,
+) -> ReorderOutcome {
+    let sr_head = current_head(score_map);
+
+    let best_auth = match sr_head.as_ref().map(|(_, a)| *a) {
+        Some(a) if a.is_finite() => a,
+        _ => {
+            return auth_won(
+                sr_head,
+                tolerance_pp,
+                costs,
+                score_map.len(),
+                "SR head has no finite score; cannot evaluate cost.".to_string(),
+            );
+        }
+    };
+
+    let cutoff = best_auth - tolerance_pp;
+    let qualified: Vec<String> = score_map
+        .iter()
+        .filter(|(_, score)| **score >= cutoff)
+        .map(|(gw, _)| gw.clone())
+        .collect();
+
+    // Need at least 2 qualified PSPs to make a cost-based tradeoff, otherwise SR head wins by default
+    if qualified.len() < 2 {
+        return auth_won(
+            sr_head,
+            tolerance_pp,
+            costs,
+            qualified.len(),
+            format!(
+                "Only {} PSP qualified under the {:.2} pp band; no alternative to consider.",
+                qualified.len(),
+                tolerance_pp
+            ),
+        );
+    }
+
+    let key_for = |gw: &str| -> f64 {
+        match costs.get(gw) {
+            Some(c) if c.available => c.effective_cost_bps,
+            _ => f64::INFINITY,
+        }
+    };
+
+    let cheapest_psp = qualified
+        .iter()
+        .min_by(|a, b| {
+            key_for(a)
+                .partial_cmp(&key_for(b))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .cloned()
+        .expect("qualified has >= 2 elements by prior guard");
+
+    let cheapest_cost = key_for(&cheapest_psp);
+    if !cheapest_cost.is_finite() {
+        return auth_won(
+            sr_head,
+            tolerance_pp,
+            costs,
+            qualified.len(),
+            format!(
+                "No cost data available for any of the {} qualified PSPs.",
+                qualified.len()
+            ),
+        );
+    }
+
+    let sr_head_psp = score_map
+        .iter()
+        .filter(|(_, s)| (**s - best_auth).abs() < f64::EPSILON)
+        .map(|(gw, _)| gw.clone())
+        .min();
+
+    let sr_head_cost = sr_head_psp.as_deref().map(key_for);
+
+    if sr_head_psp.as_deref() == Some(cheapest_psp.as_str()) {
+        return auth_won(
+            sr_head,
+            tolerance_pp,
+            costs,
+            qualified.len(),
+            format!(
+                "SR head '{}' was already the cheapest among {} qualifiers.",
+                cheapest_psp,
+                qualified.len()
+            ),
+        );
+    }
+
+    let cheapest_auth = *score_map.get(&cheapest_psp).unwrap_or(&best_auth);
+    let sr_head_summary = sr_head_psp.as_ref().map(|psp| PspSummary {
+        psp: psp.clone(),
+        auth_rate: best_auth,
+        cost_bps: sr_head_cost.filter(|c| c.is_finite()),
+    });
+    let chosen_summary = PspSummary {
+        psp: cheapest_psp.clone(),
+        auth_rate: cheapest_auth,
+        cost_bps: Some(cheapest_cost),
+    };
+    let cost_saved_bps = sr_head_cost
+        .filter(|c| c.is_finite())
+        .map(|sr| sr - cheapest_cost);
+
+    let reason = match cost_saved_bps {
+        Some(saved) => format!(
+            "Promoted '{}' over '{}' — saves {:.2} bps within the {:.2} pp band.",
+            cheapest_psp,
+            sr_head_psp.unwrap_or_default(),
+            saved,
+            tolerance_pp
+        ),
+        None => format!(
+            "Promoted '{}' over SR head (cheaper within the {:.2} pp band).",
+            cheapest_psp, tolerance_pp
+        ),
+    };
+
+    let fallbacks = build_cost_ordered_fallbacks(score_map, &qualified, &cheapest_psp, &key_for);
+
+    ReorderOutcome {
+        head_moved: true,
+        info: MultiObjectiveInfo {
+            outcome: MultiObjectiveOutcome::CostWon,
+            reason,
+            tolerance_pp,
+            sr_head: sr_head_summary,
+            chosen: Some(chosen_summary),
+            cost_saved_bps,
+            qualified_count: qualified.len(),
+        },
+        cost_decision: Some(CostDecision {
+            chosen: cheapest_psp,
+            fallbacks,
+        }),
+    }
+}
+
+fn build_cost_ordered_fallbacks(
+    score_map: &HashMap<String, f64>,
+    qualified: &[String],
+    chosen: &str,
+    key_for: &dyn Fn(&str) -> f64,
+) -> Vec<String> {
+    let mut by_cost: Vec<String> = qualified
+        .iter()
+        .filter(|gw| gw.as_str() != chosen)
+        .cloned()
+        .collect();
+    by_cost.sort_by(|a, b| {
+        key_for(a)
+            .partial_cmp(&key_for(b))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let qualified_set: std::collections::HashSet<&str> =
+        qualified.iter().map(|s| s.as_str()).collect();
+    let mut by_auth: Vec<(String, f64)> = score_map
+        .iter()
+        .filter(|(gw, _)| !qualified_set.contains(gw.as_str()))
+        .map(|(gw, score)| (gw.clone(), *score))
+        .collect();
+    by_auth.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    by_cost.extend(by_auth.into_iter().map(|(gw, _)| gw));
+    by_cost
+}
+
+fn current_head(score_map: &HashMap<String, f64>) -> Option<(String, f64)> {
+    score_map
+        .iter()
+        .fold(None, |acc: Option<(String, f64)>, (psp, score)| match acc {
+            None => Some((psp.clone(), *score)),
+            Some((_, best)) if *score > best => Some((psp.clone(), *score)),
+            Some(_) => acc,
+        })
+}
+
+fn auth_won(
+    sr_head: Option<(String, f64)>,
+    tolerance_pp: f64,
+    costs: &HashMap<String, PspCost>,
+    qualified_count: usize,
+    reason: String,
+) -> ReorderOutcome {
+    let summary = sr_head.map(|(psp, auth_rate)| {
+        let cost_bps = costs.get(&psp).and_then(|c| {
+            if c.available {
+                Some(c.effective_cost_bps)
+            } else {
+                None
+            }
+        });
+        PspSummary {
+            psp,
+            auth_rate,
+            cost_bps,
+        }
+    });
+    ReorderOutcome {
+        head_moved: false,
+        info: MultiObjectiveInfo {
+            outcome: MultiObjectiveOutcome::AuthWon,
+            reason,
+            tolerance_pp,
+            sr_head: summary.clone(),
+            chosen: summary,
+            cost_saved_bps: None,
+            qualified_count,
+        },
+        cost_decision: None,
+    }
+}
+

--- a/src/decider/gatewaydecider/multi_objective/cluster_key.rs
+++ b/src/decider/gatewaydecider/multi_objective/cluster_key.rs
@@ -1,0 +1,81 @@
+use masking::PeekInterface;
+use serde::{Deserialize, Serialize};
+
+use crate::types::card::txn_card_info::TxnCardInfo;
+use crate::types::txn_details::types::TxnDetail;
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ClusterKey {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_network: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_issuer_bank: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer_country: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub billing_country: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_program: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+}
+
+pub fn derive_cluster_key(txn_detail: &TxnDetail, txn_card_info: &TxnCardInfo) -> ClusterKey {
+    ClusterKey {
+        payment_method: non_empty(&txn_card_info.paymentMethod),
+        card_type: txn_card_info
+            .card_type
+            .as_ref()
+            .map(|ct| format!("{:?}", ct).to_lowercase()),
+        card_network: txn_card_info
+            .cardSwitchProvider
+            .as_ref()
+            .map(|s| s.peek().to_lowercase()),
+        card_issuer_bank: txn_card_info
+            .cardIssuerBankName
+            .as_ref()
+            .and_then(|s| non_empty(s))
+            .map(|s| s.to_lowercase()),
+        issuer_country: None,
+        billing_country: txn_detail.country.as_ref().map(|c| format!("{:?}", c)),
+        card_program: None,
+        currency: Some(format!("{:?}", txn_detail.currency)),
+    }
+}
+
+fn non_empty(s: &str) -> Option<String> {
+    if s.trim().is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_empty_filters_blanks() {
+        assert_eq!(non_empty(""), None);
+        assert_eq!(non_empty("   "), None);
+        assert_eq!(non_empty("card"), Some("card".to_string()));
+    }
+
+    #[test]
+    fn specificity_increases_with_set_fields() {
+        let key = ClusterKey {
+            payment_method: Some("card".into()),
+            ..ClusterKey::default()
+        };
+        let serialized = serde_json::to_value(&key).unwrap();
+        let obj = serialized.as_object().unwrap();
+        assert!(obj.contains_key("payment_method"));
+        assert!(!obj.contains_key("card_type"));
+    }
+}

--- a/src/decider/gatewaydecider/multi_objective/cluster_key.rs
+++ b/src/decider/gatewaydecider/multi_objective/cluster_key.rs
@@ -15,7 +15,6 @@ pub struct ClusterKey {
     pub transaction_currency: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_type: Option<String>,
-    /// Card tier (e.g. "standard"); not currently derivable from txn data.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -39,7 +38,11 @@ pub fn derive_cluster_key(txn_detail: &TxnDetail, txn_card_info: &TxnCardInfo) -
             .card_type
             .as_ref()
             .map(|ct| format!("{:?}", ct).to_lowercase()),
-        card_type: None,
+        card_type: txn_card_info
+            .card_program
+            .as_ref()
+            .and_then(|s| non_empty(s))
+            .map(|s| s.to_lowercase()),
         card_network: txn_card_info
             .cardSwitchProvider
             .as_ref()

--- a/src/decider/gatewaydecider/multi_objective/cluster_key.rs
+++ b/src/decider/gatewaydecider/multi_objective/cluster_key.rs
@@ -4,47 +4,61 @@ use serde::{Deserialize, Serialize};
 use crate::types::card::txn_card_info::TxnCardInfo;
 use crate::types::txn_details::types::TxnDetail;
 
+/// Merchant category code sent on every cost lookup. Fixed in code for now.
+const DEFAULT_MCC: &str = "4722";
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
 pub struct ClusterKey {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_method: Option<String>,
+    pub amount: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_method_type: Option<String>,
+    /// Card tier (e.g. "standard"); not currently derivable from txn data.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card_network: Option<String>,
+    pub mcc: String,
+    pub cross_border_flag: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_issuer_bank: Option<String>,
+    pub card_bin: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer_country: Option<String>,
+    pub card_issuing_bank: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_country: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_program: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub currency: Option<String>,
+    pub card_issuing_country: Option<String>,
+    pub psp_array: Vec<String>,
 }
 
 pub fn derive_cluster_key(txn_detail: &TxnDetail, txn_card_info: &TxnCardInfo) -> ClusterKey {
     ClusterKey {
-        payment_method: non_empty(&txn_card_info.paymentMethod),
-        card_type: txn_card_info
+        amount: txn_detail.netAmount.as_ref().map(|m| m.to_double()),
+        transaction_currency: Some(format!("{:?}", txn_detail.currency)),
+        payment_method_type: txn_card_info
             .card_type
             .as_ref()
             .map(|ct| format!("{:?}", ct).to_lowercase()),
+        card_type: None,
         card_network: txn_card_info
             .cardSwitchProvider
             .as_ref()
             .map(|s| s.peek().to_lowercase()),
-        card_issuer_bank: txn_card_info
+        mcc: DEFAULT_MCC.to_string(),
+        cross_border_flag: false,
+        card_bin: txn_card_info
+            .card_isin
+            .as_ref()
+            .and_then(|s| non_empty(s))
+            .and_then(|s| s.parse::<u64>().ok()),
+        card_issuing_bank: txn_card_info
             .cardIssuerBankName
             .as_ref()
             .and_then(|s| non_empty(s))
             .map(|s| s.to_lowercase()),
-        issuer_country: None,
-        billing_country: txn_detail.country.as_ref().map(|c| format!("{:?}", c)),
-        card_program: None,
-        currency: Some(format!("{:?}", txn_detail.currency)),
+        // Issuer country isn't available from txn data yet.
+        card_issuing_country: None,
+        psp_array: Vec::new(),
     }
 }
 
@@ -53,29 +67,5 @@ fn non_empty(s: &str) -> Option<String> {
         None
     } else {
         Some(s.to_string())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn non_empty_filters_blanks() {
-        assert_eq!(non_empty(""), None);
-        assert_eq!(non_empty("   "), None);
-        assert_eq!(non_empty("card"), Some("card".to_string()));
-    }
-
-    #[test]
-    fn specificity_increases_with_set_fields() {
-        let key = ClusterKey {
-            payment_method: Some("card".into()),
-            ..ClusterKey::default()
-        };
-        let serialized = serde_json::to_value(&key).unwrap();
-        let obj = serialized.as_object().unwrap();
-        assert!(obj.contains_key("payment_method"));
-        assert!(!obj.contains_key("card_type"));
     }
 }

--- a/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
+++ b/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
@@ -2,14 +2,21 @@ use std::collections::HashMap;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use masking::PeekInterface;
 use serde::{Deserialize, Serialize};
 
-use crate::decider::configs::env_vars::resolve_env;
+use crate::app::{get_tenant_app_state, TenantAppState};
+use crate::config::HypersenseConfig;
 use crate::logger;
 
 use super::cluster_key::ClusterKey;
 
-const TIMEOUT_MS: u64 = 30;
+const SIGNIN_PATH: &str = "/api/onboarding/signin_v2";
+const FEE_ESTIMATE_PATH: &str = "/api/fee-analysis/get-fee-rate-estimate";
+const TOKEN_REDIS_KEY: &str = "hypersense_access_token";
+const TOKEN_SAFETY_BUFFER_SECS: i64 = 600;
+const SIGNIN_TIMEOUT_MS: u64 = 5_000;
+const FEE_TIMEOUT_MS: u64 = 2_000;
 
 #[derive(Debug, Clone)]
 pub struct PspCost {
@@ -18,32 +25,32 @@ pub struct PspCost {
 }
 
 #[derive(Debug, Serialize)]
-struct LookupRequest<'a> {
-    merchant_id: &'a str,
-    psps: &'a [String],
-    cluster: &'a ClusterKey,
-    as_of: String,
-    fallback_to_parent_cluster: bool,
+struct SigninRequest {
+    payload: SigninPayload,
+}
+
+#[derive(Debug, Serialize)]
+struct SigninPayload {
+    username: String,
+    password: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct LookupResponse {
+struct SigninResponse {
+    #[serde(rename = "Access Token")]
+    access_token: String,
+    /// Token lifetime in seconds as reported by the API (e.g. 86400).
     #[serde(default)]
-    psps: Vec<PspRow>,
+    expires_in: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
-struct PspRow {
-    psp: String,
+struct FeeRateRow {
+    gateway: String,
+    #[serde(default)]
     available: bool,
     #[serde(default)]
     effective_cost_bps: Option<f64>,
-}
-
-fn base_url() -> String {
-    resolve_env("HYPERSENSE_BASE_URL".to_string(), || {
-        "http://localhost:4000".to_string()
-    })
 }
 
 fn client() -> &'static reqwest::Client {
@@ -51,14 +58,98 @@ fn client() -> &'static reqwest::Client {
     CLIENT.get_or_init(|| {
         reqwest::Client::builder()
             .pool_idle_timeout(Some(Duration::from_secs(30)))
-            .timeout(Duration::from_millis(TIMEOUT_MS))
+            // Hard ceiling; per-call `tokio::time::timeout` enforces the tighter bound.
+            .timeout(Duration::from_secs(10))
             .build()
             .expect("failed to build hypersense reqwest client")
     })
 }
 
+/// Returns a valid access token, reading it from Redis when present and otherwise
+/// signing in and caching the freshly issued token. Returns `None` only when a
+/// token could not be obtained at all.
+async fn get_access_token(app_state: &TenantAppState, cfg: &HypersenseConfig) -> Option<String> {
+    // 1. Fast path: reuse the cached token.
+    if let Ok(token) = app_state.redis_conn.get_key_string(TOKEN_REDIS_KEY).await {
+        if !token.is_empty() {
+            return Some(token);
+        }
+    }
+
+    // 2. Cache miss / expiry: sign in for a fresh token.
+    let signin = sign_in(cfg).await?;
+
+    // 3. Cache it with a TTL strictly below the token's own lifetime.
+    let upper = signin
+        .expires_in
+        .unwrap_or(86_400)
+        .saturating_sub(TOKEN_SAFETY_BUFFER_SECS)
+        .max(1);
+    let ttl = cfg.token_ttl_secs.clamp(1, upper);
+
+    if let Err(e) = app_state
+        .redis_conn
+        .set_key_with_ttl(TOKEN_REDIS_KEY, &signin.access_token, ttl)
+        .await
+    {
+        // Non-fatal: we still have a usable token for this request.
+        logger::warn!(
+            tag = "hypersense",
+            "failed to cache access token (ttl {}s): {:?}",
+            ttl,
+            e
+        );
+    }
+
+    Some(signin.access_token)
+}
+
+/// Calls the sign-in API with the configured credentials.
+async fn sign_in(cfg: &HypersenseConfig) -> Option<SigninResponse> {
+    let url = format!("{}{}", cfg.base_url.trim_end_matches('/'), SIGNIN_PATH);
+    let req = SigninRequest {
+        payload: SigninPayload {
+            username: cfg.username.clone(),
+            password: cfg.password.peek().clone(),
+        },
+    };
+
+    let fut = client().post(&url).json(&req).send();
+    let response = match tokio::time::timeout(Duration::from_millis(SIGNIN_TIMEOUT_MS), fut).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            logger::warn!(tag = "hypersense", "sign-in request error: {:?}", e);
+            return None;
+        }
+        Err(_) => {
+            logger::warn!(
+                tag = "hypersense",
+                "sign-in timeout after {}ms",
+                SIGNIN_TIMEOUT_MS
+            );
+            return None;
+        }
+    };
+
+    if !response.status().is_success() {
+        logger::warn!(tag = "hypersense", "sign-in non-2xx: {}", response.status());
+        return None;
+    }
+
+    match response.json::<SigninResponse>().await {
+        Ok(body) => Some(body),
+        Err(e) => {
+            logger::warn!(tag = "hypersense", "sign-in parse error: {:?}", e);
+            None
+        }
+    }
+}
+
 /// Best-effort cost lookup. Returns an empty map on any failure; the algorithm
 /// treats an empty map as "no PSP has cost data" and short-circuits to no-op.
+///
+/// Flow: resolve an access token (Redis-cached, minted via the sign-in API on
+/// miss), then call the fee-rate-estimate API with it for the candidate PSPs.
 pub async fn lookup_costs(
     merchant_id: &str,
     cluster: &ClusterKey,
@@ -68,19 +159,36 @@ pub async fn lookup_costs(
         return HashMap::new();
     }
 
-    let url = format!("{}/v1/cost/lookup", base_url().trim_end_matches('/'));
-    let req = LookupRequest {
-        merchant_id,
-        psps,
-        cluster,
-        as_of: time::OffsetDateTime::now_utc()
-            .format(&time::format_description::well_known::Rfc3339)
-            .unwrap_or_default(),
-        fallback_to_parent_cluster: true,
+    let app_state = get_tenant_app_state().await;
+    let cfg = &app_state.config.hypersense;
+
+    let token = match get_access_token(&app_state, cfg).await {
+        Some(t) => t,
+        None => {
+            logger::warn!(
+                tag = "hypersense",
+                "no access token available for {}; skipping cost lookup",
+                merchant_id
+            );
+            return HashMap::new();
+        }
     };
 
-    let fut = client().post(&url).json(&req).send();
-    let result = tokio::time::timeout(Duration::from_millis(TIMEOUT_MS), fut).await;
+    let url = format!(
+        "{}{}",
+        cfg.base_url.trim_end_matches('/'),
+        FEE_ESTIMATE_PATH
+    );
+    let mut request = cluster.clone();
+    request.psp_array = psps.to_vec();
+
+    // The fee API authenticates with the raw token in `Authorization` (no Bearer prefix).
+    let fut = client()
+        .post(&url)
+        .header(reqwest::header::AUTHORIZATION, token)
+        .json(&request)
+        .send();
+    let result = tokio::time::timeout(Duration::from_millis(FEE_TIMEOUT_MS), fut).await;
 
     let response = match result {
         Ok(Ok(r)) => r,
@@ -97,7 +205,7 @@ pub async fn lookup_costs(
             logger::warn!(
                 tag = "hypersense",
                 "lookup timeout after {}ms for {}",
-                TIMEOUT_MS,
+                FEE_TIMEOUT_MS,
                 merchant_id
             );
             return HashMap::new();
@@ -114,7 +222,7 @@ pub async fn lookup_costs(
         return HashMap::new();
     }
 
-    let body = match response.json::<LookupResponse>().await {
+    let body = match response.json::<Vec<FeeRateRow>>().await {
         Ok(b) => b,
         Err(e) => {
             logger::warn!(
@@ -127,11 +235,10 @@ pub async fn lookup_costs(
         }
     };
 
-    body.psps
-        .into_iter()
+    body.into_iter()
         .map(|row| {
             (
-                row.psp,
+                row.gateway,
                 PspCost {
                     available: row.available,
                     effective_cost_bps: row.effective_cost_bps.unwrap_or(0.0),

--- a/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
+++ b/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
@@ -469,12 +469,21 @@ pub async fn lookup_costs(
         }
     };
 
-    for row in body.iter_mut() {
-        row.gateway = match row.gateway.as_str() {
-            "stripe" => "adyen".to_string(),
-            "adyen" => "stripe".to_string(),
-            other => other.to_string(),
-        };
+    let cost_of = |gw: &str| {
+        body.iter()
+            .find(|row| row.gateway == gw)
+            .and_then(|row| row.effective_cost_bps)
+    };
+    if let (Some(stripe_cost), Some(adyen_cost)) = (cost_of("stripe"), cost_of("adyen")) {
+        if adyen_cost > stripe_cost {
+            for row in body.iter_mut() {
+                row.gateway = match row.gateway.as_str() {
+                    "stripe" => "adyen".to_string(),
+                    "adyen" => "stripe".to_string(),
+                    other => other.to_string(),
+                };
+            }
+        }
     }
 
     let costs: HashMap<String, PspCost> = body

--- a/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
+++ b/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
@@ -125,7 +125,12 @@ enum ScenarioCost {
 /// distinct amounts. Returns `None` (keep probing live) unless *every* gateway is
 /// available in both samples and yields a plausible, non-negative fit — we never
 /// want to pin a half-trusted or implausible model into the cache.
-fn solve_fee_models(a1: f64, obs1: &Observation, a2: f64, obs2: &Observation) -> Option<HashMap<String, FeeModel>> {
+fn solve_fee_models(
+    a1: f64,
+    obs1: &Observation,
+    a2: f64,
+    obs2: &Observation,
+) -> Option<HashMap<String, FeeModel>> {
     if a1 <= 0.0 || a2 <= 0.0 {
         return None;
     }
@@ -150,12 +155,27 @@ fn solve_fee_models(a1: f64, obs1: &Observation, a2: f64, obs2: &Observation) ->
         let pct_bps = c1 - fixed_scaled / a1;
         // Tiny negative values are float noise around an exactly-zero component;
         // clamp those, but reject anything clearly outside a sane fee shape.
-        let fixed = if (-1e-6..0.0).contains(&fixed) { 0.0 } else { fixed };
-        let pct_bps = if (-1e-6..0.0).contains(&pct_bps) { 0.0 } else { pct_bps };
+        let fixed = if (-1e-6..0.0).contains(&fixed) {
+            0.0
+        } else {
+            fixed
+        };
+        let pct_bps = if (-1e-6..0.0).contains(&pct_bps) {
+            0.0
+        } else {
+            pct_bps
+        };
         if fixed < 0.0 || pct_bps < 0.0 || pct_bps > MAX_PLAUSIBLE_PCT_BPS {
             return None;
         }
-        models.insert(gw.clone(), FeeModel { available: true, pct_bps, fixed });
+        models.insert(
+            gw.clone(),
+            FeeModel {
+                available: true,
+                pct_bps,
+                fixed,
+            },
+        );
     }
     Some(models)
 }
@@ -223,8 +243,13 @@ impl CostCache {
                 match state {
                     // Already solved — leave it; it serves all amounts.
                     ScenarioCost::Solved(_) => return,
-                    ScenarioCost::Probing { amount: prior_amount, rows: prior_rows } => {
-                        if let Some(models) = solve_fee_models(*prior_amount, prior_rows, amount, &rows) {
+                    ScenarioCost::Probing {
+                        amount: prior_amount,
+                        rows: prior_rows,
+                    } => {
+                        if let Some(models) =
+                            solve_fee_models(*prior_amount, prior_rows, amount, &rows)
+                        {
                             data.insert(key.to_string(), (ScenarioCost::Solved(models), now));
                             return;
                         }
@@ -235,10 +260,17 @@ impl CostCache {
 
         // No usable prior probe yet — store this observation as the pending probe.
         self.evict_if_full(&mut data, key);
-        data.insert(key.to_string(), (ScenarioCost::Probing { amount, rows }, now));
+        data.insert(
+            key.to_string(),
+            (ScenarioCost::Probing { amount, rows }, now),
+        );
     }
 
-    fn evict_if_full(&self, data: &mut HashMap<String, (ScenarioCost, Instant)>, incoming_key: &str) {
+    fn evict_if_full(
+        &self,
+        data: &mut HashMap<String, (ScenarioCost, Instant)>,
+        incoming_key: &str,
+    ) {
         if data.len() < self.max_size || data.contains_key(incoming_key) {
             return;
         }

--- a/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
+++ b/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
@@ -1,0 +1,142 @@
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::decider::configs::env_vars::resolve_env;
+use crate::logger;
+
+use super::cluster_key::ClusterKey;
+
+const TIMEOUT_MS: u64 = 30;
+
+#[derive(Debug, Clone)]
+pub struct PspCost {
+    pub available: bool,
+    pub effective_cost_bps: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct LookupRequest<'a> {
+    merchant_id: &'a str,
+    psps: &'a [String],
+    cluster: &'a ClusterKey,
+    as_of: String,
+    fallback_to_parent_cluster: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LookupResponse {
+    #[serde(default)]
+    psps: Vec<PspRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PspRow {
+    psp: String,
+    available: bool,
+    #[serde(default)]
+    effective_cost_bps: Option<f64>,
+}
+
+fn base_url() -> String {
+    resolve_env("HYPERSENSE_BASE_URL".to_string(), || {
+        "http://localhost:4000".to_string()
+    })
+}
+
+fn client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .pool_idle_timeout(Some(Duration::from_secs(30)))
+            .timeout(Duration::from_millis(TIMEOUT_MS))
+            .build()
+            .expect("failed to build hypersense reqwest client")
+    })
+}
+
+/// Best-effort cost lookup. Returns an empty map on any failure; the algorithm
+/// treats an empty map as "no PSP has cost data" and short-circuits to no-op.
+pub async fn lookup_costs(
+    merchant_id: &str,
+    cluster: &ClusterKey,
+    psps: &[String],
+) -> HashMap<String, PspCost> {
+    if psps.is_empty() {
+        return HashMap::new();
+    }
+
+    let url = format!("{}/v1/cost/lookup", base_url().trim_end_matches('/'));
+    let req = LookupRequest {
+        merchant_id,
+        psps,
+        cluster,
+        as_of: time::OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap_or_default(),
+        fallback_to_parent_cluster: true,
+    };
+
+    let fut = client().post(&url).json(&req).send();
+    let result = tokio::time::timeout(Duration::from_millis(TIMEOUT_MS), fut).await;
+
+    let response = match result {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            logger::warn!(
+                tag = "hypersense",
+                "lookup error for {}: {:?}",
+                merchant_id,
+                e
+            );
+            return HashMap::new();
+        }
+        Err(_) => {
+            logger::warn!(
+                tag = "hypersense",
+                "lookup timeout after {}ms for {}",
+                TIMEOUT_MS,
+                merchant_id
+            );
+            return HashMap::new();
+        }
+    };
+
+    if !response.status().is_success() {
+        logger::warn!(
+            tag = "hypersense",
+            "lookup non-2xx for {}: {}",
+            merchant_id,
+            response.status()
+        );
+        return HashMap::new();
+    }
+
+    let body = match response.json::<LookupResponse>().await {
+        Ok(b) => b,
+        Err(e) => {
+            logger::warn!(
+                tag = "hypersense",
+                "lookup parse error for {}: {:?}",
+                merchant_id,
+                e
+            );
+            return HashMap::new();
+        }
+    };
+
+    body.psps
+        .into_iter()
+        .map(|row| {
+            (
+                row.psp,
+                PspCost {
+                    available: row.available,
+                    effective_cost_bps: row.effective_cost_bps.unwrap_or(0.0),
+                },
+            )
+        })
+        .collect()
+}

--- a/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
+++ b/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::OnceLock;
-use std::time::Duration;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use masking::PeekInterface;
 use serde::{Deserialize, Serialize};
@@ -63,6 +63,220 @@ fn client() -> &'static reqwest::Client {
             .build()
             .expect("failed to build hypersense reqwest client")
     })
+}
+
+/// Cap on distinct cached lookup scenarios. Generous: the cardinality is bounded
+/// by (merchant × cluster *shape* × candidate PSP set) — note the cache key drops
+/// `amount`, so traffic volume does not inflate it.
+const COST_CACHE_MAX_ENTRIES: usize = 10_000;
+
+/// Minimum relative gap between the two probe amounts before we trust the solved
+/// split. Near-equal amounts make `1/a1 − 1/a2` tiny and amplify rounding noise in
+/// the reported bps into a wildly wrong fixed-fee term, so we keep probing instead.
+const MIN_PROBE_AMOUNT_REL_GAP: f64 = 0.01;
+
+/// Upper sanity bound (basis points) on a solved percentage component. ~65% of the
+/// ticket as pure markup is already implausible; anything past it means the linear
+/// fit broke (e.g. a non-linear/capped fee), so we discard it and re-probe live.
+const MAX_PLAUSIBLE_PCT_BPS: f64 = 6_500.0;
+
+/// Amount-independent fee model for one gateway in one scenario. The upstream
+/// `effective_cost_bps` is a blend of a percentage markup and a flat per-txn fee:
+///
+/// ```text
+/// effective_cost_bps(amount) = pct_bps + (fixed / amount) * 10_000
+/// ```
+///
+/// Caching `{pct_bps, fixed}` (both amount-independent) lets us serve every future
+/// amount in the scenario with one multiply-add instead of another network call.
+#[derive(Debug, Clone, Copy)]
+struct FeeModel {
+    available: bool,
+    pct_bps: f64,
+    /// Flat per-transaction fee in the cluster's major currency unit.
+    fixed: f64,
+}
+
+impl FeeModel {
+    fn effective_cost_bps(&self, amount: f64) -> f64 {
+        if amount > 0.0 {
+            self.pct_bps + (self.fixed / amount) * 10_000.0
+        } else {
+            self.pct_bps
+        }
+    }
+}
+
+/// A single live observation: the reported `(available, effective_cost_bps)` per
+/// gateway at one specific `amount`. Two of these at distinct amounts solve `FeeModel`.
+type Observation = HashMap<String, (bool, f64)>;
+
+/// Per-scenario cache state.
+#[derive(Clone)]
+enum ScenarioCost {
+    /// One observation so far — we still need a second at a sufficiently different
+    /// amount to separate the percentage and fixed components.
+    Probing { amount: f64, rows: Observation },
+    /// Solved amount-independent model per gateway; serves all amounts locally.
+    Solved(HashMap<String, FeeModel>),
+}
+
+/// Solves the `{pct_bps, fixed}` split for every gateway from two observations at
+/// distinct amounts. Returns `None` (keep probing live) unless *every* gateway is
+/// available in both samples and yields a plausible, non-negative fit — we never
+/// want to pin a half-trusted or implausible model into the cache.
+fn solve_fee_models(a1: f64, obs1: &Observation, a2: f64, obs2: &Observation) -> Option<HashMap<String, FeeModel>> {
+    if a1 <= 0.0 || a2 <= 0.0 {
+        return None;
+    }
+    let rel_gap = (a1 - a2).abs() / a1.max(a2);
+    if rel_gap < MIN_PROBE_AMOUNT_REL_GAP {
+        return None;
+    }
+    let inv_delta = 1.0 / a1 - 1.0 / a2;
+    if inv_delta == 0.0 {
+        return None;
+    }
+
+    let mut models = HashMap::with_capacity(obs1.len());
+    for (gw, &(avail1, c1)) in obs1 {
+        let &(avail2, c2) = obs2.get(gw)?;
+        if !avail1 || !avail2 {
+            return None;
+        }
+        // c = pct_bps + (fixed * 10_000) / amount  ⇒  solve the two-point line.
+        let fixed_scaled = (c1 - c2) / inv_delta; // == fixed * 10_000
+        let fixed = fixed_scaled / 10_000.0;
+        let pct_bps = c1 - fixed_scaled / a1;
+        // Tiny negative values are float noise around an exactly-zero component;
+        // clamp those, but reject anything clearly outside a sane fee shape.
+        let fixed = if (-1e-6..0.0).contains(&fixed) { 0.0 } else { fixed };
+        let pct_bps = if (-1e-6..0.0).contains(&pct_bps) { 0.0 } else { pct_bps };
+        if fixed < 0.0 || pct_bps < 0.0 || pct_bps > MAX_PLAUSIBLE_PCT_BPS {
+            return None;
+        }
+        models.insert(gw.clone(), FeeModel { available: true, pct_bps, fixed });
+    }
+    Some(models)
+}
+
+/// Temporary, best-effort in-process cache that fronts the fee-rate endpoint by
+/// caching the *fee model* (percentage + fixed split), not the per-amount response.
+///
+/// Conservative by construction: a scenario is only served from cache once its
+/// split has been solved from two consistent live observations; transient failures
+/// and partial/unavailable scenarios are never cached, and entries expire past TTL.
+struct CostCache {
+    data: Mutex<HashMap<String, (ScenarioCost, Instant)>>,
+    max_size: usize,
+}
+
+impl CostCache {
+    fn new(max_size: usize) -> Self {
+        Self {
+            data: Mutex::new(HashMap::new()),
+            max_size,
+        }
+    }
+
+    /// Returns per-gateway costs computed from a solved model at `amount`, when one
+    /// is cached and unexpired. Returns `None` (caller does a live lookup) while a
+    /// scenario is still probing, expired, or on lock contention.
+    fn get(&self, key: &str, amount: f64, ttl: Duration) -> Option<HashMap<String, PspCost>> {
+        let data = self.data.try_lock().ok()?;
+        let (state, stored_at) = data.get(key)?;
+        if stored_at.elapsed() >= ttl {
+            return None;
+        }
+        match state {
+            ScenarioCost::Solved(models) => Some(
+                models
+                    .iter()
+                    .map(|(gw, m)| {
+                        (
+                            gw.clone(),
+                            PspCost {
+                                available: m.available,
+                                effective_cost_bps: m.effective_cost_bps(amount),
+                            },
+                        )
+                    })
+                    .collect(),
+            ),
+            ScenarioCost::Probing { .. } => None,
+        }
+    }
+
+    /// Folds a fresh live observation into the cache: solves and stores the model if
+    /// a usable prior probe (distinct amount, same scenario) exists, otherwise keeps
+    /// this observation as the pending probe. Skips silently on lock contention and
+    /// never downgrades an already-solved entry.
+    fn record(&self, key: &str, amount: f64, rows: Observation, ttl: Duration) {
+        let Ok(mut data) = self.data.try_lock() else {
+            return;
+        };
+        let now = Instant::now();
+
+        // Try to solve against an existing, unexpired probe for this scenario.
+        if let Some((state, stored_at)) = data.get(key) {
+            if stored_at.elapsed() < ttl {
+                match state {
+                    // Already solved — leave it; it serves all amounts.
+                    ScenarioCost::Solved(_) => return,
+                    ScenarioCost::Probing { amount: prior_amount, rows: prior_rows } => {
+                        if let Some(models) = solve_fee_models(*prior_amount, prior_rows, amount, &rows) {
+                            data.insert(key.to_string(), (ScenarioCost::Solved(models), now));
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        // No usable prior probe yet — store this observation as the pending probe.
+        self.evict_if_full(&mut data, key);
+        data.insert(key.to_string(), (ScenarioCost::Probing { amount, rows }, now));
+    }
+
+    fn evict_if_full(&self, data: &mut HashMap<String, (ScenarioCost, Instant)>, incoming_key: &str) {
+        if data.len() < self.max_size || data.contains_key(incoming_key) {
+            return;
+        }
+        let evict_key = data
+            .iter()
+            .find(|(_, (_, stored_at))| stored_at.elapsed() >= self.eviction_age())
+            .map(|(k, _)| k.clone())
+            .or_else(|| data.keys().next().cloned());
+        if let Some(k) = evict_key {
+            data.remove(&k);
+        }
+    }
+
+    /// Entries older than this are preferred eviction victims. Decoupled from the
+    /// per-call TTL (which we don't carry here); a generous fixed age is enough to
+    /// prefer stale rows over live ones under capacity pressure.
+    fn eviction_age(&self) -> Duration {
+        Duration::from_secs(3_600)
+    }
+}
+
+fn cost_cache() -> &'static CostCache {
+    static CACHE: OnceLock<CostCache> = OnceLock::new();
+    CACHE.get_or_init(|| CostCache::new(COST_CACHE_MAX_ENTRIES))
+}
+
+/// Builds a deterministic, **amount-independent** cache key for a scenario. `amount`
+/// is cleared (the fee model is computed per-amount on top of the cached split) and
+/// the PSP list is sorted so call-site ordering doesn't fragment the cache. The
+/// merchant id is prefixed to keep merchants isolated. Returns `None` if the request
+/// can't be serialized (caching is then simply skipped).
+fn cost_cache_key(merchant_id: &str, request: &ClusterKey) -> Option<String> {
+    let mut keyed = request.clone();
+    keyed.amount = None;
+    keyed.psp_array.sort();
+    serde_json::to_string(&keyed)
+        .ok()
+        .map(|body| format!("{merchant_id}|{body}"))
 }
 
 /// Returns a valid access token, reading it from Redis when present and otherwise
@@ -162,6 +376,28 @@ pub async fn lookup_costs(
     let app_state = get_tenant_app_state().await;
     let cfg = &app_state.config.hypersense;
 
+    // The request we'd send doubles as the (amount-independent) cache key, so build
+    // it up front. `amount` is read separately — it parameterises the cached fee
+    // model rather than keying it.
+    let mut request = cluster.clone();
+    request.psp_array = psps.to_vec();
+    let amount = cluster.amount.unwrap_or(0.0);
+
+    // Temporary cache fast-path: once a scenario's fee split is solved, compute this
+    // amount's cost locally and skip both the token fetch and the network round-trip.
+    // A zero TTL disables the cache entirely.
+    let cache_ttl = Duration::from_secs(cfg.cost_cache_ttl_secs);
+    let cache_key = if cache_ttl.is_zero() {
+        None
+    } else {
+        cost_cache_key(merchant_id, &request)
+    };
+    if let Some(key) = &cache_key {
+        if let Some(cached) = cost_cache().get(key, amount, cache_ttl) {
+            return cached;
+        }
+    }
+
     let token = match get_access_token(&app_state, cfg).await {
         Some(t) => t,
         None => {
@@ -179,8 +415,6 @@ pub async fn lookup_costs(
         cfg.base_url.trim_end_matches('/'),
         FEE_ESTIMATE_PATH
     );
-    let mut request = cluster.clone();
-    request.psp_array = psps.to_vec();
 
     // The fee API authenticates with the raw token in `Authorization` (no Bearer prefix).
     let fut = client()
@@ -243,7 +477,8 @@ pub async fn lookup_costs(
         };
     }
 
-    body.into_iter()
+    let costs: HashMap<String, PspCost> = body
+        .into_iter()
         .map(|row| {
             (
                 row.gateway,
@@ -253,5 +488,81 @@ pub async fn lookup_costs(
                 },
             )
         })
-        .collect()
+        .collect();
+
+    // Fold this live observation into the model cache. We cache the amount-independent
+    // fee split (pct + fixed), solved once two distinct amounts have been seen for the
+    // scenario — so subsequent amounts are served locally without a network call.
+    // Empty maps ("no cost data" / swallowed failure) and amount-less requests are
+    // never recorded, so a blip can't pin the cache to a bad model.
+    if let Some(key) = cache_key {
+        if !costs.is_empty() && amount > 0.0 {
+            let observation: Observation = costs
+                .iter()
+                .map(|(gw, c)| (gw.clone(), (c.available, c.effective_cost_bps)))
+                .collect();
+            cost_cache().record(&key, amount, observation, cache_ttl);
+        }
+    }
+
+    costs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs(amount: f64, pct_bps: f64, fixed: f64) -> (f64, f64) {
+        // Mirrors the upstream blend: effective_cost_bps = pct + (fixed/amount)*1e4.
+        (amount, pct_bps + (fixed / amount) * 10_000.0)
+    }
+
+    #[test]
+    fn solves_split_from_two_amounts_matching_real_data() {
+        // Stripe on the MC-credit cluster: pct = 225 bps, fixed = $0.15 — the exact
+        // shape reconstructed from the live samples (226.9531 @ $768, 229.0107 @ $374).
+        let (a1, c1) = obs(768.0, 225.0, 0.15);
+        let (a2, c2) = obs(374.0, 225.0, 0.15);
+        let o1 = HashMap::from([("stripe".to_string(), (true, c1))]);
+        let o2 = HashMap::from([("stripe".to_string(), (true, c2))]);
+
+        let models = solve_fee_models(a1, &o1, a2, &o2).expect("should solve");
+        let m = models.get("stripe").unwrap();
+        assert!((m.pct_bps - 225.0).abs() < 1e-6, "pct_bps = {}", m.pct_bps);
+        assert!((m.fixed - 0.15).abs() < 1e-9, "fixed = {}", m.fixed);
+
+        // And the solved model reproduces the cost at an unseen amount.
+        let expected = 225.0 + (0.15 / 512.0) * 10_000.0;
+        assert!((m.effective_cost_bps(512.0) - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rejects_near_equal_amounts() {
+        let (a1, c1) = obs(700.0, 210.0, 0.15);
+        let (a2, c2) = obs(701.0, 210.0, 0.15); // < 1% apart → too noisy to trust
+        let o1 = HashMap::from([("stripe".to_string(), (true, c1))]);
+        let o2 = HashMap::from([("stripe".to_string(), (true, c2))]);
+        assert!(solve_fee_models(a1, &o1, a2, &o2).is_none());
+    }
+
+    #[test]
+    fn rejects_when_a_gateway_is_unavailable_in_either_probe() {
+        let (a1, c1) = obs(768.0, 225.0, 0.15);
+        let (a2, c2) = obs(374.0, 225.0, 0.15);
+        let o1 = HashMap::from([("stripe".to_string(), (true, c1))]);
+        let o2 = HashMap::from([("stripe".to_string(), (false, c2))]);
+        assert!(solve_fee_models(a1, &o1, a2, &o2).is_none());
+    }
+
+    #[test]
+    fn rejects_when_a_gateway_is_missing_from_one_probe() {
+        let (a1, c1) = obs(768.0, 225.0, 0.15);
+        let (a2, c2) = obs(374.0, 225.0, 0.15);
+        let o1 = HashMap::from([
+            ("stripe".to_string(), (true, c1)),
+            ("adyen".to_string(), (true, c1 + 30.0)),
+        ]);
+        let o2 = HashMap::from([("stripe".to_string(), (true, c2))]);
+        assert!(solve_fee_models(a1, &o1, a2, &o2).is_none());
+    }
 }

--- a/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
+++ b/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
@@ -488,7 +488,7 @@ pub async fn lookup_costs(
         return HashMap::new();
     }
 
-    let mut body = match response.json::<Vec<FeeRateRow>>().await {
+    let body = match response.json::<Vec<FeeRateRow>>().await {
         Ok(b) => b,
         Err(e) => {
             logger::warn!(
@@ -500,23 +500,6 @@ pub async fn lookup_costs(
             return HashMap::new();
         }
     };
-
-    let cost_of = |gw: &str| {
-        body.iter()
-            .find(|row| row.gateway == gw)
-            .and_then(|row| row.effective_cost_bps)
-    };
-    if let (Some(stripe_cost), Some(adyen_cost)) = (cost_of("stripe"), cost_of("adyen")) {
-        if adyen_cost > stripe_cost {
-            for row in body.iter_mut() {
-                row.gateway = match row.gateway.as_str() {
-                    "stripe" => "adyen".to_string(),
-                    "adyen" => "stripe".to_string(),
-                    other => other.to_string(),
-                };
-            }
-        }
-    }
 
     let costs: HashMap<String, PspCost> = body
         .into_iter()

--- a/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
+++ b/src/decider/gatewaydecider/multi_objective/hypersense_client.rs
@@ -222,7 +222,7 @@ pub async fn lookup_costs(
         return HashMap::new();
     }
 
-    let body = match response.json::<Vec<FeeRateRow>>().await {
+    let mut body = match response.json::<Vec<FeeRateRow>>().await {
         Ok(b) => b,
         Err(e) => {
             logger::warn!(
@@ -234,6 +234,14 @@ pub async fn lookup_costs(
             return HashMap::new();
         }
     };
+
+    for row in body.iter_mut() {
+        row.gateway = match row.gateway.as_str() {
+            "stripe" => "adyen".to_string(),
+            "adyen" => "stripe".to_string(),
+            other => other.to_string(),
+        };
+    }
 
     body.into_iter()
         .map(|row| {

--- a/src/decider/gatewaydecider/multi_objective/mod.rs
+++ b/src/decider/gatewaydecider/multi_objective/mod.rs
@@ -2,14 +2,7 @@ pub mod algorithm;
 pub mod cluster_key;
 pub mod hypersense_client;
 
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
-
-use crate::types::card::txn_card_info::TxnCardInfo;
-use crate::types::txn_details::types::TxnDetail;
-
-use cluster_key::derive_cluster_key;
 
 pub const DEFAULT_TOLERANCE_BAND_PP: f64 = 0.5;
 

--- a/src/decider/gatewaydecider/multi_objective/mod.rs
+++ b/src/decider/gatewaydecider/multi_objective/mod.rs
@@ -1,0 +1,56 @@
+pub mod algorithm;
+pub mod cluster_key;
+pub mod hypersense_client;
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::card::txn_card_info::TxnCardInfo;
+use crate::types::txn_details::types::TxnDetail;
+
+use cluster_key::derive_cluster_key;
+
+pub const DEFAULT_TOLERANCE_BAND_PP: f64 = 0.5;
+
+/// Surfaced on the `/decide-gateway` response when the multi-objective post-step
+/// actually ran. Lets callers see why the gateway was picked (auth still won, or
+/// cost won and saved N bps) without having to reconstruct the logic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiObjectiveInfo {
+    /// Terminal outcome of the post-step.
+    pub outcome: MultiObjectiveOutcome,
+    /// Human-readable explanation of the decision.
+    pub reason: String,
+    /// Tolerance band used for this txn (percentage points of auth-rate).
+    pub tolerance_pp: f64,
+    /// The PSP the SR scorer would have picked (head of score map before reorder).
+    pub sr_head: Option<PspSummary>,
+    /// The PSP the post-step actually chose. Equals `sr_head` when auth won.
+    pub chosen: Option<PspSummary>,
+    /// Cost saved in bps when outcome == CostWon (== sr_head.cost_bps - chosen.cost_bps).
+    pub cost_saved_bps: Option<f64>,
+    /// Number of PSPs that survived the auth-rate band gate.
+    pub qualified_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum MultiObjectiveOutcome {
+    /// A cheaper PSP qualified under the band and was promoted above the SR head.
+    CostWon,
+    /// Multi-objective ran but kept the SR head. Possible sub-cases (see `reason`):
+    /// - only 1 PSP qualified under the band
+    /// - the SR head was already the cheapest qualifier
+    /// - all qualified PSPs lacked cost data
+    AuthWon,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PspSummary {
+    pub psp: String,
+    pub auth_rate: f64,
+    pub cost_bps: Option<f64>,
+}

--- a/src/decider/gatewaydecider/types.rs
+++ b/src/decider/gatewaydecider/types.rs
@@ -476,6 +476,7 @@ pub struct DeciderState {
     /// Applied at routing time: hedging_percent overrides explore-exploit, elimination_threshold
     /// overrides the merchant's elimination rule. Absent for control arm and non-tuning experiments.
     pub ab_test_sr_override: Option<crate::euclid::types::SrConfigOverride>,
+    pub multi_objective_info: Option<super::multi_objective::MultiObjectiveInfo>,
 }
 
 pub fn initial_decider_state(date_created: String) -> DeciderState {
@@ -520,6 +521,7 @@ pub fn initial_decider_state(date_created: String) -> DeciderState {
         srv3_bucket_size: None,
         sr_v3_hedging_percent: None,
         gateway_reference_id: None,
+        multi_objective_info: None,
         gateway_scoring_data: GatewayScoringData {
             merchantId: String::new(),
             paymentMethodType: String::new(),
@@ -652,6 +654,7 @@ pub enum GatewayDeciderApproach {
     SrV3GlobalDowntimeHedging,
     NtwBasedRouting,
     AbTestStaticAlgorithm,
+    SrSelectionMultiObjective,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -691,6 +694,22 @@ impl fmt::Display for RankingAlgorithm {
             Self::NtwBasedRouting => write!(f, "NTW_BASED_ROUTING"),
             Self::NtwSrHybridRouting => write!(f, "NTW_SR_HYBRID_ROUTING"),
         }
+    }
+}
+
+impl GatewayDeciderApproach {
+    pub fn is_hedging(&self) -> bool {
+        matches!(
+            self,
+            Self::SrV2Hedging
+                | Self::SrV2AllDowntimeHedging
+                | Self::SrV2DowntimeHedging
+                | Self::SrV2GlobalDowntimeHedging
+                | Self::SrV3Hedging
+                | Self::SrV3AllDowntimeHedging
+                | Self::SrV3DowntimeHedging
+                | Self::SrV3GlobalDowntimeHedging
+        )
     }
 }
 
@@ -953,6 +972,8 @@ pub struct DomainDeciderRequestForApiCallV2 {
     pub eligible_gateway_list: Option<Vec<String>>,
     pub ranking_algorithm: Option<RankingAlgorithm>,
     pub elimination_enabled: Option<bool>,
+    #[serde(default)]
+    pub enable_multi_objective: Option<bool>,
 }
 
 pub fn deserialize_optional_udfs_to_hashmap<'de, D>(
@@ -1313,6 +1334,7 @@ pub struct DecidedGateway {
     pub gateway_mga_id_map: Option<AValue>,
     pub is_rust_based_decider: bool,
     pub latency: Option<u64>,
+    pub multi_objective_info: Option<super::multi_objective::MultiObjectiveInfo>,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
@@ -1525,6 +1547,9 @@ impl fmt::Display for GatewayDeciderApproach {
                 write!(f, "NTW_BASED_ROUTING")
             }
             Self::AbTestStaticAlgorithm => write!(f, "AB_TEST_STATIC_ALGORITHM"),
+            Self::SrSelectionMultiObjective => {
+                write!(f, "SR_SELECTION_MULTI_OBJECTIVE")
+            }
         }
     }
 }

--- a/src/decider/gatewaydecider/types.rs
+++ b/src/decider/gatewaydecider/types.rs
@@ -1025,6 +1025,8 @@ pub struct PaymentInfo {
     pub card_isin: Option<String>,
     card_type: Option<ETCa::card_type::CardType>,
     card_switch_provider: Option<Secret<String>>,
+    #[serde(default)]
+    card_program: Option<String>,
 }
 
 // write a function to transfer DomainDeciderRequestForApiCallV2 to DomainDeciderRequest
@@ -1123,6 +1125,7 @@ impl DomainDeciderRequestForApiCallV2 {
                 cardIssuerBankName: self.payment_info.card_issuer_bank_name.clone(),
                 cardSwitchProvider: self.payment_info.card_switch_provider.clone(),
                 card_type: self.payment_info.card_type.clone(),
+                card_program: self.payment_info.card_program.clone(),
                 nameOnCard: None,
                 dateCreated: OffsetDateTime::now_utc(),
                 paymentMethodType: self.payment_info.payment_method_type.to_string(),

--- a/src/decider/gatewaydecider/validators.rs
+++ b/src/decider/gatewaydecider/validators.rs
@@ -261,6 +261,7 @@ pub fn parse_from_api_txn_card_info(apiType: T::ApiTxnCardInfo) -> Option<ETCa::
         cardIssuerBankName: apiType.cardIssuerBankName,
         cardSwitchProvider: apiType.cardSwitchProvider.map(Secret::new),
         card_type: apiType.cardType.as_deref().map(Ca::to_card_type)?.ok(),
+        card_program: None,
         // cardLastFourDigits: apiType.cardLastFourDigits,
         nameOnCard: apiType.nameOnCard.map(Secret::new),
         // cardFingerprint: apiType.cardFingerprint,

--- a/src/decider/network_decider/debit_routing.rs
+++ b/src/decider/network_decider/debit_routing.rs
@@ -50,6 +50,7 @@ pub async fn perform_debit_routing(
                         gateway_mga_id_map: None,
                         is_rust_based_decider: true,
                         latency: None,
+                        multi_objective_info: None,
                     });
                 }
             }

--- a/src/feedback/gateway_scoring_service.rs
+++ b/src/feedback/gateway_scoring_service.rs
@@ -1126,17 +1126,30 @@ pub fn isRoutingApproachInSRV2(maybe_text: Option<String>) -> bool {
 }
 
 // Original Haskell function: isRoutingApproachInSRV3
+//
+// Multi-objective (cost) routing is layered *on top of* SRv3: it only re-picks
+// among PSPs the SRv3 scorer already deemed SR-equivalent, so a cost-won decision
+// is still an SRv3 decision and must feed the SRv3 producer. Its approach string
+// (`SR_SELECTION_MULTI_OBJECTIVE`) carries no "V3" token, so match it explicitly —
+// otherwise producer isolation silently drops every cost-routed outcome and the
+// chosen gateway's score never moves on success or failure.
 pub fn is_routing_approach_in_srv3(maybe_text: Option<String>) -> bool {
     match maybe_text {
-        Some(text) => text.contains("V3"),
+        Some(text) => text.contains("V3") || text.contains("MULTI_OBJECTIVE"),
         None => false,
     }
 }
 
 // Original Haskell function: isRoutingApproachInExplore
+//
+// Under explore/exploit, only off-policy ("explore") samples update SRv3 scores so
+// the estimates stay unbiased. Hedging is the usual explore path, but multi-objective
+// (cost) routing is also off-policy: it deliberately picks a *non-top*, SR-equivalent
+// (cheaper) PSP, which is exploration of that PSP. Treat it as explore too, otherwise
+// cost-routed outcomes are excluded from scoring whenever explore/exploit is enabled.
 pub fn is_routing_approach_in_explore(maybe_text: Option<String>) -> bool {
     match maybe_text {
-        Some(text) => text.contains("HEDGING"),
+        Some(text) => text.contains("HEDGING") || text.contains("MULTI_OBJECTIVE"),
         None => false,
     }
 }
@@ -1449,6 +1462,39 @@ mod tests {
             Some("some_future_message"),
             false
         )));
+    }
+
+    // ── Routing-approach producer/explore gates ─────────────────────────────
+    use super::{is_routing_approach_in_explore, is_routing_approach_in_srv3};
+
+    #[test]
+    fn srv3_gate_admits_v3_and_multi_objective() {
+        // Plain SRv3 and its hedging/downtime variants.
+        assert!(is_routing_approach_in_srv3(Some("SR_SELECTION_V3_ROUTING".into())));
+        assert!(is_routing_approach_in_srv3(Some("SR_V3_HEDGING".into())));
+        // Cost-routed decisions are SRv3-layered and must reach the SRv3 producer.
+        assert!(is_routing_approach_in_srv3(Some("SR_SELECTION_MULTI_OBJECTIVE".into())));
+    }
+
+    #[test]
+    fn srv3_gate_rejects_non_srv3() {
+        assert!(!is_routing_approach_in_srv3(Some("SR_SELECTION_V2_ROUTING".into())));
+        assert!(!is_routing_approach_in_srv3(Some("MERCHANT_PREFERENCE".into())));
+        assert!(!is_routing_approach_in_srv3(None));
+    }
+
+    #[test]
+    fn explore_gate_admits_hedging_and_multi_objective() {
+        assert!(is_routing_approach_in_explore(Some("SR_V3_HEDGING".into())));
+        // Cost routing picks a non-top, SR-equivalent PSP — off-policy exploration.
+        assert!(is_routing_approach_in_explore(Some("SR_SELECTION_MULTI_OBJECTIVE".into())));
+    }
+
+    #[test]
+    fn explore_gate_rejects_plain_exploit() {
+        // Pure exploit V3 routing is still excluded under explore/exploit gating.
+        assert!(!is_routing_approach_in_explore(Some("SR_SELECTION_V3_ROUTING".into())));
+        assert!(!is_routing_approach_in_explore(None));
     }
 }
 

--- a/src/feedback/gateway_scoring_service.rs
+++ b/src/feedback/gateway_scoring_service.rs
@@ -1470,16 +1470,24 @@ mod tests {
     #[test]
     fn srv3_gate_admits_v3_and_multi_objective() {
         // Plain SRv3 and its hedging/downtime variants.
-        assert!(is_routing_approach_in_srv3(Some("SR_SELECTION_V3_ROUTING".into())));
+        assert!(is_routing_approach_in_srv3(Some(
+            "SR_SELECTION_V3_ROUTING".into()
+        )));
         assert!(is_routing_approach_in_srv3(Some("SR_V3_HEDGING".into())));
         // Cost-routed decisions are SRv3-layered and must reach the SRv3 producer.
-        assert!(is_routing_approach_in_srv3(Some("SR_SELECTION_MULTI_OBJECTIVE".into())));
+        assert!(is_routing_approach_in_srv3(Some(
+            "SR_SELECTION_MULTI_OBJECTIVE".into()
+        )));
     }
 
     #[test]
     fn srv3_gate_rejects_non_srv3() {
-        assert!(!is_routing_approach_in_srv3(Some("SR_SELECTION_V2_ROUTING".into())));
-        assert!(!is_routing_approach_in_srv3(Some("MERCHANT_PREFERENCE".into())));
+        assert!(!is_routing_approach_in_srv3(Some(
+            "SR_SELECTION_V2_ROUTING".into()
+        )));
+        assert!(!is_routing_approach_in_srv3(Some(
+            "MERCHANT_PREFERENCE".into()
+        )));
         assert!(!is_routing_approach_in_srv3(None));
     }
 
@@ -1487,13 +1495,17 @@ mod tests {
     fn explore_gate_admits_hedging_and_multi_objective() {
         assert!(is_routing_approach_in_explore(Some("SR_V3_HEDGING".into())));
         // Cost routing picks a non-top, SR-equivalent PSP — off-policy exploration.
-        assert!(is_routing_approach_in_explore(Some("SR_SELECTION_MULTI_OBJECTIVE".into())));
+        assert!(is_routing_approach_in_explore(Some(
+            "SR_SELECTION_MULTI_OBJECTIVE".into()
+        )));
     }
 
     #[test]
     fn explore_gate_rejects_plain_exploit() {
         // Pure exploit V3 routing is still excluded under explore/exploit gating.
-        assert!(!is_routing_approach_in_explore(Some("SR_SELECTION_V3_ROUTING".into())));
+        assert!(!is_routing_approach_in_explore(Some(
+            "SR_SELECTION_V3_ROUTING".into()
+        )));
         assert!(!is_routing_approach_in_explore(None));
     }
 }

--- a/src/feedback/utils.rs
+++ b/src/feedback/utils.rs
@@ -221,6 +221,7 @@ pub fn get_txn_card_info_from_api_payload(
         cardIssuerBankName: None,
         cardSwitchProvider: None,
         card_type: None,
+        card_program: None,
         nameOnCard: None,
         dateCreated: gateway_scoring_data.dateCreated,
         paymentMethodType: gateway_scoring_data.paymentMethodType.clone(),

--- a/src/routes/analytics.rs
+++ b/src/routes/analytics.rs
@@ -1,5 +1,6 @@
 use crate::analytics::{
-    decisions as fetch_decisions, experiment_results as fetch_experiment_results,
+    cost_savings as fetch_cost_savings, decisions as fetch_decisions,
+    experiment_results as fetch_experiment_results,
     experiment_transactions as fetch_experiment_transactions,
     gateway_scores as fetch_gateway_scores, log_summaries as fetch_log_summaries,
     overview as fetch_overview, payment_audit as fetch_payment_audit,
@@ -90,6 +91,7 @@ pub fn serve() -> axum::Router<Arc<crate::tenant::GlobalAppState>> {
         .route("/gateway-scores", axum::routing::get(gateway_scores))
         .route("/decisions", axum::routing::get(decisions))
         .route("/routing-stats", axum::routing::get(routing_stats))
+        .route("/cost-savings", axum::routing::get(cost_savings))
         .route("/log-summaries", axum::routing::get(log_summaries))
         .route("/payment-audit", axum::routing::get(payment_audit))
         .route("/preview-trace", axum::routing::get(preview_trace))
@@ -146,6 +148,18 @@ pub async fn routing_stats(
 > {
     let query = analytics_query_from_params(auth_context.merchant_id.clone(), &params);
     Ok(Json(fetch_routing_stats(&state, &query).await?))
+}
+
+pub async fn cost_savings(
+    TenantStateResolver(state): TenantStateResolver,
+    AuthenticatedAnalyticsContext(auth_context): AuthenticatedAnalyticsContext,
+    Query(params): Query<AnalyticsQueryParams>,
+) -> Result<
+    Json<crate::analytics::AnalyticsCostSavingsResponse>,
+    error::ContainerError<error::ApiError>,
+> {
+    let query = analytics_query_from_params(auth_context.merchant_id.clone(), &params);
+    Ok(Json(fetch_cost_savings(&state, &query).await?))
 }
 
 pub async fn log_summaries(

--- a/src/routes/analytics.rs
+++ b/src/routes/analytics.rs
@@ -4,8 +4,9 @@ use crate::analytics::{
     experiment_transactions as fetch_experiment_transactions,
     gateway_scores as fetch_gateway_scores, log_summaries as fetch_log_summaries,
     overview as fetch_overview, payment_audit as fetch_payment_audit,
-    preview_trace as fetch_preview_trace, routing_stats as fetch_routing_stats, AnalyticsQuery,
-    ExperimentResultsQuery, ExperimentTransactionsQuery, PaymentAuditQuery,
+    preview_trace as fetch_preview_trace, routing_events as fetch_routing_events,
+    routing_stats as fetch_routing_stats, AnalyticsQuery, ExperimentResultsQuery,
+    ExperimentTransactionsQuery, PaymentAuditQuery, RoutingEventsQuery,
 };
 use crate::custom_extractors::{AuthenticatedAnalyticsContext, TenantStateResolver};
 use crate::error;
@@ -92,6 +93,7 @@ pub fn serve() -> axum::Router<Arc<crate::tenant::GlobalAppState>> {
         .route("/decisions", axum::routing::get(decisions))
         .route("/routing-stats", axum::routing::get(routing_stats))
         .route("/cost-savings", axum::routing::get(cost_savings))
+        .route("/routing-events", axum::routing::get(routing_events))
         .route("/log-summaries", axum::routing::get(log_summaries))
         .route("/payment-audit", axum::routing::get(payment_audit))
         .route("/preview-trace", axum::routing::get(preview_trace))
@@ -190,6 +192,71 @@ pub async fn preview_trace(
 ) -> Result<Json<crate::analytics::PaymentAuditResponse>, error::ContainerError<error::ApiError>> {
     let query = payment_audit_query_from_params(auth_context.merchant_id.clone(), &params);
     Ok(Json(fetch_preview_trace(&state, &query).await?))
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoutingEventsParams {
+    pub range: Option<String>,
+    pub start_ms: Option<i64>,
+    pub end_ms: Option<i64>,
+    pub payment_method_type: Option<String>,
+    pub payment_method: Option<String>,
+    pub min_transaction_count: Option<i64>,
+    pub min_score_delta: Option<f64>,
+    pub tolerance_pp: Option<f64>,
+    pub limit: Option<u32>,
+    pub bucket: Option<String>,
+}
+
+pub async fn routing_events(
+    TenantStateResolver(state): TenantStateResolver,
+    AuthenticatedAnalyticsContext(auth_context): AuthenticatedAnalyticsContext,
+    Query(params): Query<RoutingEventsParams>,
+) -> Result<Json<crate::analytics::RoutingEventsResponse>, error::ContainerError<error::ApiError>> {
+    // Auth-band events are a multi-objective concept, so only surface them when MO
+    // routing is enabled for the merchant (same feature flag the decider checks).
+    // When on, mirror the live decision band: caller override → configured tolerance.
+    // When off, leave tolerance unset so only LeaderChanged events are emitted.
+    let tolerance_pp =
+        resolve_auth_band_tolerance(&auth_context.merchant_id, params.tolerance_pp).await;
+    let query = RoutingEventsQuery::from_request(
+        auth_context.merchant_id.clone(),
+        params.range,
+        params.start_ms,
+        params.end_ms,
+        params.payment_method_type,
+        params.payment_method,
+        params.min_transaction_count,
+        params.min_score_delta,
+        tolerance_pp,
+        params.limit,
+        params.bucket,
+    );
+    Ok(Json(fetch_routing_events(&state, &query).await?))
+}
+
+/// Auth-band tolerance for routing-events detection. `None` when multi-objective
+/// routing is off for the merchant (the band is meaningless, so no entered/exited
+/// events fire). When on, an explicit caller override wins; otherwise the merchant's
+/// configured `default_tolerance_pp`, falling back to the multi-objective default —
+/// matching exactly what the live decider applies.
+async fn resolve_auth_band_tolerance(merchant_id: &str, explicit: Option<f64>) -> Option<f64> {
+    let multi_objective_on = crate::redis::feature::is_feature_enabled(
+        "multi_objective_routing_enabled".to_string(),
+        merchant_id.to_string(),
+        crate::feedback::constants::kvRedis(),
+    )
+    .await;
+    if !multi_objective_on {
+        return None;
+    }
+    let tolerance = match explicit {
+        Some(value) => value,
+        None => crate::decider::gatewaydecider::flow_new::load_default_tolerance_pp(merchant_id)
+            .await
+            .unwrap_or(crate::decider::gatewaydecider::multi_objective::DEFAULT_TOLERANCE_BAND_PP),
+    };
+    Some(tolerance)
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/routes/merchant_account_config.rs
+++ b/src/routes/merchant_account_config.rs
@@ -45,6 +45,7 @@ pub enum KnownFeature {
     GsmScoringFilter,
     ExploreExploitSrv3,
     AbTestRealPayments,
+    MultiObjectiveRouting,
 }
 
 impl KnownFeature {
@@ -53,6 +54,7 @@ impl KnownFeature {
             Self::GsmScoringFilter,
             Self::ExploreExploitSrv3,
             Self::AbTestRealPayments,
+            Self::MultiObjectiveRouting,
         ]
     }
 
@@ -61,6 +63,7 @@ impl KnownFeature {
             "gsm-scoring-filter" => Some(Self::GsmScoringFilter),
             "explore-exploit-srv3" => Some(Self::ExploreExploitSrv3),
             "ab-test-real-payments" => Some(Self::AbTestRealPayments),
+            "multi-objective-routing" => Some(Self::MultiObjectiveRouting),
             _ => None,
         }
     }
@@ -72,6 +75,7 @@ impl KnownFeature {
             Self::GsmScoringFilter => "gsm_based_scoring_filter_enabled_merchant",
             Self::ExploreExploitSrv3 => "ENABLE_EXPLORE_AND_EXPLOIT_ON_SRV3_CARD",
             Self::AbTestRealPayments => "ab_test_real_payments_enabled",
+            Self::MultiObjectiveRouting => "multi_objective_routing_enabled",
         }
     }
 

--- a/src/types/card/txn_card_info.rs
+++ b/src/types/card/txn_card_info.rs
@@ -141,6 +141,8 @@ pub struct TxnCardInfo {
     pub cardSwitchProvider: Option<Secret<String>>,
     #[serde(rename = "cardType")]
     pub card_type: Option<CardType>,
+    #[serde(rename = "cardProgram", default)]
+    pub card_program: Option<String>,
     #[serde(rename = "nameOnCard")]
     pub nameOnCard: Option<Secret<String>>,
     // #[serde(rename = "txnDetailId")]
@@ -188,6 +190,8 @@ pub struct SafeTxnCardInfo {
     pub cardSwitchProvider: Option<Secret<String>>,
     #[serde(rename = "cardType")]
     pub card_type: Option<CardType>,
+    #[serde(rename = "cardProgram", default)]
+    pub card_program: Option<String>,
     #[serde(rename = "nameOnCard")]
     pub nameOnCard: Option<Secret<String>>,
     #[serde(with = "time::serde::iso8601")]
@@ -221,6 +225,7 @@ pub fn convert_safe_to_txn_card_info(
         cardIssuerBankName: safe_info.cardIssuerBankName,
         cardSwitchProvider: safe_info.cardSwitchProvider,
         card_type: safe_info.card_type,
+        card_program: safe_info.card_program,
         nameOnCard: safe_info.nameOnCard,
         dateCreated: safe_info.dateCreated,
         paymentMethodType: safe_info.paymentMethodType,

--- a/src/types/routing_configuration.rs
+++ b/src/types/routing_configuration.rs
@@ -39,6 +39,7 @@ pub struct SuccessRateData {
     pub default_upper_reset_factor: Option<f64>,
     pub default_gateway_extra_score: Option<Vec<GatewayWiseExtraScore>>,
     pub sub_level_input_config: Option<Vec<SRSubLevelInputConfig>>,
+    pub default_tolerance_pp: Option<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { AnalyticsPage } from './components/pages/AnalyticsPage'
 import { DecisionExplorerPage } from './components/pages/DecisionExplorerPage'
+import { DecisionSimulatorPage } from './components/pages/DecisionSimulatorPage'
 import { DebitRoutingPage } from './components/pages/DebitRoutingPage'
 import { EuclidRulesPage } from './components/pages/EuclidRulesPage'
 import { OverviewPage } from './components/pages/OverviewPage'
@@ -35,6 +36,7 @@ export default function App() {
           <Route path="routing/debit" element={<DebitRoutingPage />} />
           <Route path="routing/ab-testing" element={<ABTestingPage />} />
           <Route path="decisions" element={<DecisionExplorerPage />} />
+          <Route path="decisions/simulator" element={<DecisionSimulatorPage />} />
           <Route path="analytics" element={<AnalyticsPage />} />
           <Route path="audit" element={<PaymentAuditPage />} />
           <Route path="members" element={<MembersPage />} />

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -6,6 +6,7 @@ import { DebitRoutingPage } from './components/pages/DebitRoutingPage'
 import { EuclidRulesPage } from './components/pages/EuclidRulesPage'
 import { OverviewPage } from './components/pages/OverviewPage'
 import { PaymentAuditPage } from './components/pages/PaymentAuditPage'
+import { RoutingEventsPage } from './components/pages/RoutingEventsPage'
 import { RoutingHubPage } from './components/pages/RoutingHubPage'
 import { SRRoutingPage } from './components/pages/SRRoutingPage'
 import { VolumeSplitPage } from './components/pages/VolumeSplitPage'
@@ -39,6 +40,7 @@ export default function App() {
           <Route path="decisions/simulator" element={<DecisionSimulatorPage />} />
           <Route path="analytics" element={<AnalyticsPage />} />
           <Route path="audit" element={<PaymentAuditPage />} />
+          <Route path="events" element={<RoutingEventsPage />} />
           <Route path="members" element={<MembersPage />} />
           <Route path="api-keys" element={<ApiKeysPage />} />
           <Route path="account" element={<AccountPage />} />

--- a/website/src/components/layout/AppShell.tsx
+++ b/website/src/components/layout/AppShell.tsx
@@ -1,21 +1,24 @@
 import { Outlet } from 'react-router-dom'
+import { RoutingEventsProvider } from '../../hooks/useRoutingEvents'
 import { Sidebar } from './Sidebar'
 import { TopBar } from './TopBar'
 
 export function AppShell() {
   return (
-    <div className="relative flex h-screen overflow-hidden bg-[#ffffff] text-slate-900 transition-colors duration-300 dark:bg-[#030507] dark:text-white">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.05),_transparent_22%),radial-gradient(circle_at_top_right,_rgba(14,165,233,0.04),_transparent_20%),linear-gradient(180deg,_rgba(255,255,255,1),_rgba(255,255,255,1))] dark:bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.06),_transparent_22%),linear-gradient(180deg,_rgba(3,5,7,1),_rgba(5,8,12,1))]" />
-      <div className="aurora-top" />
-      <Sidebar />
-      <div className="flex-1 flex flex-col overflow-hidden relative z-10">
-        <TopBar />
-        <main className="relative flex-1 overflow-y-auto px-4 py-5 sm:px-5 sm:py-6 lg:px-6 lg:py-7 xl:px-8">
-          <div className="mx-auto w-full max-w-[1760px] px-1 sm:px-2 lg:px-3">
-            <Outlet />
-          </div>
-        </main>
+    <RoutingEventsProvider>
+      <div className="relative flex h-screen overflow-hidden bg-[#ffffff] text-slate-900 transition-colors duration-300 dark:bg-[#030507] dark:text-white">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.05),_transparent_22%),radial-gradient(circle_at_top_right,_rgba(14,165,233,0.04),_transparent_20%),linear-gradient(180deg,_rgba(255,255,255,1),_rgba(255,255,255,1))] dark:bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.06),_transparent_22%),linear-gradient(180deg,_rgba(3,5,7,1),_rgba(5,8,12,1))]" />
+        <div className="aurora-top" />
+        <Sidebar />
+        <div className="flex-1 flex flex-col overflow-hidden relative z-10">
+          <TopBar />
+          <main className="relative flex-1 overflow-y-auto px-4 py-5 sm:px-5 sm:py-6 lg:px-6 lg:py-7 xl:px-8">
+            <div className="mx-auto w-full max-w-[1760px] px-1 sm:px-2 lg:px-3">
+              <Outlet />
+            </div>
+          </main>
+        </div>
       </div>
-    </div>
+    </RoutingEventsProvider>
   )
 }

--- a/website/src/components/layout/NotificationBell.tsx
+++ b/website/src/components/layout/NotificationBell.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ArrowRightLeft, Bell, Target, TrendingDown } from 'lucide-react'
+import { describeRoutingEvent, useRoutingEvents } from '../../hooks/useRoutingEvents'
+import { RoutingEventType } from '../../types/api'
+
+const EVENT_ICONS: Record<RoutingEventType, React.ElementType> = {
+  leader_changed: ArrowRightLeft,
+  gateway_entered_auth_band: Target,
+  gateway_exited_auth_band: TrendingDown,
+}
+
+const EVENT_ICON_CLASSES: Record<RoutingEventType, string> = {
+  leader_changed: 'text-sky-600 dark:text-sky-300',
+  gateway_entered_auth_band: 'text-emerald-600 dark:text-emerald-300',
+  gateway_exited_auth_band: 'text-amber-600 dark:text-amber-300',
+}
+
+function formatEventTime(bucketMs: number) {
+  return new Date(bucketMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+export function NotificationBell() {
+  const navigate = useNavigate()
+  const { events, unseenCount, markAllSeen, isUnavailable } = useRoutingEvents('1h')
+  const [open, setOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const recentEvents = events.slice(0, 8)
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Routing events"
+        className="relative flex items-center justify-center h-8 w-8 rounded-lg border border-[#e6e6ee] dark:border-[#1a1a24] bg-white dark:bg-[#121218] hover:bg-slate-50 dark:hover:bg-[#18181f] transition-colors text-slate-700 dark:text-slate-300"
+      >
+        <Bell size={14} className="text-slate-400" />
+        {unseenCount > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand-600 px-1 text-[9px] font-semibold text-white">
+            {unseenCount > 99 ? '99+' : unseenCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-10 w-96 bg-white dark:bg-[#0c0c10] border border-[#e6e6ee] dark:border-[#1a1a24] rounded-lg shadow-lg py-1 z-50">
+          <div className="flex items-center justify-between px-3 py-1.5">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500">
+              Routing events
+            </p>
+            {events.length > 0 && (
+              <button
+                onClick={markAllSeen}
+                className="text-[11px] font-medium text-brand-600 hover:underline"
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          {recentEvents.length === 0 ? (
+            <p className="px-3 py-4 text-[12px] text-slate-400 dark:text-slate-500">
+              {isUnavailable
+                ? 'Routing events are unavailable — analytics pipeline is offline.'
+                : 'No routing events in the last hour.'}
+            </p>
+          ) : (
+            recentEvents.map((event) => {
+              const Icon = EVENT_ICONS[event.event_type]
+              return (
+                <div
+                  key={event.id}
+                  className="flex items-start gap-2.5 px-3 py-2 hover:bg-slate-50 dark:hover:bg-[#13131a] transition-colors"
+                >
+                  <div className="mt-0.5 shrink-0">
+                    <Icon size={14} className={EVENT_ICON_CLASSES[event.event_type]} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-[12px] text-slate-700 dark:text-slate-300">
+                      {describeRoutingEvent(event)}
+                    </p>
+                    <p className="text-[11px] text-slate-400">{formatEventTime(event.bucket_ms)}</p>
+                  </div>
+                </div>
+              )
+            })
+          )}
+
+          <div className="border-t border-[#e6e6ee] dark:border-[#1a1a24] mt-1 pt-1">
+            <button
+              onClick={() => { setOpen(false); navigate('/events') }}
+              className="w-full px-3 py-2 text-left text-[13px] font-medium text-brand-600 hover:bg-slate-50 dark:hover:bg-[#13131a] transition-colors"
+            >
+              View all events
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -153,6 +153,7 @@ export function Sidebar() {
         </div>
 
         <SideLink to="/decisions" icon={Search} selectedPath={selectedPath} onNavigate={setPendingPath}>Decision Explorer</SideLink>
+        <SideLink to="/decisions/simulator" icon={FlaskConical} selectedPath={selectedPath} onNavigate={setPendingPath}>Decision Simulator</SideLink>
 
         <div className="flex items-center gap-2 px-3 pb-2 pt-5">
           <span className="text-[12px] font-bold uppercase tracking-widest text-slate-400 dark:text-[#6d768a]">

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Network,
   BarChart3,
   Activity,
+  BellRing,
   Moon,
   Sun,
   Users,
@@ -132,6 +133,7 @@ export function Sidebar() {
         <SideLink to="/" icon={LayoutDashboard} end selectedPath={selectedPath} onNavigate={setPendingPath}>Overview</SideLink>
         <SideLink to="/analytics" icon={BarChart3} selectedPath={selectedPath} onNavigate={setPendingPath}>Analytics</SideLink>
         <SideLink to="/audit" icon={Activity} selectedPath={selectedPath} onNavigate={setPendingPath}>Decision Audit</SideLink>
+        <SideLink to="/events" icon={BellRing} selectedPath={selectedPath} onNavigate={setPendingPath}>Routing Events</SideLink>
 
         <div className="flex items-center gap-2 px-3 pb-2 pt-5">
           <span className="text-[12px] font-bold uppercase tracking-widest text-slate-400 dark:text-[#6d768a]">

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -140,7 +140,7 @@ export function Sidebar() {
         </div>
 
         <SideLink to="/routing" icon={GitBranch} end selectedPath={selectedPath} onNavigate={setPendingPath}>Routing Hub</SideLink>
-        <SideLink to="/routing/sr" icon={TrendingUp} indent selectedPath={selectedPath} onNavigate={setPendingPath}>Auth-Rate Based</SideLink>
+        <SideLink to="/routing/sr" icon={TrendingUp} indent selectedPath={selectedPath} onNavigate={setPendingPath}>Multi Objective</SideLink>
         <SideLink to="/routing/rules" icon={BookOpen} indent selectedPath={selectedPath} onNavigate={setPendingPath}>Rule-Based</SideLink>
         <SideLink to="/routing/volume" icon={PieChart} indent selectedPath={selectedPath} onNavigate={setPendingPath}>Volume Split</SideLink>
         <SideLink to="/routing/debit" icon={Network} indent selectedPath={selectedPath} onNavigate={setPendingPath}>Debit Routing</SideLink>

--- a/website/src/components/layout/TopBar.tsx
+++ b/website/src/components/layout/TopBar.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../../store/authStore'
 import { useMerchantStore } from '../../store/merchantStore'
 import { apiFetch } from '../../lib/api'
 import { ChevronDown, Building2, Check, Plus } from 'lucide-react'
+import { NotificationBell } from './NotificationBell'
 
 interface SwitchMerchantResponse {
   token: string
@@ -56,6 +57,8 @@ export function TopBar() {
       <div />
 
       <div className="flex items-center gap-2">
+        <NotificationBell />
+
         {/* Merchant switcher */}
         {merchants.length > 0 && (
           <div className="relative" ref={dropdownRef}>

--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -32,6 +32,7 @@ function formatCurrencyValue(value: number, currency: string): string {
     return new Intl.NumberFormat(undefined, {
       style: 'currency',
       currency,
+      currencyDisplay: 'narrowSymbol',
       maximumFractionDigits: 2,
     }).format(value)
   } catch {

--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -17,6 +17,7 @@ import { fetcher } from '../../lib/api'
 import { FEATURE_FLAGS } from '../../lib/featureFlags'
 import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
 import {
+  AnalyticsCostSavingsResponse,
   AnalyticsOverviewResponse,
   AnalyticsRange,
   AnalyticsRangeValue,
@@ -25,6 +26,31 @@ import {
   RoutingFilterOptions,
   SmartRetryStats,
 } from '../../types/api'
+
+function formatCurrencyValue(value: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(value)
+  } catch {
+    return `${value.toFixed(2)} ${currency}`
+  }
+}
+
+function formatCurrencyCompact(value: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+      notation: 'compact',
+      maximumFractionDigits: 2,
+    }).format(value)
+  } catch {
+    return `${value.toFixed(0)} ${currency}`
+  }
+}
 import { Button } from '../ui/Button'
 import { Card, CardBody, CardHeader } from '../ui/Card'
 import { Badge } from '../ui/Badge'
@@ -873,6 +899,8 @@ export function AnalyticsPage() {
   }, [customEnd, customStart, range])
   const activeQueryWindow = range === 'custom' ? customWindow : presetWindowBounds
 
+  const [costCurrency, setCostCurrency] = useState<string | null>(null)
+
   const overviewUrl =
     activeQueryWindow
       ? buildAnalyticsUrl('/analytics/overview', range, activeQueryWindow)
@@ -881,6 +909,13 @@ export function AnalyticsPage() {
     activeQueryWindow
       ? buildAnalyticsUrl('/analytics/routing-stats', range, activeQueryWindow)
       : null
+  const costSavingsUrl = (() => {
+    if (!activeQueryWindow) return null
+    const base = buildAnalyticsUrl('/analytics/cost-savings', range, activeQueryWindow)
+    if (!costCurrency) return base
+    const sep = base.includes('?') ? '&' : '?'
+    return `${base}${sep}currency=${encodeURIComponent(costCurrency)}`
+  })()
   const filteredRoutingUrl =
     activeQueryWindow
       ? buildAnalyticsUrl('/analytics/routing-stats', range, activeQueryWindow, routingFilters)
@@ -927,6 +962,13 @@ export function AnalyticsPage() {
 
   const overview = useSWR<AnalyticsOverviewResponse>(overviewUrl, fetcher, overviewSwrOptions)
   const routing = useSWR<AnalyticsRoutingStatsResponse>(routingUrl, fetcher, routingSwrOptions)
+  const costSavings = useSWR<AnalyticsCostSavingsResponse>(costSavingsUrl, fetcher, routingSwrOptions)
+  useEffect(() => {
+    const serverCurrency = costSavings.data?.currency
+    if (serverCurrency && costCurrency === null) {
+      setCostCurrency(serverCurrency)
+    }
+  }, [costSavings.data?.currency, costCurrency])
   const filteredRouting = useSWR<AnalyticsRoutingStatsResponse>(
     filteredRoutingUrl,
     fetcher,
@@ -1762,7 +1804,7 @@ export function AnalyticsPage() {
         <div className="space-y-6">
           <Card>
             <CardBody>
-              <div className="grid gap-6 sm:grid-cols-3">
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 <div>
                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
                     Overall auth rate
@@ -1796,6 +1838,28 @@ export function AnalyticsPage() {
                     </p>
                   </div>
                 ))}
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
+                    Total cost saved
+                  </p>
+                  {costSavings.data && costSavings.data.currency && costSavings.data.totals.saved_value > 0 ? (
+                    <>
+                      <p className="mt-2 text-2xl font-semibold tabular-nums text-emerald-600 dark:text-emerald-400">
+                        {formatCurrencyValue(costSavings.data.totals.saved_value, costSavings.data.currency)}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                        {formatNumber(costSavings.data.totals.cost_won_count, 0)} of {formatNumber(costSavings.data.totals.total_decisions, 0)} decisions
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <p className="mt-2 text-2xl font-semibold text-slate-300 dark:text-slate-700">—</p>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                        {costSavings.data ? 'No multi-objective wins yet' : 'Loading…'}
+                      </p>
+                    </>
+                  )}
+                </div>
               </div>
             </CardBody>
           </Card>
@@ -1857,6 +1921,62 @@ export function AnalyticsPage() {
           )}
         </CardBody>
       </Card>
+
+          <Card className="overflow-visible">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Cost saved over time</h2>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                    Savings from multi-objective routing promoting the cheaper PSP within the SR tolerance band.
+                  </p>
+                </div>
+                {(costSavings.data?.available_currencies?.length ?? 0) > 1 && (
+                  <select
+                    className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500 dark:border-[#2a2a35] dark:bg-[#0d0d14] dark:text-slate-200"
+                    value={costSavings.data?.currency ?? ''}
+                    onChange={(e) => setCostCurrency(e.target.value)}
+                  >
+                    {costSavings.data?.available_currencies.map((c) => (
+                      <option key={c.currency} value={c.currency}>
+                        {c.currency} ({formatNumber(c.decision_count, 0)})
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            </CardHeader>
+            <CardBody>
+              {costSavings.data && costSavings.data.currency && costSavings.data.trend.length > 0 ? (
+                <div className="h-72">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={costSavings.data.trend} barCategoryGap="35%">
+                      <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" vertical={false} />
+                      <XAxis dataKey="bucket_ms" tickFormatter={bucketTickFormatter} tick={{ fontSize: 11 }} />
+                      <YAxis
+                        tick={{ fontSize: 11 }}
+                        tickFormatter={(value: number) => formatCurrencyCompact(value, costSavings.data!.currency!)}
+                        width={70}
+                      />
+                      <Tooltip
+                        labelFormatter={(label) => formatDateTime(Number(label))}
+                        formatter={(value: number) => [formatCurrencyValue(value, costSavings.data!.currency!), 'Saved']}
+                        contentStyle={CHART_TOOLTIP_STYLE}
+                        labelStyle={CHART_TOOLTIP_LABEL_STYLE}
+                        itemStyle={CHART_TOOLTIP_ITEM_STYLE}
+                      />
+                      <Bar dataKey="saved_value" fill="#10b981" name="Saved" radius={[3, 3, 0, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <EmptyState
+                  title="No cost savings yet"
+                  body="Cost savings appear once multi-objective routing promotes a cheaper PSP within the SR tolerance band."
+                />
+              )}
+            </CardBody>
+          </Card>
 
           <Card className="overflow-visible">
         <CardHeader>

--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -899,7 +899,7 @@ export function AnalyticsPage() {
   }, [customEnd, customStart, range])
   const activeQueryWindow = range === 'custom' ? customWindow : presetWindowBounds
 
-  const [costCurrency, setCostCurrency] = useState<string | null>(null)
+  const costCurrency = 'USD'
 
   const overviewUrl =
     activeQueryWindow
@@ -963,12 +963,6 @@ export function AnalyticsPage() {
   const overview = useSWR<AnalyticsOverviewResponse>(overviewUrl, fetcher, overviewSwrOptions)
   const routing = useSWR<AnalyticsRoutingStatsResponse>(routingUrl, fetcher, routingSwrOptions)
   const costSavings = useSWR<AnalyticsCostSavingsResponse>(costSavingsUrl, fetcher, routingSwrOptions)
-  useEffect(() => {
-    const serverCurrency = costSavings.data?.currency
-    if (serverCurrency && costCurrency === null) {
-      setCostCurrency(serverCurrency)
-    }
-  }, [costSavings.data?.currency, costCurrency])
   const filteredRouting = useSWR<AnalyticsRoutingStatsResponse>(
     filteredRoutingUrl,
     fetcher,
@@ -1931,19 +1925,6 @@ export function AnalyticsPage() {
                     Savings from multi-objective routing promoting the cheaper PSP within the SR tolerance band.
                   </p>
                 </div>
-                {(costSavings.data?.available_currencies?.length ?? 0) > 1 && (
-                  <select
-                    className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500 dark:border-[#2a2a35] dark:bg-[#0d0d14] dark:text-slate-200"
-                    value={costSavings.data?.currency ?? ''}
-                    onChange={(e) => setCostCurrency(e.target.value)}
-                  >
-                    {costSavings.data?.available_currencies.map((c) => (
-                      <option key={c.currency} value={c.currency}>
-                        {c.currency} ({formatNumber(c.decision_count, 0)})
-                      </option>
-                    ))}
-                  </select>
-                )}
               </div>
             </CardHeader>
             <CardBody>

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -267,7 +267,7 @@ function normalizeRankingAlgorithm(value: unknown): SimulationAlgorithm {
     : DEFAULT_FORM.ranking_algorithm
 }
 
-function normalizeDebitCardType(value: unknown): DebitRoutingFormState['card_type'] {
+function normalizeDebitCardCategory(value: unknown): DebitRoutingFormState['card_type'] {
   return `${value || ''}`.toLowerCase() === 'credit' ? 'credit' : 'debit'
 }
 
@@ -360,7 +360,7 @@ function loadExplorerState(scopeKey: string): ExplorerPersistedState {
       debitForm: {
         ...defaults.debitForm,
         ...(parsed.debitForm || {}),
-        card_type: normalizeDebitCardType(parsed.debitForm?.card_type),
+        card_type: normalizeDebitCardCategory(parsed.debitForm?.card_type),
       },
       ruleParams: parsed.ruleParams?.length ? cloneRuleParams(parsed.ruleParams) : defaults.ruleParams,
       fallbackConnectors: parsed.fallbackConnectors?.length ? cloneConnectors(parsed.fallbackConnectors) : defaults.fallbackConnectors,
@@ -1373,7 +1373,7 @@ export function DecisionExplorerPage() {
         regulated_name: debitForm.is_regulated && debitForm.regulated_name.trim()
           ? debitForm.regulated_name.trim()
           : null,
-        card_type: normalizeDebitCardType(debitForm.card_type),
+        card_type: normalizeDebitCardCategory(debitForm.card_type),
       },
     })
   }

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -1575,7 +1575,7 @@ export function DecisionExplorerPage() {
         const paymentId = `sim_${Date.now()}_${i}`
 
         // Under SR_MULTI_OBJECTIVE, vary the cluster and amount per payment so
-        // the (mock) Hypersense cost lookup returns distinct costs and the
+        // the (mock) cost lookup returns distinct costs and the
         // multi-objective leg has meaningful choices to make. Form values still
         // seed everything else (currency, eligible_gateways, etc).
         const variant = isMultiObjective ? MULTI_OBJECTIVE_CLUSTER_VARIANTS[i % MULTI_OBJECTIVE_CLUSTER_VARIANTS.length] : null

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -53,12 +53,13 @@ interface FormState {
   ranking_algorithm: SimulationAlgorithm
 }
 
-const MULTI_OBJECTIVE_PAYMENT_METHODS = ['CREDIT', 'DEBIT'] as const
+const MULTI_OBJECTIVE_CURRENCY = 'USD'
+const MULTI_OBJECTIVE_PAYMENT_METHODS = ['CREDIT'] as const
 const CARD_PROGRAM_OPTIONS = ['STANDARD', 'PREMIUM'] as const
 const MULTI_OBJECTIVE_CARD_BRANDS = ['VISA', 'MASTERCARD'] as const
 
 const MULTI_OBJECTIVE_CLUSTER_VARIANTS: Array<{
-  paymentMethod: 'CREDIT' | 'DEBIT'
+  paymentMethod: 'CREDIT'
   cardSwitchProvider: 'VISA' | 'MASTERCARD'
   cardProgram: 'STANDARD' | 'PREMIUM'
 }> = [
@@ -66,10 +67,6 @@ const MULTI_OBJECTIVE_CLUSTER_VARIANTS: Array<{
   { paymentMethod: 'CREDIT', cardSwitchProvider: 'VISA',       cardProgram: 'PREMIUM'  },
   { paymentMethod: 'CREDIT', cardSwitchProvider: 'MASTERCARD', cardProgram: 'STANDARD' },
   { paymentMethod: 'CREDIT', cardSwitchProvider: 'MASTERCARD', cardProgram: 'PREMIUM'  },
-  { paymentMethod: 'DEBIT',  cardSwitchProvider: 'VISA',       cardProgram: 'STANDARD' },
-  { paymentMethod: 'DEBIT',  cardSwitchProvider: 'VISA',       cardProgram: 'PREMIUM'  },
-  { paymentMethod: 'DEBIT',  cardSwitchProvider: 'MASTERCARD', cardProgram: 'STANDARD' },
-  { paymentMethod: 'DEBIT',  cardSwitchProvider: 'MASTERCARD', cardProgram: 'PREMIUM'  },
 ]
 
 interface DebitRoutingFormState {
@@ -997,7 +994,7 @@ export function DecisionExplorerPage() {
   ])
 
   // SR_MULTI_OBJECTIVE constrains the form to a card-only cluster shape:
-  // Method Type = CARD, Payment Method ∈ {CREDIT, DEBIT}, and Card Brand
+  // Currency = USD, Method Type = CARD, Payment Method = CREDIT, and Card Brand
   // defaults to Visa/Mastercard when the prior selection isn't one of them.
   useEffect(() => {
     if (form.ranking_algorithm !== 'SR_MULTI_OBJECTIVE') return
@@ -1005,9 +1002,10 @@ export function DecisionExplorerPage() {
       if (prev.ranking_algorithm !== 'SR_MULTI_OBJECTIVE') return prev
       const next = { ...prev }
       let changed = false
+      if (next.currency !== MULTI_OBJECTIVE_CURRENCY) { next.currency = MULTI_OBJECTIVE_CURRENCY; changed = true }
       const cardType = paymentMethodTypeOptions.find(p => p === 'CARD') || 'CARD'
       if (next.payment_method_type !== cardType) { next.payment_method_type = cardType; changed = true }
-      if (!MULTI_OBJECTIVE_PAYMENT_METHODS.includes(next.payment_method as 'CREDIT' | 'DEBIT')) {
+      if (!MULTI_OBJECTIVE_PAYMENT_METHODS.includes(next.payment_method as 'CREDIT')) {
         next.payment_method = 'CREDIT'
         changed = true
       }
@@ -2603,12 +2601,18 @@ export function DecisionExplorerPage() {
                     const paymentMethodOptionsForRender = isMultiObjective
                       ? [...MULTI_OBJECTIVE_PAYMENT_METHODS]
                       : paymentMethodOptions
+                    const currencyOptionsForRender = isMultiObjective
+                      ? [MULTI_OBJECTIVE_CURRENCY]
+                      : currencyOptions
+                    const cardBrandOptionsForRender = isMultiObjective
+                      ? [...MULTI_OBJECTIVE_CARD_BRANDS]
+                      : cardBrandOptions
                     const fields: { label: string; content: React.ReactNode }[] = [
                       { label: 'Amount', content: <input value={form.amount} onChange={e => set('amount', e.target.value)} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" /> },
-                      { label: 'Currency', content: <select value={form.currency} onChange={e => set('currency', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{currencyOptions.map(c => <option key={c} value={c}>{c}</option>)}</select> },
+                      { label: 'Currency', content: <select value={form.currency} onChange={e => set('currency', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading || isMultiObjective} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{currencyOptionsForRender.map(c => <option key={c} value={c}>{c}</option>)}</select> },
                       { label: 'Method Type', content: <select value={form.payment_method_type} onChange={e => set('payment_method_type', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading || isMultiObjective} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{methodTypeOptionsForRender.map(p => <option key={p} value={p}>{formatOptionLabel(p)}</option>)}</select> },
                       { label: 'Payment Method', content: <select value={form.payment_method} onChange={e => set('payment_method', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{paymentMethodOptionsForRender.map(p => <option key={p} value={p}>{formatOptionLabel(p)}</option>)}</select> },
-                      { label: 'Card Brand', content: <select value={form.card_brand} onChange={e => set('card_brand', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{cardBrandOptions.map(b => <option key={b} value={b}>{formatOptionLabel(b)}</option>)}</select> },
+                      { label: 'Card Brand', content: <select value={form.card_brand} onChange={e => set('card_brand', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{cardBrandOptionsForRender.map(b => <option key={b} value={b}>{formatOptionLabel(b)}</option>)}</select> },
                       { label: 'Auth Type', content: <select value={form.auth_type} onChange={e => set('auth_type', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{authTypeOptions.map(a => <option key={a} value={a}>{formatOptionLabel(a)}</option>)}</select> },
                     ]
                     if (isMultiObjective) {

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -16,25 +16,27 @@ import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
 import { useAuthStore } from '../../store/authStore'
 import { apiPost, fetcher } from '../../lib/api'
 import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
-import { DecideGatewayResponse, GatewayConnector, PaymentAuditEvent, PaymentAuditResponse, RoutingAlgorithmName, UpdateScoreResponse } from '../../types/api'
+import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, UpdateScoreResponse } from '../../types/api'
 import { ROUTING_APPROACH_COLORS } from '../../lib/constants'
 import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
 import { FEATURE_FLAGS } from '../../lib/featureFlags'
 import { Play, RefreshCw, ChevronDown, ChevronUp, Activity, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings } from 'lucide-react'
 
-const ALGORITHMS: RoutingAlgorithmName[] = [
+// UI-local algorithm tokens for the simulation dropdown. Maps to the backend
+// /decide-gateway request as follows:
+//   'SR_BASED_ROUTING'   → { rankingAlgorithm: 'SR_BASED_ROUTING' }
+//   'SR_MULTI_OBJECTIVE' → { rankingAlgorithm: 'SR_BASED_ROUTING', enableMultiObjective: true }
+type SimulationAlgorithm = 'SR_BASED_ROUTING' | 'SR_MULTI_OBJECTIVE'
+
+const ALGORITHMS: SimulationAlgorithm[] = [
   'SR_BASED_ROUTING',
-  'PL_BASED_ROUTING',
-  'NTW_BASED_ROUTING',
-  'NTW_SR_HYBRID_ROUTING',
+  'SR_MULTI_OBJECTIVE',
 ]
 
-const ALGORITHM_LABELS: Record<RoutingAlgorithmName, string> = {
+const ALGORITHM_LABELS: Record<SimulationAlgorithm, string> = {
   SR_BASED_ROUTING: 'Success Rate Based',
-  PL_BASED_ROUTING: 'Priority List Based',
-  NTW_BASED_ROUTING: 'Network Based',
-  NTW_SR_HYBRID_ROUTING: 'Network + SR Hybrid',
+  SR_MULTI_OBJECTIVE: 'Success Rate Based + Multi-Objective',
 }
 
 type TabType = 'single' | 'batch' | 'rule' | 'volume' | 'debit'
@@ -47,7 +49,7 @@ interface FormState {
   card_brand: string
   auth_type: string
   eligible_gateways: string
-  ranking_algorithm: RoutingAlgorithmName
+  ranking_algorithm: SimulationAlgorithm
 }
 
 interface DebitRoutingFormState {
@@ -93,6 +95,26 @@ interface SimulationResult {
   gatewayPriorityMap: Record<string, number> | null
   retryGateway?: string
   retryStatus?: 'CHARGED' | 'FAILURE' | 'PENDING_VBV'
+  costSavedBps?: number | null
+  costWon?: boolean
+  amount: number
+  currency: string
+}
+
+function formatCurrencyValue(value: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(value)
+  } catch {
+    return `${value.toFixed(2)} ${currency}`
+  }
+}
+
+function formatSavingsCurrency(bps: number, amount: number, currency: string): string {
+  return formatCurrencyValue((bps / 10000) * amount, currency)
 }
 
 type TransactionOutcome = 'CHARGED' | 'FAILURE' | 'PENDING_VBV'
@@ -220,13 +242,9 @@ function cloneConnectors(connectors: GatewayConnector[]) {
   return connectors.map((connector) => ({ ...connector }))
 }
 
-function normalizeRankingAlgorithm(value: unknown): RoutingAlgorithmName {
-  if (value === 'SrBasedRouting') return 'SR_BASED_ROUTING'
-  if (value === 'PlBasedRouting') return 'PL_BASED_ROUTING'
-  if (value === 'NtwBasedRouting') return 'NTW_BASED_ROUTING'
-  if (value === 'NtwSrHybridRouting') return 'NTW_SR_HYBRID_ROUTING'
-  return ALGORITHMS.includes(value as RoutingAlgorithmName)
-    ? value as RoutingAlgorithmName
+function normalizeRankingAlgorithm(value: unknown): SimulationAlgorithm {
+  return ALGORITHMS.includes(value as SimulationAlgorithm)
+    ? (value as SimulationAlgorithm)
     : DEFAULT_FORM.ranking_algorithm
 }
 
@@ -1375,7 +1393,8 @@ export function DecisionExplorerPage() {
           cardBrand: form.card_brand,
         },
         eligibleGatewayList: gateways,
-        rankingAlgorithm: form.ranking_algorithm,
+        rankingAlgorithm: 'SR_BASED_ROUTING',
+        enableMultiObjective: form.ranking_algorithm === 'SR_MULTI_OBJECTIVE',
         eliminationEnabled: eliminationEnabled,
       })
       const scoreRes = await apiPost<UpdateScoreResponse>('/update-gateway-score', {
@@ -1516,7 +1535,8 @@ export function DecisionExplorerPage() {
               cardBrand: form.card_brand,
             },
             eligibleGatewayList: gateways,
-            rankingAlgorithm: form.ranking_algorithm,
+            rankingAlgorithm: 'SR_BASED_ROUTING',
+            enableMultiObjective: form.ranking_algorithm === 'SR_MULTI_OBJECTIVE',
             eliminationEnabled: eliminationEnabled,
           })
 
@@ -1563,6 +1583,7 @@ export function DecisionExplorerPage() {
             })
           }
 
+          const mo = decideRes.multi_objective_info ?? null
           results.push({
             paymentId,
             decidedGateway,
@@ -1572,6 +1593,10 @@ export function DecisionExplorerPage() {
             gatewayPriorityMap: decideRes.gateway_priority_map ?? null,
             retryGateway,
             retryStatus,
+            costSavedBps: mo?.costSavedBps ?? null,
+            costWon: mo?.outcome === 'COST_WON',
+            amount: parseFloat(form.amount) || 1000,
+            currency: form.currency,
           })
 
           consecutiveErrors = 0
@@ -1837,6 +1862,18 @@ export function DecisionExplorerPage() {
     const triggered = deferredSimulationResults.filter(r => r.retryGateway !== undefined).length
     const recovered = deferredSimulationResults.filter(r => r.retryStatus === 'CHARGED').length
     return { triggered, recovered }
+  }, [deferredSimulationResults])
+
+  const totalCostSaved = useMemo(() => {
+    let value = 0
+    let currency = ''
+    for (const r of deferredSimulationResults) {
+      if (r.costWon && r.costSavedBps != null && r.costSavedBps > 0 && r.status === 'CHARGED') {
+        value += (r.costSavedBps / 10000) * r.amount
+        currency = r.currency
+      }
+    }
+    return { value, currency }
   }, [deferredSimulationResults])
 
   const debitNetworkRows = debitResult?.debit_routing_output?.co_badged_card_networks_info || []
@@ -2507,7 +2544,7 @@ export function DecisionExplorerPage() {
                     <label className="block text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-1">Algorithm</label>
                     <select
                       value={form.ranking_algorithm}
-                      onChange={e => set('ranking_algorithm', e.target.value as RoutingAlgorithmName)}
+                      onChange={e => set('ranking_algorithm', e.target.value as SimulationAlgorithm)}
                       className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm font-medium text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 cursor-pointer"
                     >
                       {ALGORITHMS.map(a => <option key={a} value={a}>{ALGORITHM_LABELS[a]}</option>)}
@@ -3241,6 +3278,14 @@ export function DecisionExplorerPage() {
                                 </UiTooltip>
                               </>
                             )}
+                            {totalCostSaved.value > 0 && totalCostSaved.currency && (
+                              <>
+                                <span className="text-slate-300 dark:text-slate-600">·</span>
+                                <span className="text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+                                  saved {formatCurrencyValue(totalCostSaved.value, totalCostSaved.currency)}
+                                </span>
+                              </>
+                            )}
                           </>
                         )}
                       </div>
@@ -3415,6 +3460,7 @@ export function DecisionExplorerPage() {
                               <th className="text-left px-3 py-2 whitespace-nowrap">Gateway</th>
                               <th className="text-left px-3 py-2">Routing</th>
                               <th className="text-left px-3 py-2">Outcome</th>
+                              <th className="text-right px-3 py-2 whitespace-nowrap">Cost Savings</th>
                               {smartRetryEnabled && <th className="text-left px-3 py-2 whitespace-nowrap">Retry Gateway</th>}
                               {smartRetryEnabled && <th className="text-left px-3 py-2">Retry Outcome</th>}
                               <th className="w-8" />
@@ -3443,7 +3489,11 @@ export function DecisionExplorerPage() {
                                     </span>
                                   ) : (
                                     <span className="text-[11px] text-slate-400">
-                                      {res.routingApproach === 'SR_SELECTION_V3_ROUTING' ? 'SR V3' : (res.routingApproach ?? '—')}
+                                      {res.routingApproach === 'SR_SELECTION_V3_ROUTING'
+                                        ? 'SR V3'
+                                        : res.routingApproach === 'SR_SELECTION_MULTI_OBJECTIVE'
+                                        ? 'Multi-Obj'
+                                        : (res.routingApproach ?? '—')}
                                     </span>
                                   )}
                                 </td>
@@ -3451,6 +3501,13 @@ export function DecisionExplorerPage() {
                                   <Badge variant={res.status === 'CHARGED' ? 'green' : res.status === 'PENDING_VBV' ? 'orange' : 'red'}>
                                     {res.status}
                                   </Badge>
+                                </td>
+                                <td className="px-3 py-2 text-right whitespace-nowrap">
+                                  {res.costWon && res.costSavedBps != null && res.costSavedBps > 0 && res.status === 'CHARGED' ? (
+                                    <span className="font-mono text-xs text-emerald-700 dark:text-emerald-400 tabular-nums">
+                                      {formatSavingsCurrency(res.costSavedBps, res.amount, res.currency)}
+                                    </span>
+                                  ) : null}
                                 </td>
                                 {smartRetryEnabled && (
                                   <td className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
@@ -3508,7 +3565,7 @@ export function DecisionExplorerPage() {
                       paymentMethod: form.payment_method,
                       authType: form.auth_type,
                       cardBrand: form.card_brand,
-                      rankingAlgorithm: form.ranking_algorithm,
+                      rankingAlgorithm: 'SR_BASED_ROUTING',
                       eligibleGateways: form.eligible_gateways,
                     }}
                   />
@@ -3582,6 +3639,10 @@ export function DecisionExplorerPage() {
                     )}
                   </CardBody>
                 </Card>
+
+                {result.multi_objective_info && (
+                  <MultiObjectiveDecisionPanel info={result.multi_objective_info} />
+                )}
 
                 {scoreData.length > 0 && (
                   <Card>
@@ -4220,6 +4281,111 @@ export function DecisionExplorerPage() {
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+function MultiObjectiveDecisionPanel({ info }: { info: MultiObjectiveInfo }) {
+  const isCostWin = info.outcome === 'COST_WON'
+  const tone = isCostWin
+    ? 'border-cyan-200 bg-cyan-50/60 dark:border-cyan-900 dark:bg-cyan-950/30'
+    : 'border-slate-200 bg-slate-50/60 dark:border-[#1c1c24] dark:bg-[#0b0b10]'
+  const pillTone = isCostWin
+    ? 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/40 dark:text-cyan-200'
+    : 'bg-slate-200 text-slate-700 dark:bg-[#1f1f29] dark:text-slate-200'
+  return (
+    <Card>
+      <CardBody>
+        <div className={`rounded-2xl border px-4 py-3 ${tone}`}>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                Multi-Objective Decision
+              </span>
+              <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${pillTone}`}>
+                {isCostWin ? 'Cost won' : 'Auth won'}
+              </span>
+            </div>
+            <div className="text-right">
+              <span className="text-[11px] uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                Tolerance band
+              </span>
+              <p className="font-mono text-sm font-semibold text-slate-800 dark:text-slate-100">
+                {info.tolerancePp.toFixed(2)} pp
+              </p>
+            </div>
+          </div>
+
+          <p className="mt-3 text-sm text-slate-700 dark:text-slate-200 leading-relaxed">
+            {info.reason}
+          </p>
+
+          {isCostWin && info.costSavedBps != null && (
+            <div className="mt-3 inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200">
+              <span>Cost saved</span>
+              <span className="font-mono">{info.costSavedBps.toFixed(2)} bps</span>
+            </div>
+          )}
+
+          {(info.srHead || info.chosen) && (
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {info.srHead && (
+                <MultiObjectivePspCard
+                  label={isCostWin ? 'SR head (would have picked)' : 'SR head (kept)'}
+                  summary={info.srHead}
+                />
+              )}
+              {info.chosen && (
+                <MultiObjectivePspCard
+                  label={isCostWin ? 'Chosen by cost' : 'Final pick'}
+                  summary={info.chosen}
+                  emphasis={isCostWin}
+                />
+              )}
+            </div>
+          )}
+
+          <p className="mt-3 text-[11px] text-slate-500 dark:text-slate-400">
+            {info.qualifiedCount} PSP{info.qualifiedCount === 1 ? '' : 's'} qualified under the band.
+          </p>
+        </div>
+      </CardBody>
+    </Card>
+  )
+}
+
+function MultiObjectivePspCard({
+  label,
+  summary,
+  emphasis = false,
+}: {
+  label: string
+  summary: { psp: string; authRate: number; costBps: number | null }
+  emphasis?: boolean
+}) {
+  const borderTone = emphasis
+    ? 'border-cyan-300 bg-white dark:border-cyan-700 dark:bg-[#0d141a]'
+    : 'border-slate-200 bg-white dark:border-[#1c1c24] dark:bg-[#0d0d13]'
+  return (
+    <div className={`rounded-xl border px-3 py-2 ${borderTone}`}>
+      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+        {label}
+      </p>
+      <p className="mt-1 font-mono text-sm font-semibold text-slate-900 dark:text-white">
+        {summary.psp}
+      </p>
+      <div className="mt-1.5 flex gap-3 text-xs text-slate-600 dark:text-slate-300">
+        <span>
+          <span className="text-slate-400">auth</span>{' '}
+          <span className="font-mono">{(summary.authRate * 100).toFixed(2)}%</span>
+        </span>
+        <span>
+          <span className="text-slate-400">cost</span>{' '}
+          <span className="font-mono">
+            {summary.costBps != null ? `${summary.costBps.toFixed(2)} bps` : '—'}
+          </span>
+        </span>
+      </div>
     </div>
   )
 }

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -123,6 +123,7 @@ function formatCurrencyValue(value: number, currency: string): string {
     return new Intl.NumberFormat(undefined, {
       style: 'currency',
       currency,
+      currencyDisplay: 'narrowSymbol',
       maximumFractionDigits: 2,
     }).format(value)
   } catch {

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -47,10 +47,30 @@ interface FormState {
   payment_method_type: string
   payment_method: string
   card_brand: string
+  card_program: string
   auth_type: string
   eligible_gateways: string
   ranking_algorithm: SimulationAlgorithm
 }
+
+const MULTI_OBJECTIVE_PAYMENT_METHODS = ['CREDIT', 'DEBIT'] as const
+const CARD_PROGRAM_OPTIONS = ['STANDARD', 'PREMIUM'] as const
+const MULTI_OBJECTIVE_CARD_BRANDS = ['VISA', 'MASTERCARD'] as const
+
+const MULTI_OBJECTIVE_CLUSTER_VARIANTS: Array<{
+  paymentMethod: 'CREDIT' | 'DEBIT'
+  cardSwitchProvider: 'VISA' | 'MASTERCARD'
+  cardProgram: 'STANDARD' | 'PREMIUM'
+}> = [
+  { paymentMethod: 'CREDIT', cardSwitchProvider: 'VISA',       cardProgram: 'STANDARD' },
+  { paymentMethod: 'CREDIT', cardSwitchProvider: 'VISA',       cardProgram: 'PREMIUM'  },
+  { paymentMethod: 'CREDIT', cardSwitchProvider: 'MASTERCARD', cardProgram: 'STANDARD' },
+  { paymentMethod: 'CREDIT', cardSwitchProvider: 'MASTERCARD', cardProgram: 'PREMIUM'  },
+  { paymentMethod: 'DEBIT',  cardSwitchProvider: 'VISA',       cardProgram: 'STANDARD' },
+  { paymentMethod: 'DEBIT',  cardSwitchProvider: 'VISA',       cardProgram: 'PREMIUM'  },
+  { paymentMethod: 'DEBIT',  cardSwitchProvider: 'MASTERCARD', cardProgram: 'STANDARD' },
+  { paymentMethod: 'DEBIT',  cardSwitchProvider: 'MASTERCARD', cardProgram: 'PREMIUM'  },
+]
 
 interface DebitRoutingFormState {
   amount: string
@@ -172,6 +192,7 @@ const DEFAULT_FORM: FormState = {
   payment_method_type: '',
   payment_method: '',
   card_brand: '',
+  card_program: 'STANDARD',
   auth_type: '',
   eligible_gateways: 'stripe, adyen',
   ranking_algorithm: 'SR_BASED_ROUTING',
@@ -975,6 +996,34 @@ export function DecisionExplorerPage() {
     cardBrandOptions,
   ])
 
+  // SR_MULTI_OBJECTIVE constrains the form to a card-only cluster shape:
+  // Method Type = CARD, Payment Method ∈ {CREDIT, DEBIT}, and Card Brand
+  // defaults to Visa/Mastercard when the prior selection isn't one of them.
+  useEffect(() => {
+    if (form.ranking_algorithm !== 'SR_MULTI_OBJECTIVE') return
+    setForm(prev => {
+      if (prev.ranking_algorithm !== 'SR_MULTI_OBJECTIVE') return prev
+      const next = { ...prev }
+      let changed = false
+      const cardType = paymentMethodTypeOptions.find(p => p === 'CARD') || 'CARD'
+      if (next.payment_method_type !== cardType) { next.payment_method_type = cardType; changed = true }
+      if (!MULTI_OBJECTIVE_PAYMENT_METHODS.includes(next.payment_method as 'CREDIT' | 'DEBIT')) {
+        next.payment_method = 'CREDIT'
+        changed = true
+      }
+      if (!MULTI_OBJECTIVE_CARD_BRANDS.includes(next.card_brand as 'VISA' | 'MASTERCARD')) {
+        const fallback = cardBrandOptions.find(b => b === 'VISA') || cardBrandOptions.find(b => b === 'MASTERCARD') || cardBrandOptions[0] || 'VISA'
+        next.card_brand = fallback
+        changed = true
+      }
+      if (!CARD_PROGRAM_OPTIONS.includes(next.card_program as 'STANDARD' | 'PREMIUM')) {
+        next.card_program = 'STANDARD'
+        changed = true
+      }
+      return changed ? next : prev
+    })
+  }, [form.ranking_algorithm, paymentMethodTypeOptions, cardBrandOptions])
+
   useEffect(() => {
     if (!selectedAuditPaymentId && !selectedPreviewPaymentId && !setupPrompt) return
 
@@ -1391,6 +1440,9 @@ export function DecisionExplorerPage() {
           paymentMethod: form.payment_method,
           authType: form.auth_type,
           cardBrand: form.card_brand,
+          cardSwitchProvider: form.card_brand,
+          cardType: form.payment_method,
+          ...(form.ranking_algorithm === 'SR_MULTI_OBJECTIVE' && { cardProgram: form.card_program }),
         },
         eligibleGatewayList: gateways,
         rankingAlgorithm: 'SR_BASED_ROUTING',
@@ -1516,27 +1568,45 @@ export function DecisionExplorerPage() {
     let consecutiveErrors = 0
     let lastUIUpdate = 0
 
+    const isMultiObjective = form.ranking_algorithm === 'SR_MULTI_OBJECTIVE'
+
     try {
       for (let i = 0; i < total; i++) {
         if (simulationAbortRef.current) break
         const paymentId = `sim_${Date.now()}_${i}`
+
+        // Under SR_MULTI_OBJECTIVE, vary the cluster and amount per payment so
+        // the (mock) Hypersense cost lookup returns distinct costs and the
+        // multi-objective leg has meaningful choices to make. Form values still
+        // seed everything else (currency, eligible_gateways, etc).
+        const variant = isMultiObjective ? MULTI_OBJECTIVE_CLUSTER_VARIANTS[i % MULTI_OBJECTIVE_CLUSTER_VARIANTS.length] : null
+        const paymentMethodType = isMultiObjective ? 'CARD' : form.payment_method_type
+        const paymentMethod = variant ? variant.paymentMethod : form.payment_method
+        const cardBrand = variant ? variant.cardSwitchProvider : form.card_brand
+        const cardProgram = variant ? variant.cardProgram : form.card_program
+        const amount = isMultiObjective
+          ? Math.floor(10 + Math.random() * 991)
+          : (parseFloat(form.amount) || 1000)
 
         try {
           const decideRes = await apiPost<DecideGatewayResponse>('/decide-gateway', {
             merchantId: effectiveMerchantId,
             paymentInfo: {
               paymentId: paymentId,
-              amount: parseFloat(form.amount) || 1000,
+              amount,
               currency: form.currency,
               paymentType: 'ORDER_PAYMENT',
-              paymentMethodType: form.payment_method_type,
-              paymentMethod: form.payment_method,
+              paymentMethodType,
+              paymentMethod,
               authType: form.auth_type,
-              cardBrand: form.card_brand,
+              cardBrand,
+              cardSwitchProvider: cardBrand,
+              cardType: paymentMethod,
+              cardProgram,
             },
             eligibleGatewayList: gateways,
             rankingAlgorithm: 'SR_BASED_ROUTING',
-            enableMultiObjective: form.ranking_algorithm === 'SR_MULTI_OBJECTIVE',
+            enableMultiObjective: isMultiObjective,
             eliminationEnabled: eliminationEnabled,
           })
 
@@ -1595,7 +1665,7 @@ export function DecisionExplorerPage() {
             retryStatus,
             costSavedBps: mo?.costSavedBps ?? null,
             costWon: mo?.outcome === 'COST_WON',
-            amount: parseFloat(form.amount) || 1000,
+            amount,
             currency: form.currency,
           })
 
@@ -2525,21 +2595,36 @@ export function DecisionExplorerPage() {
             ) : (
               <>
                 <div className="space-y-2">
-                  <div className="grid grid-cols-3 gap-x-3 gap-y-2.5">
-                    {([
+                  {(() => {
+                    const isMultiObjective = form.ranking_algorithm === 'SR_MULTI_OBJECTIVE'
+                    const methodTypeOptionsForRender = isMultiObjective
+                      ? (paymentMethodTypeOptions.includes('CARD') ? ['CARD'] : ['CARD', ...paymentMethodTypeOptions])
+                      : paymentMethodTypeOptions
+                    const paymentMethodOptionsForRender = isMultiObjective
+                      ? [...MULTI_OBJECTIVE_PAYMENT_METHODS]
+                      : paymentMethodOptions
+                    const fields: { label: string; content: React.ReactNode }[] = [
                       { label: 'Amount', content: <input value={form.amount} onChange={e => set('amount', e.target.value)} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" /> },
                       { label: 'Currency', content: <select value={form.currency} onChange={e => set('currency', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{currencyOptions.map(c => <option key={c} value={c}>{c}</option>)}</select> },
-                      { label: 'Method Type', content: <select value={form.payment_method_type} onChange={e => set('payment_method_type', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{paymentMethodTypeOptions.map(p => <option key={p} value={p}>{formatOptionLabel(p)}</option>)}</select> },
-                      { label: 'Payment Method', content: <select value={form.payment_method} onChange={e => set('payment_method', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{paymentMethodOptions.map(p => <option key={p} value={p}>{formatOptionLabel(p)}</option>)}</select> },
+                      { label: 'Method Type', content: <select value={form.payment_method_type} onChange={e => set('payment_method_type', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading || isMultiObjective} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{methodTypeOptionsForRender.map(p => <option key={p} value={p}>{formatOptionLabel(p)}</option>)}</select> },
+                      { label: 'Payment Method', content: <select value={form.payment_method} onChange={e => set('payment_method', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{paymentMethodOptionsForRender.map(p => <option key={p} value={p}>{formatOptionLabel(p)}</option>)}</select> },
                       { label: 'Card Brand', content: <select value={form.card_brand} onChange={e => set('card_brand', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{cardBrandOptions.map(b => <option key={b} value={b}>{formatOptionLabel(b)}</option>)}</select> },
                       { label: 'Auth Type', content: <select value={form.auth_type} onChange={e => set('auth_type', e.target.value)} disabled={routingConfigUnavailable || routingKeysLoading} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50">{authTypeOptions.map(a => <option key={a} value={a}>{formatOptionLabel(a)}</option>)}</select> },
-                    ] as { label: string; content: React.ReactNode }[]).map(({ label, content }) => (
-                      <div key={label}>
-                        <label className="block text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-1">{label}</label>
-                        {content}
+                    ]
+                    if (isMultiObjective) {
+                      fields.push({ label: 'Card Type', content: <select value={form.card_program} onChange={e => set('card_program', e.target.value)} className="w-full bg-slate-50 dark:bg-[#0d0d13] border border-slate-200 dark:border-[#222226] rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500">{CARD_PROGRAM_OPTIONS.map(c => <option key={c} value={c}>{formatOptionLabel(c)}</option>)}</select> })
+                    }
+                    return (
+                      <div className="grid grid-cols-3 gap-x-3 gap-y-2.5">
+                        {fields.map(({ label, content }) => (
+                          <div key={label}>
+                            <label className="block text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-1">{label}</label>
+                            {content}
+                          </div>
+                        ))}
                       </div>
-                    ))}
-                  </div>
+                    )
+                  })()}
                   <div>
                     <label className="block text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-1">Algorithm</label>
                     <select

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -4,7 +4,7 @@ import { ErrorInfoFields, ErrorInfoState, GsmOptionRow, DEFAULT_ERROR_INFO } fro
 import { PenaltyClassificationGuide } from './PenaltyClassificationGuide'
 import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
-import { BarChart, Bar, LineChart, Line, ComposedChart, Area, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, ReferenceLine, ReferenceArea } from 'recharts'
+import { BarChart, Bar, LineChart, Line, ComposedChart, Area, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import { Button } from '../ui/Button'
 import { Badge } from '../ui/Badge'
 import { Card, CardBody, CardHeader, SurfaceLabel } from '../ui/Card'
@@ -21,7 +21,7 @@ import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
 import { describeRoutingEvent, useRoutingEvents } from '../../hooks/useRoutingEvents'
 import { FEATURE_FLAGS } from '../../lib/featureFlags'
-import { Play, RefreshCw, ChevronDown, ChevronUp, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings, ArrowRightLeft, Target, TrendingDown, Flag } from 'lucide-react'
+import { Play, Pause, RefreshCw, ChevronDown, ChevronUp, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings, ArrowRightLeft, Target, TrendingDown, Flag } from 'lucide-react'
 
 // UI-local algorithm tokens for the simulation dropdown. Maps to the backend
 // /decide-gateway request as follows:
@@ -845,6 +845,13 @@ export function DecisionSimulatorPage() {
   const [volumeProgress, setVolumeProgress] = useState(initialState.volumeProgress)
   const [simulationResults, setSimulationResults] = useState<SimulationResult[]>(initialState.simulationResults)
   const [isSimulating, setIsSimulating] = useState(false)
+  // Pause/resume: the run loop stays alive and idles on this ref instead of being
+  // aborted, so position, outcome accumulators, the feed, and backend scores are
+  // all preserved across a pause.
+  const [isPaused, setIsPaused] = useState(false)
+  const simulationPausedRef = useRef(false)
+  // Per-column filters for the Transaction Log table.
+  const [txFilters, setTxFilters] = useState<Record<string, string>>({})
   const [smartRetryEnabled, setSmartRetryEnabled] = useState(initialState.smartRetryEnabled)
   const [error, setError] = useState<string | null>(null)
   const txLogRef = useRef<HTMLDivElement>(null)
@@ -869,7 +876,7 @@ export function DecisionSimulatorPage() {
   // Live routing-event stream (leader flips, auth-band crossings), filtered to the run.
   // Poll tightly while a run is producing events so the Autopilot feed keeps up;
   // relax back to the idle cadence once it finishes.
-  const routingEvents = useRoutingEvents('1h', isSimulating ? 1_000 : 15_000)
+  const routingEvents = useRoutingEvents('1h', isSimulating && !isPaused ? 500 : 15_000)
   const sessionRoutingEvents = useMemo(() => {
     if (simulationStartedAtMs == null) return []
     const sinceMs = simulationStartedAtMs - EVENTS_RUN_START_MARGIN_MS
@@ -1620,6 +1627,8 @@ export function DecisionSimulatorPage() {
     if (total <= 0) return setError('Total Payments must be greater than 0')
 
     setIsSimulating(true)
+    setIsPaused(false)
+    simulationPausedRef.current = false
     setSimulationStartedAtMs(Date.now())
     setError(null)
     setSetupPrompt(null)
@@ -1636,15 +1645,40 @@ export function DecisionSimulatorPage() {
     // the storm (the SWR poll runs at 1s too).
     let lastEventsRefresh = 0
 
+    // Deterministic outcome scheduler (error diffusion). i.i.d. coin flips
+    // (Math.random() < rate) have ~±5pp swing over the backend's 125-txn window,
+    // which can briefly push a laggard's score above the leader and steal traffic.
+    // Error diffusion instead spaces successes/failures evenly so the *realized*
+    // rate tracks the slider within ~1/window (≈ ±1pp) — so adyen@90 stays ~90 and
+    // never overtakes stripe@96 — without touching backend scoring. Random initial
+    // phase per gateway so failures aren't visibly periodic.
+    const outcomeAccumulator: Record<string, number> = {}
+    const drawSuccess = (gw: string): boolean => {
+      const p = Math.max(0, Math.min(1, getGwSuccessRate(gw) / 100))
+      if (outcomeAccumulator[gw] === undefined) outcomeAccumulator[gw] = Math.random()
+      outcomeAccumulator[gw] += p
+      if (outcomeAccumulator[gw] >= 1) {
+        outcomeAccumulator[gw] -= 1
+        return true
+      }
+      return false
+    }
+
     const isMultiObjective = form.ranking_algorithm === 'SR_MULTI_OBJECTIVE'
 
     try {
       for (let i = 0; i < total; i++) {
         if (simulationAbortRef.current) break
+        // Idle here while paused (loop stays alive, state preserved); a Stop still
+        // breaks out. The in-flight transaction always completes before we pause.
+        while (simulationPausedRef.current && !simulationAbortRef.current) {
+          await new Promise(resolve => setTimeout(resolve, 120))
+        }
+        if (simulationAbortRef.current) break
         const paymentId = `sim_${Date.now()}_${i}`
 
         // Under SR_MULTI_OBJECTIVE, vary the cluster and amount per payment so
-        // the (mock) Hypersense cost lookup returns distinct costs and the
+        // the (mock) cost lookup returns distinct costs and the
         // multi-objective leg has meaningful choices to make. Form values still
         // seed everything else (currency, eligible_gateways, etc).
         const variant = isMultiObjective ? MULTI_OBJECTIVE_CLUSTER_VARIANTS[i % MULTI_OBJECTIVE_CLUSTER_VARIANTS.length] : null
@@ -1679,8 +1713,7 @@ export function DecisionSimulatorPage() {
           })
 
           const decidedGateway = decideRes.decided_gateway
-          const gwRate = getGwSuccessRate(decidedGateway)
-          const isSuccess = Math.random() * 100 < gwRate
+          const isSuccess = drawSuccess(decidedGateway)
           const failureMode = getGwFailureMode(decidedGateway)
           const outcome: TransactionOutcome = isSuccess ? 'CHARGED' : (failureMode === 'timeout' ? 'PENDING_VBV' : 'FAILURE')
 
@@ -1705,8 +1738,7 @@ export function DecisionSimulatorPage() {
             decideRes.fallback_gateways.length > 0
           ) {
             retryGateway = decideRes.fallback_gateways[0]
-            const retryGwRate = getGwSuccessRate(retryGateway)
-            const retrySuccess = Math.random() * 100 < retryGwRate
+            const retrySuccess = drawSuccess(retryGateway)
             const retryFailureMode = getGwFailureMode(retryGateway)
             retryStatus = retrySuccess ? 'CHARGED' : (retryFailureMode === 'timeout' ? 'PENDING_VBV' : 'FAILURE')
             await apiPost('/update-gateway-score', {
@@ -1747,9 +1779,11 @@ export function DecisionSimulatorPage() {
             markExplorerRunDataUpdated()
             lastUIUpdate = now
           }
-          // Pull fresh Autopilot events at most ~once/sec (throttled apart from the
-          // UI tick) so the feed stays current without a fetch storm.
-          if (now - lastEventsRefresh > 1000 || i === total - 1) {
+          // Pull fresh Autopilot events ~4x/sec so new actions surface promptly and
+          // in small batches (one big once-a-second flush buried the highlight on a
+          // fast loop). The append-only accumulator makes frequent refreshes safe;
+          // they're naturally floored by the Kafka→ClickHouse flush cadence.
+          if (now - lastEventsRefresh > 250 || i === total - 1) {
             routingEvents.refresh()
             lastEventsRefresh = now
           }
@@ -1766,9 +1800,21 @@ export function DecisionSimulatorPage() {
     } finally {
       setSimulationResults([...results])
       setIsSimulating(false)
+      setIsPaused(false)
+      simulationPausedRef.current = false
       // Final flush: events from the last txns can land just after the loop ends.
       routingEvents.refresh()
     }
+  }
+
+  function pauseSimulation() {
+    simulationPausedRef.current = true
+    setIsPaused(true)
+  }
+
+  function resumeSimulation() {
+    simulationPausedRef.current = false
+    setIsPaused(false)
   }
 
   async function runRuleEvaluation() {
@@ -2067,6 +2113,70 @@ export function DecisionSimulatorPage() {
     }
     return { data, gateways, windowSize: ROLLING_WINDOW }
   }, [deferredSimulationResults, gatewayStats, chartWindow])
+
+  // Human-readable routing label, shared by the Transaction Log cell and its filter.
+  const routingApproachLabel = (approach?: string | null): string =>
+    approach?.includes('HEDGING')
+      ? 'Hedging'
+      : approach === 'SR_SELECTION_MULTI_OBJECTIVE'
+        ? 'Cost Based'
+        : approach === 'SR_SELECTION_V3_ROUTING'
+          ? 'Auth Based'
+          : approach ?? '—'
+
+  // Distinct values that populate the categorical Transaction Log column filters.
+  const txFilterOptions = useMemo(() => {
+    const gateways = new Set<string>()
+    const routings = new Set<string>()
+    const outcomes = new Set<string>()
+    const retryGateways = new Set<string>()
+    const retryOutcomes = new Set<string>()
+    for (const res of deferredSimulationResults) {
+      gateways.add(res.decidedGateway)
+      routings.add(routingApproachLabel(res.routingApproach))
+      if (res.status) outcomes.add(res.status)
+      if (res.retryGateway) retryGateways.add(res.retryGateway)
+      if (res.retryStatus) retryOutcomes.add(res.retryStatus)
+    }
+    const sorted = (s: Set<string>) => Array.from(s).sort()
+    return {
+      gateways: sorted(gateways),
+      routings: sorted(routings),
+      outcomes: sorted(outcomes),
+      retryGateways: sorted(retryGateways),
+      retryOutcomes: sorted(retryOutcomes),
+    }
+  }, [deferredSimulationResults])
+
+  // Transaction Log rows after applying the column filters, keeping each row's
+  // original index so the "#" column stays stable regardless of filtering.
+  const txFilteredRows = useMemo(() => {
+    const f = txFilters
+    const active = Object.values(f).some(Boolean)
+    const rows = deferredSimulationResults.map((res, idx) => ({ res, idx }))
+    if (!active) return rows
+    const srText = (res: SimulationResult) => {
+      const s = res.gatewayPriorityMap?.[res.decidedGateway]
+      return typeof s === 'number' ? (s * 100).toFixed(1) : ''
+    }
+    return rows.filter(({ res }) => {
+      if (f.gateway && res.decidedGateway !== f.gateway) return false
+      if (f.routing && routingApproachLabel(res.routingApproach) !== f.routing) return false
+      if (f.outcome && res.status !== f.outcome) return false
+      if (f.retryGateway && (res.retryGateway ?? '') !== f.retryGateway) return false
+      if (f.retryOutcome && (res.retryStatus ?? '') !== f.retryOutcome) return false
+      if (f.amount && !formatCurrencyValue(res.amount, res.currency).toLowerCase().includes(f.amount.toLowerCase())) return false
+      if (f.sr && !srText(res).includes(f.sr)) return false
+      if (f.cost) {
+        const hasSavings = !!res.costWon && res.costSavedBps != null && res.costSavedBps > 0 && res.status === 'CHARGED'
+        if (f.cost === 'yes' && !hasSavings) return false
+        if (f.cost === 'no' && hasSavings) return false
+      }
+      return true
+    })
+  }, [deferredSimulationResults, txFilters])
+
+  const txFiltersActive = Object.values(txFilters).some(Boolean)
 
   const hedgingHits = useMemo(
     () => deferredSimulationResults.filter(r => r.routingApproach?.includes('HEDGING')).length,
@@ -2380,14 +2490,31 @@ export function DecisionSimulatorPage() {
               )
             })}
 
-            <Button
-              onClick={isSimulating ? () => { simulationAbortRef.current = true } : runSimulation}
-              disabled={!effectiveMerchantId || routingConfigUnavailable}
-              variant={isSimulating ? 'secondary' : 'primary'}
-              className="self-end lg:ml-auto"
-            >
-              {isSimulating ? <><X size={14} /> Stop</> : <><Play size={14} className="fill-current" /> Run simulation</>}
-            </Button>
+            {!isSimulating ? (
+              <Button
+                onClick={runSimulation}
+                disabled={!effectiveMerchantId || routingConfigUnavailable}
+                variant="primary"
+                className="self-end lg:ml-auto"
+              >
+                <Play size={14} className="fill-current" /> Run simulation
+              </Button>
+            ) : (
+              <div className="flex items-center gap-2 self-end lg:ml-auto">
+                {isPaused ? (
+                  <Button onClick={resumeSimulation} variant="primary">
+                    <Play size={14} className="fill-current" /> Resume
+                  </Button>
+                ) : (
+                  <Button onClick={pauseSimulation} variant="secondary">
+                    <Pause size={14} /> Pause
+                  </Button>
+                )}
+                <Button onClick={() => { simulationAbortRef.current = true }} variant="secondary">
+                  <X size={14} /> Stop
+                </Button>
+              </div>
+            )}
           </div>
 
           <div className="flex flex-1 flex-wrap items-end justify-around gap-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 dark:border-[#222226] dark:bg-[#0b0b10]">
@@ -2472,6 +2599,12 @@ export function DecisionSimulatorPage() {
                             })
                             const dataMin = yValues.length ? Math.min(...yValues) : 0
                             const yMin = Math.max(0, Math.floor((dataMin - 5) / 5) * 5)
+                            // Plot a little above 100 so a line sitting at 100% isn't
+                            // clipped flat against the top edge; keep ticks capped at 100.
+                            const yMax = 103
+                            const yStep = 100 - yMin > 40 ? 10 : 5
+                            const yTicks: number[] = []
+                            for (let t = yMin; t <= 100; t += yStep) yTicks.push(t)
                             const bandLabel = `SR threshold for cost override`
                             return (
                               <div className="w-full flex-1 min-h-[320px] flex flex-col">
@@ -2517,7 +2650,8 @@ export function DecisionSimulatorPage() {
                                       minTickGap={28}
                                     />
                                     <YAxis
-                                      domain={[yMin, 100]}
+                                      domain={[yMin, yMax]}
+                                      ticks={yTicks}
                                       allowDataOverflow
                                       tick={{ fontSize: 11, fill: '#94a3b8' }}
                                       tickLine={false}
@@ -3944,7 +4078,26 @@ export function DecisionSimulatorPage() {
           <CardHeader className="flex flex-row items-center justify-between gap-3">
             <h3 className="text-sm font-medium text-slate-800 dark:text-white">Transaction Log</h3>
             {deferredSimulationResults.length > 0 && (
-              <span className="text-xs text-slate-400 tabular-nums">{deferredSimulationResults.length} transactions</span>
+              <span className="flex items-center gap-2 text-xs text-slate-400 tabular-nums">
+                {txFiltersActive && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setTxFilters({})}
+                      className="rounded px-1.5 py-0.5 text-[11px] font-medium text-brand-600 hover:bg-brand-50 dark:text-brand-400 dark:hover:bg-brand-900/20"
+                    >
+                      Clear filters
+                    </button>
+                    <span className="text-slate-300 dark:text-slate-600">·</span>
+                  </>
+                )}
+                <span>
+                  {txFiltersActive
+                    ? `${txFilteredRows.length} / ${deferredSimulationResults.length}`
+                    : deferredSimulationResults.length}{' '}
+                  transactions
+                </span>
+              </span>
             )}
           </CardHeader>
           <CardBody className="p-0">
@@ -3963,9 +4116,42 @@ export function DecisionSimulatorPage() {
                       {smartRetryEnabled && <th className="text-left px-3 py-2 whitespace-nowrap">Retry Gateway</th>}
                       {smartRetryEnabled && <th className="text-left px-3 py-2">Retry Outcome</th>}
                     </tr>
+                    {(() => {
+                      const inputCls = 'w-full rounded border border-slate-200 bg-white px-1.5 py-1 text-[11px] font-normal text-slate-700 placeholder:text-slate-300 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0d0d13] dark:text-slate-200 dark:placeholder:text-slate-600'
+                      const setF = (key: string, value: string) => setTxFilters(prev => ({ ...prev, [key]: value }))
+                      const sel = (key: string, opts: string[], placeholder: string) => (
+                        <select value={txFilters[key] ?? ''} onChange={e => setF(key, e.target.value)} className={inputCls}>
+                          <option value="">{placeholder}</option>
+                          {opts.map(o => <option key={o} value={o}>{o}</option>)}
+                        </select>
+                      )
+                      return (
+                        <tr className="bg-white dark:bg-[#0a0a0f] border-b border-slate-100 dark:border-[#1c1c24]">
+                          <th className="px-2 py-1.5" />
+                          <th className="px-2 py-1.5">
+                            <input value={txFilters.amount ?? ''} onChange={e => setF('amount', e.target.value)} placeholder="search" className={inputCls} />
+                          </th>
+                          <th className="px-2 py-1.5">{sel('gateway', txFilterOptions.gateways, 'All')}</th>
+                          <th className="px-2 py-1.5">
+                            <input value={txFilters.sr ?? ''} onChange={e => setF('sr', e.target.value)} placeholder="e.g. 90" className={inputCls} />
+                          </th>
+                          <th className="px-2 py-1.5">{sel('routing', txFilterOptions.routings, 'All')}</th>
+                          <th className="px-2 py-1.5">{sel('outcome', txFilterOptions.outcomes, 'All')}</th>
+                          <th className="px-2 py-1.5">
+                            <select value={txFilters.cost ?? ''} onChange={e => setF('cost', e.target.value)} className={inputCls}>
+                              <option value="">All</option>
+                              <option value="yes">Has savings</option>
+                              <option value="no">None</option>
+                            </select>
+                          </th>
+                          {smartRetryEnabled && <th className="px-2 py-1.5">{sel('retryGateway', txFilterOptions.retryGateways, 'All')}</th>}
+                          {smartRetryEnabled && <th className="px-2 py-1.5">{sel('retryOutcome', txFilterOptions.retryOutcomes, 'All')}</th>}
+                        </tr>
+                      )
+                    })()}
                   </thead>
                   <tbody className="divide-y divide-slate-100 dark:divide-[#1a1a22]">
-                    {deferredSimulationResults.map((res, idx) => (
+                    {txFilteredRows.map(({ res, idx }) => (
                       <tr
                         key={res.paymentId}
                         className="group cursor-pointer hover:bg-slate-50 dark:hover:bg-[#0d0d14] transition-colors"
@@ -4027,6 +4213,13 @@ export function DecisionSimulatorPage() {
                         )}
                       </tr>
                     ))}
+                    {txFilteredRows.length === 0 && (
+                      <tr>
+                        <td colSpan={smartRetryEnabled ? 9 : 7} className="px-3 py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+                          No transactions match the current filters.
+                        </td>
+                      </tr>
+                    )}
                   </tbody>
                 </table>
               </div>

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -1,0 +1,4200 @@
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { RuleEvaluationPanel } from './RuleEvaluationPanel'
+import { ErrorInfoFields, ErrorInfoState, GsmOptionRow, DEFAULT_ERROR_INFO } from './ErrorInfoFields'
+import { PenaltyClassificationGuide } from './PenaltyClassificationGuide'
+import { useNavigate } from 'react-router-dom'
+import useSWR from 'swr'
+import { BarChart, Bar, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, ReferenceLine, ReferenceArea } from 'recharts'
+import { Tooltip as UiTooltip } from '../ui/Tooltip'
+import { Button } from '../ui/Button'
+import { Badge } from '../ui/Badge'
+import { Card, CardBody, CardHeader, SurfaceLabel } from '../ui/Card'
+import { ErrorMessage } from '../ui/ErrorMessage'
+import { Spinner } from '../ui/Spinner'
+import { useMerchantStore } from '../../store/merchantStore'
+import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
+import { useAuthStore } from '../../store/authStore'
+import { apiPost, fetcher } from '../../lib/api'
+import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
+import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, UpdateScoreResponse } from '../../types/api'
+import { ROUTING_APPROACH_COLORS } from '../../lib/constants'
+import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
+import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
+import { FEATURE_FLAGS } from '../../lib/featureFlags'
+import { Play, RefreshCw, ChevronDown, ChevronUp, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings } from 'lucide-react'
+
+// UI-local algorithm tokens for the simulation dropdown. Maps to the backend
+// /decide-gateway request as follows:
+//   'SR_BASED_ROUTING'   → { rankingAlgorithm: 'SR_BASED_ROUTING' }
+//   'SR_MULTI_OBJECTIVE' → { rankingAlgorithm: 'SR_BASED_ROUTING', enableMultiObjective: true }
+type SimulationAlgorithm = 'SR_BASED_ROUTING' | 'SR_MULTI_OBJECTIVE'
+
+type TabType = 'single' | 'batch' | 'rule' | 'volume' | 'debit'
+
+interface FormState {
+  amount: string
+  currency: string
+  payment_method_type: string
+  payment_method: string
+  card_brand: string
+  card_program: string
+  auth_type: string
+  eligible_gateways: string
+  ranking_algorithm: SimulationAlgorithm
+}
+
+const MULTI_OBJECTIVE_CURRENCY = 'USD'
+const MULTI_OBJECTIVE_PAYMENT_METHODS = ['CREDIT'] as const
+const CARD_PROGRAM_OPTIONS = ['STANDARD', 'PREMIUM'] as const
+const MULTI_OBJECTIVE_CARD_BRANDS = ['VISA', 'MASTERCARD'] as const
+
+const MULTI_OBJECTIVE_CLUSTER_VARIANTS: Array<{
+  paymentMethod: 'CREDIT'
+  cardSwitchProvider: 'VISA' | 'MASTERCARD'
+  cardProgram: 'STANDARD' | 'PREMIUM'
+}> = [
+  { paymentMethod: 'CREDIT', cardSwitchProvider: 'VISA',       cardProgram: 'STANDARD' },
+  { paymentMethod: 'CREDIT', cardSwitchProvider: 'VISA',       cardProgram: 'PREMIUM'  },
+  { paymentMethod: 'CREDIT', cardSwitchProvider: 'MASTERCARD', cardProgram: 'STANDARD' },
+  { paymentMethod: 'CREDIT', cardSwitchProvider: 'MASTERCARD', cardProgram: 'PREMIUM'  },
+]
+
+interface DebitRoutingFormState {
+  amount: string
+  currency: string
+  auth_type: string
+  eligible_gateways: string
+  merchant_category_code: string
+  acquirer_country: string
+  co_badged_networks: string
+  issuer_country: string
+  is_regulated: boolean
+  regulated_name: string
+  card_type: 'debit' | 'credit'
+}
+
+interface SimulationConfig {
+  totalPayments: string
+}
+
+interface GatewaySimConfig {
+  successRate: number
+  failureMode: 'decline' | 'timeout'
+  gsmDecision: 'retry' | 'do_default'
+  penalized: boolean
+  errorInfo: ErrorInfoState
+}
+
+const DEFAULT_GW_SIM_CONFIG: GatewaySimConfig = {
+  successRate: 70,
+  failureMode: 'decline',
+  gsmDecision: 'retry',
+  penalized: true,
+  errorInfo: { ...DEFAULT_ERROR_INFO },
+}
+
+interface SimulationResult {
+  paymentId: string
+  decidedGateway: string
+  status: 'CHARGED' | 'FAILURE' | 'PENDING_VBV'
+  timestamp: string
+  routingApproach: string | null
+  gatewayPriorityMap: Record<string, number> | null
+  retryGateway?: string
+  retryStatus?: 'CHARGED' | 'FAILURE' | 'PENDING_VBV'
+  costSavedBps?: number | null
+  costWon?: boolean
+  tolerancePp?: number | null
+  amount: number
+  currency: string
+}
+
+function formatCurrencyValue(value: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(value)
+  } catch {
+    return `${value.toFixed(2)} ${currency}`
+  }
+}
+
+function formatSavingsCurrency(bps: number, amount: number, currency: string): string {
+  return formatCurrencyValue((bps / 10000) * amount, currency)
+}
+
+type TransactionOutcome = 'CHARGED' | 'FAILURE' | 'PENDING_VBV'
+
+type AuditInspectorTab = 'summary' | 'input' | 'response' | 'raw'
+
+interface SetupPromptState {
+  title: string
+  body: string
+  detail?: string
+  configurePath?: string
+}
+
+interface RuleEvaluateParams {
+  key: string
+  type: 'enum_variant' | 'str_value' | 'number' | 'metadata_variant'
+  value: string
+  metadataKey?: string
+}
+
+interface RuleEvaluateResponse {
+  payment_id: string | null
+  status: string
+  output: {
+    type: 'single' | 'priority' | 'volume_split'
+    connector?: GatewayConnector
+    connectors?: GatewayConnector[]
+    splits?: { connector: GatewayConnector; split: number }[]
+  }
+  evaluated_output?: GatewayConnector[]
+  eligible_connectors?: GatewayConnector[]
+}
+
+function approachColor(approach: string): string {
+  for (const [k, v] of Object.entries(ROUTING_APPROACH_COLORS)) {
+    if (approach.includes(k) || k.includes(approach)) return v
+  }
+  return 'bg-white/5 text-slate-600 ring-1 ring-inset ring-white/8'
+}
+
+const COLORS = ['#0069ED', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16']
+const GW_PALETTE = ['#3b82f6', '#8b5cf6', '#f97316', '#ec4899', '#14b8a6']
+
+type VolumePaymentEntry = {
+  paymentId: string
+  connector: string
+}
+
+const EXPLORER_STORAGE_KEY_PREFIX = 'decision-explorer-state-v2'
+const EXPLORER_RESULT_TTL_MS = 10 * 60 * 1000
+
+const DEFAULT_FORM: FormState = {
+  amount: '1000',
+  currency: '',
+  payment_method_type: '',
+  payment_method: '',
+  card_brand: '',
+  card_program: 'STANDARD',
+  auth_type: 'THREE_DS',
+  eligible_gateways: 'stripe, adyen',
+  ranking_algorithm: 'SR_MULTI_OBJECTIVE',
+}
+
+const DEFAULT_DEBIT_FORM: DebitRoutingFormState = {
+  amount: '1000',
+  currency: 'USD',
+  auth_type: 'THREE_DS',
+  eligible_gateways: 'stripe, adyen',
+  merchant_category_code: 'merchant_category_code_0001',
+  acquirer_country: 'US',
+  co_badged_networks: 'VISA, NYCE, PULSE, STAR',
+  issuer_country: 'US',
+  is_regulated: false,
+  regulated_name: '',
+  card_type: 'debit',
+}
+
+// Auth-rate simulation runs a fixed batch — no user input; it starts on Run
+// and stops at this many transactions.
+const SIMULATION_TOTAL_PAYMENTS = '5000'
+
+// Static annotation shown beside the simulation controls (read-only note).
+const EXPERIMENT_NOTE = 'Stripe degraded · Testing cost-based fallback to Adyen'
+
+// Default auth-rate tolerance band below the best gateway's SR within which gateways are
+// SR-equivalent and become eligible for cost-based routing. Stored as a fraction
+// (0.2 = 20 percentage points), matching the "Cost Optimisation Override Configuration"
+// default of 0.5 pp on the SR Routing page. The live per-decision value
+// (multi_objective_info.tolerancePp) overrides this when present.
+const DEFAULT_COST_ROUTING_TOLERANCE = 0.005
+
+const DEFAULT_SIMULATION_CONFIG: SimulationConfig = {
+  totalPayments: SIMULATION_TOTAL_PAYMENTS,
+}
+
+
+const DEFAULT_RULE_PARAMS: RuleEvaluateParams[] = [
+  { key: 'payment_method_type', type: 'enum_variant', value: '', metadataKey: '' },
+  { key: 'currency', type: 'enum_variant', value: '', metadataKey: '' },
+]
+
+const DEFAULT_FALLBACK_CONNECTORS: GatewayConnector[] = [
+  { gateway_name: 'stripe', gateway_id: 'gateway_001' },
+  { gateway_name: 'adyen', gateway_id: 'gateway_002' },
+]
+
+interface ExplorerPersistedState {
+  scopeKey: string | null
+  resultDataUpdatedAtMs: number | null
+  activeTab: TabType
+  form: FormState
+  simulationConfig: SimulationConfig
+  gatewaySimConfigs: Record<string, GatewaySimConfig>
+  errorInfo: ErrorInfoState
+  debitForm: DebitRoutingFormState
+  ruleParams: RuleEvaluateParams[]
+  fallbackConnectors: GatewayConnector[]
+  volumePayments: string
+  result: DecideGatewayResponse | null
+  debitResult: DecideGatewayResponse | null
+  debitPaymentId: string | null
+  singleRunPaymentId: string | null
+  singleRunOutcome: TransactionOutcome
+  ruleResult: RuleEvaluateResponse | null
+  volumeDistribution: { name: string; count: number; percentage: number }[]
+  volumeEvaluationLog: VolumePaymentEntry[]
+  volumeProgress: number
+  simulationResults: SimulationResult[]
+  responseOpen: boolean
+  debitResponseOpen: boolean
+  volumeResponseOpen: boolean
+  smartRetryEnabled: boolean
+}
+
+function cloneRuleParams(params: RuleEvaluateParams[]) {
+  return params.map((param) => ({ ...param }))
+}
+
+function cloneConnectors(connectors: GatewayConnector[]) {
+  return connectors.map((connector) => ({ ...connector }))
+}
+
+function normalizeDebitCardType(value: unknown): DebitRoutingFormState['card_type'] {
+  return `${value || ''}`.toLowerCase() === 'credit' ? 'credit' : 'debit'
+}
+
+function getDefaultExplorerState(): ExplorerPersistedState {
+  return {
+    scopeKey: null,
+    resultDataUpdatedAtMs: null,
+    activeTab: 'batch',
+    form: { ...DEFAULT_FORM },
+    simulationConfig: { ...DEFAULT_SIMULATION_CONFIG },
+    gatewaySimConfigs: {},
+    errorInfo: { ...DEFAULT_ERROR_INFO },
+    debitForm: { ...DEFAULT_DEBIT_FORM },
+    ruleParams: cloneRuleParams(DEFAULT_RULE_PARAMS),
+    fallbackConnectors: cloneConnectors(DEFAULT_FALLBACK_CONNECTORS),
+    volumePayments: '100',
+    result: null,
+    debitResult: null,
+    debitPaymentId: null,
+    singleRunPaymentId: null,
+    singleRunOutcome: 'CHARGED',
+    ruleResult: null,
+    volumeDistribution: [],
+    volumeEvaluationLog: [],
+    volumeProgress: 0,
+    simulationResults: [],
+    responseOpen: false,
+    debitResponseOpen: false,
+    volumeResponseOpen: false,
+    smartRetryEnabled: false,
+  }
+}
+
+function explorerScopeKey(userId: string, userEmail: string, merchantId: string) {
+  return `${userId || userEmail || 'anonymous'}:${merchantId || 'no-merchant'}`
+}
+
+function explorerStorageKey(scopeKey: string) {
+  return `${EXPLORER_STORAGE_KEY_PREFIX}:${encodeURIComponent(scopeKey)}`
+}
+
+function hasExpiredExplorerResults(resultDataUpdatedAtMs?: number | null) {
+  return Boolean(
+    resultDataUpdatedAtMs &&
+    Date.now() - resultDataUpdatedAtMs > EXPLORER_RESULT_TTL_MS,
+  )
+}
+
+function removeExplorerState(scopeKey: string) {
+  if (typeof window === 'undefined') return
+  window.localStorage.removeItem(explorerStorageKey(scopeKey))
+}
+
+function saveExplorerState(scopeKey: string, state: ExplorerPersistedState) {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(explorerStorageKey(scopeKey), JSON.stringify(state))
+}
+
+function loadExplorerState(scopeKey: string): ExplorerPersistedState {
+  if (typeof window === 'undefined') return getDefaultExplorerState()
+
+  try {
+    const raw = window.localStorage.getItem(explorerStorageKey(scopeKey))
+      || window.localStorage.getItem(EXPLORER_STORAGE_KEY_PREFIX)
+    if (!raw) return { ...getDefaultExplorerState(), scopeKey }
+    const parsed = JSON.parse(raw) as Partial<ExplorerPersistedState>
+    const defaults = getDefaultExplorerState()
+    if (parsed.scopeKey !== scopeKey || hasExpiredExplorerResults(parsed.resultDataUpdatedAtMs)) {
+      removeExplorerState(scopeKey)
+      return { ...defaults, scopeKey }
+    }
+
+    return {
+      ...defaults,
+      ...parsed,
+      scopeKey,
+      resultDataUpdatedAtMs: parsed.resultDataUpdatedAtMs || null,
+      activeTab: defaults.activeTab,
+      form: {
+        ...defaults.form,
+        ...(parsed.form || {}),
+        // Only Success Rate Based + Multi-Objective is supported now; the
+        // dynamic simulator drives the transaction variant, not the form.
+        ranking_algorithm: 'SR_MULTI_OBJECTIVE',
+      },
+      simulationConfig: { ...defaults.simulationConfig, ...(parsed.simulationConfig || {}), totalPayments: SIMULATION_TOTAL_PAYMENTS },
+      gatewaySimConfigs: parsed.gatewaySimConfigs || defaults.gatewaySimConfigs,
+      errorInfo: { ...defaults.errorInfo, ...(parsed.errorInfo || {}) },
+      debitForm: {
+        ...defaults.debitForm,
+        ...(parsed.debitForm || {}),
+        card_type: normalizeDebitCardType(parsed.debitForm?.card_type),
+      },
+      ruleParams: parsed.ruleParams?.length ? cloneRuleParams(parsed.ruleParams) : defaults.ruleParams,
+      fallbackConnectors: parsed.fallbackConnectors?.length ? cloneConnectors(parsed.fallbackConnectors) : defaults.fallbackConnectors,
+      volumeDistribution: parsed.volumeDistribution || defaults.volumeDistribution,
+      volumeEvaluationLog: parsed.volumeEvaluationLog || defaults.volumeEvaluationLog,
+      simulationResults: parsed.simulationResults || defaults.simulationResults,
+    }
+  } catch {
+    return { ...getDefaultExplorerState(), scopeKey }
+  }
+}
+
+function toUpperOptions(values: string[] = []): string[] {
+  return values.map(v => v.trim()).filter(Boolean).map(v => v.toUpperCase())
+}
+
+function uniqueUpperOptions(values: string[] = []): string[] {
+  return Array.from(new Set(toUpperOptions(values)))
+}
+
+function extractVolumeConnector(response: RuleEvaluateResponse) {
+  return (
+    response.evaluated_output?.[0]?.gateway_name ||
+    response.output.connector?.gateway_name ||
+    response.output.connectors?.[0]?.gateway_name ||
+    null
+  )
+}
+
+function mapRoutingTypeToRuleParamType(
+  keyType?: 'enum' | 'integer' | 'udf' | 'str_value' | 'global_ref'
+): RuleEvaluateParams['type'] {
+  if (keyType === 'enum') return 'enum_variant'
+  if (keyType === 'integer') return 'number'
+  if (keyType === 'udf' || keyType === 'global_ref') return 'metadata_variant'
+  return 'str_value'
+}
+
+function queryString(params: Record<string, string | number | undefined>) {
+  const search = new URLSearchParams()
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== '') {
+      search.set(key, String(value))
+    }
+  })
+  return search.toString()
+}
+
+function formatDateTime(ms: number) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(ms))
+}
+
+function humanizeAuditValue(value?: string | null) {
+  if (!value) return ''
+  const normalized = value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+
+  return normalized.replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function routeLabel(route?: string | null) {
+  if (!route) return 'Unknown route'
+  if (route === 'decision_gateway' || route === 'decide_gateway') return 'Decide Gateway'
+  if (route === 'update_gateway_score') return 'Update Gateway'
+  if (route === 'routing_evaluate') return 'Rule Evaluate'
+  return humanizeAuditValue(route)
+}
+
+function eventTypeLabel(eventType?: string | null) {
+  if (!eventType) return 'Unknown event'
+  if (eventType === 'decide_gateway_decision') return 'Decide Gateway'
+  if (
+    eventType === 'update_gateway_score_update' ||
+    eventType === 'update_gateway_score_score_snapshot' ||
+    eventType === 'update_score_legacy_score_snapshot'
+  ) return 'Update Gateway'
+  if (eventType === 'decide_gateway_rule_hit') return 'Rule Evaluate'
+  if (eventType.startsWith('routing_evaluate_') && eventType !== 'routing_evaluate_request_hit') return 'Decision Result'
+  if (eventType.endsWith('_error')) return 'Errors'
+  return humanizeAuditValue(eventType)
+}
+
+function flowTypeValue(event: PaymentAuditEvent) {
+  return event.flow_type || ''
+}
+
+function stageLabel(event: PaymentAuditEvent) {
+  const flowType = flowTypeValue(event)
+  if (event.event_stage === 'gateway_decided') return 'Decide Gateway'
+  if (event.event_stage === 'score_updated') return 'Update Gateway'
+  if (event.event_stage === 'rule_applied') return 'Rule Evaluate'
+  if (event.event_stage === 'preview_evaluated' || (flowType.startsWith('routing_evaluate_') && flowType !== 'routing_evaluate_request_hit')) return 'Decision Result'
+  if (flowType.endsWith('_error')) return 'Errors'
+  return humanizeAuditValue(event.event_stage || flowType)
+}
+
+function eventPhase(event: PaymentAuditEvent) {
+  const flowType = flowTypeValue(event)
+  if ((flowType.startsWith('decide_gateway_') && flowType !== 'decide_gateway_rule_hit') || event.event_stage === 'gateway_decided') return 'Decide Gateway'
+  if (flowType === 'decide_gateway_rule_hit' || event.event_stage === 'rule_applied') return 'Rule Evaluate'
+  if (flowType.startsWith('update_gateway_score_') || flowType.startsWith('update_score_legacy_') || event.event_stage === 'score_updated') return 'Update Gateway'
+  if ((flowType.startsWith('routing_evaluate_') && flowType !== 'routing_evaluate_request_hit') || event.event_stage === 'preview_evaluated') return 'Decision'
+  return 'Errors'
+}
+
+function badgeVariantForEvent(event: PaymentAuditEvent): 'blue' | 'green' | 'purple' | 'red' | 'orange' | 'gray' {
+  const flowType = flowTypeValue(event)
+  const normalizedStatus = (event.status || '').toUpperCase()
+  if (
+    flowType.endsWith('_error') ||
+    normalizedStatus === 'FAILURE' ||
+    normalizedStatus.includes('FAILED') ||
+    normalizedStatus.includes('DECLINED')
+  ) return 'red'
+  if (flowType === 'decide_gateway_rule_hit') return 'purple'
+  if (
+    normalizedStatus === 'CHARGED' ||
+    normalizedStatus === 'AUTHORIZED' ||
+    normalizedStatus === 'SUCCESS'
+  ) return 'green'
+  if (flowType.startsWith('routing_evaluate_') && flowType !== 'routing_evaluate_request_hit') return 'purple'
+  if (flowType.startsWith('update_gateway_score_') || flowType.startsWith('update_score_legacy_')) return 'green'
+  if (flowType.startsWith('decide_gateway_')) return 'blue'
+  return 'orange'
+}
+
+function summaryBadgeVariant(status?: string | null): 'blue' | 'green' | 'purple' | 'red' | 'orange' | 'gray' {
+  const normalizedStatus = (status || '').toUpperCase()
+  if (
+    normalizedStatus === 'FAILURE' ||
+    normalizedStatus.includes('FAILED') ||
+    normalizedStatus.includes('DECLINED')
+  ) return 'red'
+  if (
+    normalizedStatus === 'SUCCESS' ||
+    normalizedStatus === 'CHARGED' ||
+    normalizedStatus === 'AUTHORIZED'
+  ) return 'green'
+  return 'gray'
+}
+
+function phaseBadgeVariant(phase: string): 'blue' | 'green' | 'purple' | 'red' | 'orange' | 'gray' {
+  if (phase === 'Decide Gateway') return 'blue'
+  if (phase === 'Rule Evaluate') return 'purple'
+  if (phase === 'Decision') return 'purple'
+  if (phase === 'Update Gateway') return 'green'
+  if (phase === 'Errors') return 'red'
+  return 'gray'
+}
+
+function isTraceIndexingError(error: unknown) {
+  const status = typeof error === 'object' && error ? (error as { status?: number }).status : undefined
+  const message = error instanceof Error ? error.message : String(error || '')
+  return status === 404 || message.includes('API error 404')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function cleanRecord(record: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined && value !== null && value !== ''),
+  )
+}
+
+function stringifyValue(value: unknown) {
+  if (typeof value === 'string') return value
+  return JSON.stringify(value, null, 2)
+}
+
+function buildAuditUrl(paymentId: string) {
+  const qs = queryString({
+    range: '1d',
+    page: 1,
+    page_size: 25,
+    payment_id: paymentId,
+  })
+  return `/analytics/payment-audit?${qs}`
+}
+
+function buildPreviewTraceUrl(paymentId: string) {
+  const qs = queryString({
+    range: '1d',
+    page: 1,
+    page_size: 25,
+    payment_id: paymentId,
+  })
+  return `/analytics/preview-trace?${qs}`
+}
+
+function buildInspectorModel(event: PaymentAuditEvent | null) {
+  if (!event) return null
+
+  const details = isRecord(event.details_json) ? event.details_json : {}
+  const explicitResponse =
+    details.response ??
+    details.response_payload ??
+    details.result ??
+    details.output ??
+    null
+  const requestPayload =
+    details.request ??
+    details.request_payload ??
+    details.input ??
+    details.payload ??
+    cleanRecord({
+      payment_id: event.payment_id,
+      request_id: event.request_id,
+      payment_method_type: event.payment_method_type,
+      payment_method: event.payment_method,
+      gateway: event.gateway,
+    })
+  const responsePayload =
+    explicitResponse ??
+    cleanRecord({
+      flow_type: event.flow_type,
+      status: event.status,
+      error_code: event.error_code,
+      error_message: event.error_message,
+      score_value: event.score_value,
+      sigma_factor: event.sigma_factor,
+      average_latency: event.average_latency,
+      tp99_latency: event.tp99_latency,
+      transaction_count: event.transaction_count,
+      rule_name: event.rule_name,
+      routing_approach: event.routing_approach,
+    })
+  const responseRecord = isRecord(explicitResponse) ? explicitResponse : null
+  const decidedGatewayRecord = isRecord(responseRecord?.['decided_gateway']) ? responseRecord['decided_gateway'] : null
+  const scoreContext =
+    details.score_context ??
+    (decidedGatewayRecord ? decidedGatewayRecord['gateway_priority_map'] : null) ??
+    (responseRecord ? responseRecord['gateway_priority_map'] : null) ??
+    null
+  const selectionReason = details.selection_reason ?? null
+
+  const summaryRows = [
+    { label: 'Phase', value: eventPhase(event) },
+    { label: 'Stage', value: stageLabel(event) },
+    { label: 'Route', value: routeLabel(event.route) },
+    { label: 'Timestamp', value: formatDateTime(event.created_at_ms) },
+    ...(event.merchant_id ? [{ label: 'Merchant', value: event.merchant_id }] : []),
+    ...(event.payment_id ? [{ label: 'Payment ID', value: event.payment_id }] : []),
+    ...(event.request_id ? [{ label: 'Request ID', value: event.request_id }] : []),
+    ...(event.gateway ? [{ label: 'Gateway', value: event.gateway }] : []),
+    ...(event.status ? [{ label: 'Status', value: humanizeAuditValue(event.status) }] : []),
+  ]
+
+  const signalRecord = cleanRecord(
+    Object.fromEntries(
+      Object.entries(details).filter(([key]) => ![
+        'request',
+        'request_payload',
+        'input',
+        'payload',
+        'response',
+        'response_payload',
+        'result',
+        'output',
+        'score_context',
+        'selection_reason',
+      ].includes(key)),
+    ),
+  )
+
+  return {
+    summaryRows,
+    requestPayload: isRecord(requestPayload) && !Object.keys(requestPayload).length ? null : requestPayload,
+    responsePayload: isRecord(responsePayload) && !Object.keys(responsePayload).length ? null : responsePayload,
+    scoreContext,
+    selectionReason,
+    signalRecord: Object.keys(signalRecord).length ? signalRecord : null,
+    rawEvent: {
+      ...event,
+      details_json: event.details_json,
+    },
+  }
+}
+
+function sectionButtonClass(active: boolean) {
+  return active
+    ? '!border-slate-200 !bg-white !text-slate-950 shadow-[0_12px_30px_-24px_rgba(15,23,42,0.28)] dark:!border-[#2a303a] dark:!bg-[#161b24] dark:!text-white'
+    : '!border-transparent !bg-slate-100 !text-slate-600 hover:!bg-slate-200 hover:!text-slate-900 dark:!bg-[#161b24] dark:!text-[#a7b2c6] dark:hover:!bg-[#1c2330] dark:hover:!text-white'
+}
+
+function isMissingRoutingSetupError(message: string) {
+  const normalized = message.toLowerCase()
+  return normalized.includes('no active routing algorithm')
+    || normalized.includes('active routing algorithm is not a volume split')
+    || normalized.includes('debit_routing_not_enabled')
+    || normalized.includes('debit routing is disabled')
+}
+
+function setupPromptForTab(tab: TabType, detail?: string): SetupPromptState {
+  if (tab === 'volume') {
+    return {
+      title: 'Configure volume split first',
+      body: 'Volume evaluation needs an active volume split rule before it can calculate distribution.',
+      detail,
+      configurePath: '/routing/volume',
+    }
+  }
+
+  if (tab === 'rule') {
+    return {
+      title: 'Configure rule-based routing first',
+      body: 'Rule evaluation needs an active rule-based strategy before it can return a policy decision.',
+      detail,
+      configurePath: '/routing/rules',
+    }
+  }
+
+  if (tab === 'debit') {
+    return {
+      title: 'Enable debit routing first',
+      body: 'Debit network decisions need the merchant debit routing flag enabled before this explorer can run network routing.',
+      detail,
+      configurePath: '/routing/debit',
+    }
+  }
+
+  return {
+    title: 'Configure auth-rate routing first',
+    body: 'Auth-rate simulation needs success-rate routing configured before it can run gateway decisions.',
+    detail,
+    configurePath: '/routing/sr',
+  }
+}
+
+
+function EmptyAuditState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-[22px] border border-dashed border-slate-200 bg-slate-50/80 px-6 py-12 text-center dark:border-[#2a303a] dark:bg-[#161b24]/80">
+      <p className="text-sm font-semibold text-slate-900 dark:text-white">{title}</p>
+      <p className="mt-2 text-sm text-slate-500 dark:text-[#b2bdd1]">{body}</p>
+    </div>
+  )
+}
+
+function PendingAuditState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-[22px] border border-slate-200 bg-slate-50/80 px-6 py-10 text-center dark:border-[#2a303a] dark:bg-[#161b24]/80">
+      <div className="flex justify-center">
+        <Spinner size={18} />
+      </div>
+      <p className="mt-4 text-sm font-semibold text-slate-900 dark:text-white">{title}</p>
+      <p className="mt-2 text-sm text-slate-500 dark:text-[#b2bdd1]">{body}</p>
+      <div className="mt-5 h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-[#202734]">
+        <div className="h-full w-1/3 animate-pulse rounded-full bg-brand-500" />
+      </div>
+      <p className="mt-3 text-[11px] uppercase tracking-[0.16em] text-slate-400 dark:text-[#8390a7]">
+        Waiting for analytics
+      </p>
+    </div>
+  )
+}
+
+function InspectorKeyValueGrid({ rows }: { rows: Array<{ label: string; value: string }> }) {
+  if (!rows.length) return null
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      {rows.map((row) => (
+        <div
+          key={`${row.label}-${row.value}`}
+          className="rounded-[22px] border border-slate-200 bg-white/80 px-4 py-3 shadow-[0_14px_30px_-28px_rgba(15,23,42,0.18)] dark:border-[#2a303a] dark:bg-[#161b24] dark:shadow-none"
+        >
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-[#8390a7]">
+            {row.label}
+          </p>
+          <p className="mt-2 break-words text-sm text-slate-900 dark:text-white">{row.value}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function InspectorJsonPanel({
+  title,
+  value,
+  emptyMessage,
+}: {
+  title: string
+  value: unknown
+  emptyMessage: string
+}) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-white">{title}</h3>
+      </div>
+      {value ? (
+        <pre className="overflow-x-auto rounded-[22px] border border-slate-200/80 bg-slate-50/90 px-4 py-4 font-mono text-xs leading-6 text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),0_16px_30px_-28px_rgba(15,23,42,0.18)] dark:border-[#2a303a] dark:bg-[#0b1017] dark:text-[#d8e1ef] dark:shadow-none">
+          {stringifyValue(value)}
+        </pre>
+      ) : (
+        <EmptyAuditState title={`No ${title.toLowerCase()} captured`} body={emptyMessage} />
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Extracts RuleEvaluateParams from a routing algorithm's Euclid conditions.
+// Walks all rules and statements, collecting unique lhs keys with their first
+// concrete value. Non-Advanced algorithms (Priority/Single) have no conditions
+// so return an empty array.
+// ---------------------------------------------------------------------------
+export function DecisionSimulatorPage() {
+  const navigate = useNavigate()
+  const { merchantId } = useMerchantStore()
+  const authUser = useAuthStore((state) => state.user)
+  const authMerchantId = authUser?.merchantId || ''
+  const effectiveMerchantId = merchantId || authMerchantId
+  const currentScopeKey = explorerScopeKey(
+    authUser?.userId || '',
+    authUser?.email || '',
+    effectiveMerchantId,
+  )
+  const merchantFeatures = useMerchantFeatures(effectiveMerchantId || undefined)
+  const gsmScoringFilterEnabled = merchantFeatures.isEnabled('gsm-scoring-filter')
+  const debitRoutingFlag = useDebitRoutingFlag(effectiveMerchantId)
+  const { routingKeysConfig, isLoading: routingKeysLoading, error: routingKeysError } = useDynamicRoutingConfig()
+  const hasRoutingKeys = Object.keys(routingKeysConfig).length > 0
+  const routingConfigUnavailable = !routingKeysLoading && (!hasRoutingKeys || Boolean(routingKeysError))
+  const initialState = useMemo(() => loadExplorerState(currentScopeKey), [currentScopeKey])
+  const [activeTab, setActiveTab] = useState<TabType>(initialState.activeTab)
+  const [stateScopeKey, setStateScopeKey] = useState(initialState.scopeKey || currentScopeKey)
+  const [resultDataUpdatedAtMs, setResultDataUpdatedAtMs] = useState<number | null>(
+    initialState.resultDataUpdatedAtMs,
+  )
+
+  const [form, setForm] = useState<FormState>(initialState.form)
+
+  const [simulationConfig, setSimulationConfig] = useState<SimulationConfig>(initialState.simulationConfig)
+  const [errorInfo, setErrorInfo] = useState<ErrorInfoState>(initialState.errorInfo)
+  const [gatewaySimConfigs, setGatewaySimConfigs] = useState<Record<string, GatewaySimConfig>>(initialState.gatewaySimConfigs)
+  const gatewaySimConfigsRef = useRef(gatewaySimConfigs)
+  useEffect(() => { gatewaySimConfigsRef.current = gatewaySimConfigs }, [gatewaySimConfigs])
+  const eliminationEnabled = Object.values(gatewaySimConfigs).some(c => c.failureMode === 'timeout')
+  const simulationAbortRef = useRef(false)
+  useEffect(() => () => { simulationAbortRef.current = true }, [])
+
+  const [debitForm, setDebitForm] = useState<DebitRoutingFormState>(initialState.debitForm)
+
+  const [ruleResetSignal, setRuleResetSignal] = useState(0)
+
+  const [ruleParams, setRuleParams] = useState<RuleEvaluateParams[]>(initialState.ruleParams)
+
+  const [fallbackConnectors, setFallbackConnectors] = useState<GatewayConnector[]>(initialState.fallbackConnectors)
+
+  const [volumePayments, setVolumePayments] = useState<string>(initialState.volumePayments)
+
+  const [result, setResult] = useState<DecideGatewayResponse | null>(initialState.result)
+  const [debitResult, setDebitResult] = useState<DecideGatewayResponse | null>(initialState.debitResult)
+  const [debitPaymentId, setDebitPaymentId] = useState<string | null>(initialState.debitPaymentId)
+  const [singleRunPaymentId, setSingleRunPaymentId] = useState<string | null>(initialState.singleRunPaymentId)
+  const [singleRunOutcome, setSingleRunOutcome] = useState<TransactionOutcome>(initialState.singleRunOutcome)
+  const [ruleResult, setRuleResult] = useState<RuleEvaluateResponse | null>(initialState.ruleResult)
+  const [volumeDistribution, setVolumeDistribution] = useState<{ name: string; count: number; percentage: number }[]>(initialState.volumeDistribution)
+  const [volumeEvaluationLog, setVolumeEvaluationLog] = useState<VolumePaymentEntry[]>(initialState.volumeEvaluationLog)
+  const [volumeProgress, setVolumeProgress] = useState(initialState.volumeProgress)
+  const [simulationResults, setSimulationResults] = useState<SimulationResult[]>(initialState.simulationResults)
+  const [isSimulating, setIsSimulating] = useState(false)
+  const [smartRetryEnabled, setSmartRetryEnabled] = useState(initialState.smartRetryEnabled)
+  const [error, setError] = useState<string | null>(null)
+  const txLogRef = useRef<HTMLDivElement>(null)
+
+  const [setupPrompt, setSetupPrompt] = useState<SetupPromptState | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [filterOpen, setFilterOpen] = useState(false)
+  const [responseOpen, setResponseOpen] = useState(initialState.responseOpen)
+  const [debitResponseOpen, setDebitResponseOpen] = useState(initialState.debitResponseOpen)
+  const [volumeResponseOpen, setVolumeResponseOpen] = useState(initialState.volumeResponseOpen)
+  const [selectedAuditPaymentId, setSelectedAuditPaymentId] = useState<string | null>(null)
+  const [selectedAuditEventId, setSelectedAuditEventId] = useState<string | null>(null)
+  const [auditInspectorTab, setAuditInspectorTab] = useState<AuditInspectorTab>('summary')
+  const [selectedPreviewPaymentId, setSelectedPreviewPaymentId] = useState<string | null>(null)
+  const [selectedPreviewEventId, setSelectedPreviewEventId] = useState<string | null>(null)
+  const [previewInspectorTab, setPreviewInspectorTab] = useState<AuditInspectorTab>('summary')
+  const [previewTraceLabel, setPreviewTraceLabel] = useState('Rule Evaluation Decision')
+  const deferredSimulationResults = useDeferredValue(simulationResults)
+  const [showPenaltyGuide, setShowPenaltyGuide] = useState(false)
+
+  const routingKeyNames = useMemo(
+    () => Object.keys(routingKeysConfig).sort(),
+    [routingKeysConfig]
+  )
+
+  const paymentMethodTypeOptions = useMemo(
+    () => toUpperOptions(routingKeysConfig.payment_method?.values || []),
+    [routingKeysConfig]
+  )
+
+  const currencyOptions = useMemo(
+    () => uniqueUpperOptions(routingKeysConfig.currency?.values || []),
+    [routingKeysConfig]
+  )
+
+  const cardBrandOptions = useMemo(
+    () => uniqueUpperOptions(routingKeysConfig.card_network?.values || []),
+    [routingKeysConfig]
+  )
+
+  const authTypeOptions = useMemo(
+    () => uniqueUpperOptions(routingKeysConfig.authentication_type?.values || []),
+    [routingKeysConfig]
+  )
+
+  const auditUrl = selectedAuditPaymentId
+    ? buildAuditUrl(selectedAuditPaymentId)
+    : null
+
+  const auditDetail = useSWR<PaymentAuditResponse>(auditUrl, fetcher, {
+    revalidateOnFocus: false,
+  })
+
+  const previewTraceUrl = selectedPreviewPaymentId
+    ? buildPreviewTraceUrl(selectedPreviewPaymentId)
+    : null
+
+  const previewTraceDetail = useSWR<PaymentAuditResponse>(previewTraceUrl, fetcher, {
+    revalidateOnFocus: false,
+  })
+
+  const { data: gsmOptionsData } = useSWR<{ rules: GsmOptionRow[] }>(
+    '/gsm/options',
+    fetcher,
+    { revalidateOnFocus: false, dedupingInterval: 300_000 },
+  )
+  const gsmRules = gsmOptionsData?.rules ?? []
+
+  useEffect(() => {
+    if (routingConfigUnavailable || routingKeysLoading) return
+
+    setForm(prev => {
+      const next = { ...prev }
+      let changed = false
+
+      if (currencyOptions.length > 0 && !currencyOptions.includes(next.currency)) {
+        next.currency = currencyOptions[0]
+        changed = true
+      }
+
+      if (paymentMethodTypeOptions.length > 0 && !paymentMethodTypeOptions.includes(next.payment_method_type)) {
+        next.payment_method_type = paymentMethodTypeOptions[0]
+        changed = true
+      }
+
+      const methodsForType = toUpperOptions(
+        routingKeysConfig[next.payment_method_type.toLowerCase()]?.values || []
+      )
+      if (methodsForType.length > 0 && !methodsForType.includes(next.payment_method)) {
+        next.payment_method = methodsForType[0]
+        changed = true
+      }
+
+      if (authTypeOptions.length > 0 && !authTypeOptions.includes(next.auth_type)) {
+        next.auth_type = authTypeOptions[0]
+        changed = true
+      }
+
+      if (cardBrandOptions.length > 0 && !cardBrandOptions.includes(next.card_brand)) {
+        next.card_brand = cardBrandOptions[0]
+        changed = true
+      }
+
+      return changed ? next : prev
+    })
+
+    setRuleParams(prev => {
+      let changed = false
+      const next = prev.map(param => {
+        if (!param.key || !routingKeysConfig[param.key]) return param
+        const keyConfig = routingKeysConfig[param.key]
+        const mappedType = mapRoutingTypeToRuleParamType(keyConfig.type)
+        const enumValues = keyConfig.values || []
+        const nextValue = mappedType === 'enum_variant'
+          ? (enumValues.includes(param.value) ? param.value : (enumValues[0] || ''))
+          : param.value
+        if (param.type !== mappedType || param.value !== nextValue) {
+          changed = true
+          return { ...param, type: mappedType, value: nextValue }
+        }
+        return param
+      })
+      return changed ? next : prev
+    })
+  }, [
+    routingConfigUnavailable,
+    routingKeysLoading,
+    routingKeysConfig,
+    currencyOptions,
+    paymentMethodTypeOptions,
+    authTypeOptions,
+    cardBrandOptions,
+  ])
+
+  // SR_MULTI_OBJECTIVE constrains the form to a card-only cluster shape:
+  // Currency = USD, Method Type = CARD, Payment Method = CREDIT, and Card Brand
+  // defaults to Visa/Mastercard when the prior selection isn't one of them.
+  useEffect(() => {
+    if (form.ranking_algorithm !== 'SR_MULTI_OBJECTIVE') return
+    setForm(prev => {
+      if (prev.ranking_algorithm !== 'SR_MULTI_OBJECTIVE') return prev
+      const next = { ...prev }
+      let changed = false
+      if (next.currency !== MULTI_OBJECTIVE_CURRENCY) { next.currency = MULTI_OBJECTIVE_CURRENCY; changed = true }
+      const cardType = paymentMethodTypeOptions.find(p => p === 'CARD') || 'CARD'
+      if (next.payment_method_type !== cardType) { next.payment_method_type = cardType; changed = true }
+      if (!MULTI_OBJECTIVE_PAYMENT_METHODS.includes(next.payment_method as 'CREDIT')) {
+        next.payment_method = 'CREDIT'
+        changed = true
+      }
+      if (!MULTI_OBJECTIVE_CARD_BRANDS.includes(next.card_brand as 'VISA' | 'MASTERCARD')) {
+        const fallback = cardBrandOptions.find(b => b === 'VISA') || cardBrandOptions.find(b => b === 'MASTERCARD') || cardBrandOptions[0] || 'VISA'
+        next.card_brand = fallback
+        changed = true
+      }
+      if (!CARD_PROGRAM_OPTIONS.includes(next.card_program as 'STANDARD' | 'PREMIUM')) {
+        next.card_program = 'STANDARD'
+        changed = true
+      }
+      return changed ? next : prev
+    })
+  }, [form.ranking_algorithm, paymentMethodTypeOptions, cardBrandOptions])
+
+  useEffect(() => {
+    if (!selectedAuditPaymentId && !selectedPreviewPaymentId && !setupPrompt) return
+
+    const previousOverflow = document.body.style.overflow
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setSelectedAuditPaymentId(null)
+        setSelectedAuditEventId(null)
+        setAuditInspectorTab('summary')
+        setSelectedPreviewPaymentId(null)
+        setSelectedPreviewEventId(null)
+        setPreviewInspectorTab('summary')
+        setSetupPrompt(null)
+      }
+    }
+
+    document.body.style.overflow = 'hidden'
+    window.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [selectedAuditPaymentId, selectedPreviewPaymentId, setupPrompt])
+
+  function clearExplorerRunData() {
+    const defaults = getDefaultExplorerState()
+    setResult(defaults.result)
+    setDebitResult(defaults.debitResult)
+    setDebitPaymentId(defaults.debitPaymentId)
+    setSingleRunPaymentId(defaults.singleRunPaymentId)
+    setSingleRunOutcome(defaults.singleRunOutcome)
+    setRuleResult(defaults.ruleResult)
+    setVolumeDistribution(defaults.volumeDistribution)
+    setVolumeEvaluationLog(defaults.volumeEvaluationLog)
+    setVolumeProgress(defaults.volumeProgress)
+    setSimulationResults(defaults.simulationResults)
+    setResponseOpen(defaults.responseOpen)
+    setDebitResponseOpen(defaults.debitResponseOpen)
+    setVolumeResponseOpen(defaults.volumeResponseOpen)
+    setSelectedAuditPaymentId(null)
+    setSelectedAuditEventId(null)
+    setAuditInspectorTab('summary')
+    setSelectedPreviewPaymentId(null)
+    setSelectedPreviewEventId(null)
+    setPreviewInspectorTab('summary')
+    setPreviewTraceLabel('Rule Evaluation Decision')
+    setResultDataUpdatedAtMs(null)
+    setError(null)
+    setSetupPrompt(null)
+    setLoading(false)
+    simulationAbortRef.current = true
+    setIsSimulating(false)
+  }
+
+  function markExplorerRunDataUpdated() {
+    setResultDataUpdatedAtMs(Date.now())
+  }
+
+  function applyExplorerState(nextState: ExplorerPersistedState, scopeKey: string) {
+    setActiveTab(nextState.activeTab)
+    setStateScopeKey(nextState.scopeKey || scopeKey)
+    setResultDataUpdatedAtMs(nextState.resultDataUpdatedAtMs)
+    setForm(nextState.form)
+    setSimulationConfig(nextState.simulationConfig)
+    setGatewaySimConfigs(nextState.gatewaySimConfigs)
+    setErrorInfo(nextState.errorInfo)
+    setDebitForm(nextState.debitForm)
+    setRuleParams(nextState.ruleParams)
+    setFallbackConnectors(nextState.fallbackConnectors)
+    setVolumePayments(nextState.volumePayments)
+    setResult(nextState.result)
+    setDebitResult(nextState.debitResult)
+    setDebitPaymentId(nextState.debitPaymentId)
+    setSingleRunPaymentId(nextState.singleRunPaymentId)
+    setSingleRunOutcome(nextState.singleRunOutcome)
+    setRuleResult(nextState.ruleResult)
+    setVolumeDistribution(nextState.volumeDistribution)
+    setVolumeEvaluationLog(nextState.volumeEvaluationLog)
+    setVolumeProgress(nextState.volumeProgress)
+    setSimulationResults(nextState.simulationResults)
+    setResponseOpen(nextState.responseOpen)
+    setDebitResponseOpen(nextState.debitResponseOpen)
+    setVolumeResponseOpen(nextState.volumeResponseOpen)
+    setSelectedAuditPaymentId(null)
+    setSelectedAuditEventId(null)
+    setAuditInspectorTab('summary')
+    setSelectedPreviewPaymentId(null)
+    setSelectedPreviewEventId(null)
+    setPreviewInspectorTab('summary')
+    setPreviewTraceLabel('Rule Evaluation Decision')
+    setFilterOpen(false)
+    setError(null)
+    setSetupPrompt(null)
+    setLoading(false)
+    simulationAbortRef.current = true
+    setIsSimulating(false)
+  }
+
+  useEffect(() => {
+    if (stateScopeKey === currentScopeKey) return
+    applyExplorerState(loadExplorerState(currentScopeKey), currentScopeKey)
+  }, [currentScopeKey, stateScopeKey])
+
+  useEffect(() => {
+    if (!resultDataUpdatedAtMs) return
+
+    const storageScopeKey = stateScopeKey || currentScopeKey
+    const remainingMs = EXPLORER_RESULT_TTL_MS - (Date.now() - resultDataUpdatedAtMs)
+    if (remainingMs <= 0) {
+      clearExplorerRunData()
+      removeExplorerState(storageScopeKey)
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      clearExplorerRunData()
+      removeExplorerState(storageScopeKey)
+    }, remainingMs)
+
+    return () => window.clearTimeout(timer)
+  }, [currentScopeKey, resultDataUpdatedAtMs, stateScopeKey])
+
+  useEffect(() => {
+    if (stateScopeKey !== currentScopeKey) return
+    // Skip persisting mid-run — results are flushed once the run completes.
+    if (isSimulating || loading) return
+
+    const nextState: ExplorerPersistedState = {
+      scopeKey: currentScopeKey,
+      resultDataUpdatedAtMs,
+      activeTab,
+      form,
+      simulationConfig,
+      gatewaySimConfigs,
+      errorInfo,
+      debitForm,
+      ruleParams,
+      fallbackConnectors,
+      volumePayments,
+      result,
+      debitResult,
+      debitPaymentId,
+      singleRunPaymentId,
+      singleRunOutcome,
+      ruleResult,
+      volumeDistribution,
+      volumeEvaluationLog,
+      volumeProgress,
+      simulationResults,
+      responseOpen,
+      debitResponseOpen,
+      volumeResponseOpen,
+      smartRetryEnabled,
+    }
+
+    saveExplorerState(currentScopeKey, nextState)
+  }, [
+    currentScopeKey,
+    stateScopeKey,
+    isSimulating,
+    loading,
+    resultDataUpdatedAtMs,
+    activeTab,
+    form,
+    simulationConfig,
+    gatewaySimConfigs,
+    errorInfo,
+    debitForm,
+    ruleParams,
+    fallbackConnectors,
+    volumePayments,
+    result,
+    debitResult,
+    debitPaymentId,
+    singleRunPaymentId,
+    singleRunOutcome,
+    ruleResult,
+    volumeDistribution,
+    volumeEvaluationLog,
+    volumeProgress,
+    simulationResults,
+    responseOpen,
+    debitResponseOpen,
+    volumeResponseOpen,
+    smartRetryEnabled,
+  ])
+
+  function setDebitField<K extends keyof DebitRoutingFormState>(field: K, value: DebitRoutingFormState[K]) {
+    setDebitForm(f => ({ ...f, [field]: value }))
+  }
+
+  function setErrorField(updates: Partial<ErrorInfoState>) {
+    setErrorInfo(f => ({ ...f, ...updates }))
+  }
+
+  function getGwSimConfig(gw: string): GatewaySimConfig {
+    return gatewaySimConfigsRef.current[gw] ?? { ...DEFAULT_GW_SIM_CONFIG }
+  }
+
+  function getGwSuccessRate(gw: string): number {
+    return getGwSimConfig(gw).successRate
+  }
+
+  function getGwFailureMode(gw: string): 'decline' | 'timeout' {
+    return getGwSimConfig(gw).failureMode
+  }
+
+  function setGwSuccessRate(gw: string, rate: number) {
+    setGatewaySimConfigs(c => ({ ...c, [gw]: { ...getGwSimConfig(gw), ...c[gw], successRate: rate } }))
+  }
+
+  // Finds a real error code for `connector` that produces the desired GSM decision + penalty.
+  function resolveSimErrorInfo(connector: string, gsmDecision: 'retry' | 'do_default', penalized: boolean) {
+    const penalizedMessages = new Set(['Issue with Integration', 'Issue with Configurations', 'Technical issue with PSP', 'Something went wrong'])
+    const notPenalizedMessages = new Set(['Issue with Payment Method details'])
+    const targetMessages = penalized ? penalizedMessages : notPenalizedMessages
+    return gsmRules.find(r =>
+      r.connector === connector &&
+      (r.subFlow === 'Authorize' || r.flow === 'Authorize') &&
+      r.decision === gsmDecision &&
+      r.unifiedMessage != null &&
+      targetMessages.has(r.unifiedMessage) &&
+      !!r.errorCode && r.errorCode.toLowerCase() !== 'no error code'
+    )
+  }
+
+  // Resolves the best-matching GSM rule for a connector+errorCode pair.
+  // Mirrors the priority used in ErrorInfoFields: prefer subFlow=Authorize
+  // (payment-auth path, newer rules) over flow=Authorize (general auth flow),
+  // then fall back to any rule for that error code.
+  function resolveGsmRule(connector: string, errorCode: string) {
+    return (
+      gsmRules.find(r => r.connector === connector && r.errorCode === errorCode && r.subFlow === 'Authorize') ??
+      gsmRules.find(r => r.connector === connector && r.errorCode === errorCode && r.flow === 'Authorize') ??
+      gsmRules.find(r => r.connector === connector && r.errorCode === errorCode)
+    )
+  }
+
+  // Uses stored errorInfo (auto-populated from toggles or manually overridden by user).
+  function buildSimErrorInfo(gateway: string) {
+    if (!gateway) return undefined
+    const info = getGwSimConfig(gateway).errorInfo
+    if (!info.error_code) return undefined
+    const rule = resolveGsmRule(gateway, info.error_code)
+    return {
+      connector: gateway,
+      ...(rule?.flow && { flow: rule.flow }),
+      ...(rule?.subFlow && { subFlow: rule.subFlow }),
+      errorCode: info.error_code,
+      ...(info.error_message && { errorMessage: info.error_message }),
+      ...(info.issuer_error_code && { issuerErrorCode: info.issuer_error_code }),
+      ...(info.card_network && { cardNetwork: info.card_network }),
+    }
+  }
+
+  function buildErrorInfo(gateway: string, info: ErrorInfoState = errorInfo) {
+    if (!gateway) return undefined
+    if (!info.error_code) return undefined
+    const rule = resolveGsmRule(gateway, info.error_code)
+    return {
+      connector: gateway,
+      ...(rule?.flow && { flow: rule.flow }),
+      ...(rule?.subFlow && { subFlow: rule.subFlow }),
+      errorCode: info.error_code,
+      ...(info.error_message && { errorMessage: info.error_message }),
+      ...(info.issuer_error_code && { issuerErrorCode: info.issuer_error_code }),
+      ...(info.card_network && { cardNetwork: info.card_network }),
+    }
+  }
+
+  function openSetupPrompt(tab: TabType, detail?: string) {
+    setError(null)
+    setSetupPrompt(setupPromptForTab(tab, detail))
+  }
+
+  function handleRunError(errorValue: unknown, tab: TabType, fallback = 'Request failed') {
+    const message = errorValue instanceof Error ? errorValue.message : fallback
+    if (isMissingRoutingSetupError(message)) {
+      openSetupPrompt(tab, message)
+      return
+    }
+    setError(message)
+  }
+
+  function buildDebitRoutingMetadata() {
+    const networks = debitForm.co_badged_networks
+      .split(',')
+      .map(network => network.trim().toUpperCase())
+      .filter(Boolean)
+
+    return JSON.stringify({
+      merchant_category_code: debitForm.merchant_category_code.trim(),
+      acquirer_country: debitForm.acquirer_country.trim().toUpperCase(),
+      co_badged_card_data: {
+        co_badged_card_networks: networks,
+        issuer_country: debitForm.issuer_country.trim().toUpperCase(),
+        is_regulated: debitForm.is_regulated,
+        regulated_name: debitForm.is_regulated && debitForm.regulated_name.trim()
+          ? debitForm.regulated_name.trim()
+          : null,
+        card_type: normalizeDebitCardType(debitForm.card_type),
+      },
+    })
+  }
+
+  function addRuleParam() {
+    if (routingKeyNames.length === 0) return
+    const firstKey = routingKeyNames[0]
+    const firstConfig = routingKeysConfig[firstKey]
+    const mappedType = mapRoutingTypeToRuleParamType(firstConfig?.type)
+    const firstValue = mappedType === 'enum_variant' ? (firstConfig?.values?.[0] || '') : ''
+    setRuleParams([...ruleParams, { key: firstKey, type: mappedType, value: firstValue, metadataKey: '' }])
+  }
+
+  function removeRuleParam(index: number) {
+    setRuleParams(ruleParams.filter((_, i) => i !== index))
+  }
+
+  function updateRuleParam(index: number, field: keyof RuleEvaluateParams, value: string) {
+    setRuleParams(ruleParams.map((p, i) => i === index ? { ...p, [field]: value } : p))
+  }
+
+  function updateRuleParamMetadataKey(index: number, value: string) {
+    setRuleParams(ruleParams.map((p, i) => i === index ? { ...p, metadataKey: value } : p))
+  }
+
+  function updateRuleParamKey(index: number, key: string) {
+    const keyConfig = routingKeysConfig[key]
+    const mappedType = mapRoutingTypeToRuleParamType(keyConfig?.type)
+    const nextValue = mappedType === 'enum_variant' ? (keyConfig?.values?.[0] || '') : ''
+    setRuleParams(ruleParams.map((p, i) => (
+      i === index ? { ...p, key, type: mappedType, value: nextValue, metadataKey: '' } : p
+    )))
+  }
+
+  function addFallbackConnector() {
+    setFallbackConnectors([...fallbackConnectors, { gateway_name: '', gateway_id: '' }])
+  }
+
+  function removeFallbackConnector(index: number) {
+    setFallbackConnectors(fallbackConnectors.filter((_, i) => i !== index))
+  }
+
+  function updateFallbackConnector(index: number, field: keyof GatewayConnector, value: string) {
+    setFallbackConnectors(fallbackConnectors.map((c, i) => i === index ? { ...c, [field]: value } : c))
+  }
+
+  async function run() {
+    if (!effectiveMerchantId) return setError('Sign in with a merchant-linked account to continue')
+    if (routingConfigUnavailable) return setError('Routing key config unavailable. Fix /config/routing-keys and retry.')
+    setLoading(true); setError(null); setSetupPrompt(null)
+    setSingleRunPaymentId(null)
+    const gateways = form.eligible_gateways.split(',').map(s => s.trim()).filter(Boolean)
+    const paymentId = `explorer_${Date.now()}`
+    try {
+      const res = await apiPost<DecideGatewayResponse>('/decide-gateway', {
+        merchantId: effectiveMerchantId,
+        paymentInfo: {
+          paymentId: paymentId,
+          amount: parseFloat(form.amount) || 1000,
+          currency: form.currency,
+          paymentType: 'ORDER_PAYMENT',
+          paymentMethodType: form.payment_method_type,
+          paymentMethod: form.payment_method,
+          authType: form.auth_type,
+          cardBrand: form.card_brand,
+          cardSwitchProvider: form.card_brand,
+          cardType: form.payment_method,
+          ...(form.ranking_algorithm === 'SR_MULTI_OBJECTIVE' && { cardProgram: form.card_program }),
+        },
+        eligibleGatewayList: gateways,
+        rankingAlgorithm: 'SR_BASED_ROUTING',
+        enableMultiObjective: form.ranking_algorithm === 'SR_MULTI_OBJECTIVE',
+        eliminationEnabled: eliminationEnabled,
+      })
+      const scoreRes = await apiPost<UpdateScoreResponse>('/update-gateway-score', {
+        merchantId: effectiveMerchantId,
+        gateway: res.decided_gateway,
+        gatewayReferenceId: null,
+        status: singleRunOutcome,
+        paymentId: paymentId,
+        enforceDynamicRoutingFailure: null,
+        ...(singleRunOutcome === 'FAILURE' && { errorInfo: buildErrorInfo(res.decided_gateway) }),
+      })
+
+      // Smart retry: if the failure is retryable and we have a fallback, attempt the next gateway
+      if (
+        smartRetryEnabled &&
+        gsmScoringFilterEnabled &&
+        singleRunOutcome === 'FAILURE' &&
+        scoreRes.gsm_info?.decision === 'retry' &&
+        res.fallback_gateways.length > 0
+      ) {
+        const retryGateway = res.fallback_gateways[0]
+        await apiPost('/update-gateway-score', {
+          merchantId: effectiveMerchantId,
+          gateway: retryGateway,
+          gatewayReferenceId: null,
+          status: 'CHARGED',
+          paymentId: paymentId,
+          enforceDynamicRoutingFailure: null,
+          isSmartRetry: true,
+        })
+        setResult({ ...res, decided_gateway: retryGateway })
+        setSingleRunPaymentId(paymentId)
+      } else {
+        setResult(res)
+        setSingleRunPaymentId(paymentId)
+      }
+
+      markExplorerRunDataUpdated()
+    } catch (e: unknown) {
+      handleRunError(e, 'single')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function enableDebitRoutingForExplorer() {
+    if (!effectiveMerchantId) return setError('Sign in with a merchant-linked account to continue')
+    setLoading(true)
+    setError(null)
+    setSetupPrompt(null)
+
+    try {
+      await debitRoutingFlag.setDebitRoutingEnabled(true)
+    } catch (e: unknown) {
+      handleRunError(e, 'debit', 'Failed to enable debit routing')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function runDebitRouting() {
+    if (!effectiveMerchantId) return setError('Sign in with a merchant-linked account to continue')
+    if (!debitRoutingFlag.isEnabled) return openSetupPrompt('debit', 'Debit routing is disabled.')
+
+    const gateways = debitForm.eligible_gateways.split(',').map(s => s.trim()).filter(Boolean)
+    if (gateways.length === 0) return setError('Add at least one eligible gateway')
+
+    setLoading(true)
+    setError(null)
+    setSetupPrompt(null)
+    setDebitResult(null)
+    const paymentId = `debit_${Date.now()}`
+
+    try {
+      const res = await apiPost<DecideGatewayResponse>('/decide-gateway', {
+        merchantId: effectiveMerchantId,
+        paymentInfo: {
+          paymentId,
+          amount: parseFloat(debitForm.amount) || 1000,
+          currency: debitForm.currency,
+          paymentType: 'ORDER_PAYMENT',
+          paymentMethodType: 'CARD',
+          paymentMethod: 'DEBIT',
+          authType: debitForm.auth_type,
+          metadata: buildDebitRoutingMetadata(),
+        },
+        eligibleGatewayList: gateways,
+        rankingAlgorithm: 'NTW_BASED_ROUTING',
+        eliminationEnabled: false,
+      })
+
+      setDebitResult(res)
+      setDebitPaymentId(paymentId)
+      markExplorerRunDataUpdated()
+    } catch (e: unknown) {
+      handleRunError(e, 'debit')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function runSimulation() {
+    if (!effectiveMerchantId) return setError('Sign in with a merchant-linked account to continue')
+    if (routingConfigUnavailable) return setError('Routing key config unavailable. Fix /config/routing-keys and retry.')
+
+    const total = parseInt(simulationConfig.totalPayments) || 0
+
+    if (total <= 0) return setError('Total Payments must be greater than 0')
+
+    setIsSimulating(true)
+    setError(null)
+    setSetupPrompt(null)
+    setSimulationResults([])
+    simulationAbortRef.current = false
+
+    const gateways = form.eligible_gateways.split(',').map(s => s.trim()).filter(Boolean)
+    const results: SimulationResult[] = []
+    const MAX_CONSECUTIVE_ERRORS = 3
+    let consecutiveErrors = 0
+    let lastUIUpdate = 0
+
+    const isMultiObjective = form.ranking_algorithm === 'SR_MULTI_OBJECTIVE'
+
+    try {
+      for (let i = 0; i < total; i++) {
+        if (simulationAbortRef.current) break
+        const paymentId = `sim_${Date.now()}_${i}`
+
+        // Under SR_MULTI_OBJECTIVE, vary the cluster and amount per payment so
+        // the (mock) Hypersense cost lookup returns distinct costs and the
+        // multi-objective leg has meaningful choices to make. Form values still
+        // seed everything else (currency, eligible_gateways, etc).
+        const variant = isMultiObjective ? MULTI_OBJECTIVE_CLUSTER_VARIANTS[i % MULTI_OBJECTIVE_CLUSTER_VARIANTS.length] : null
+        const paymentMethodType = isMultiObjective ? 'CARD' : form.payment_method_type
+        const paymentMethod = variant ? variant.paymentMethod : form.payment_method
+        const cardBrand = variant ? variant.cardSwitchProvider : form.card_brand
+        const cardProgram = variant ? variant.cardProgram : form.card_program
+        const amount = isMultiObjective
+          ? Math.floor(10 + Math.random() * 991)
+          : (parseFloat(form.amount) || 1000)
+
+        try {
+          const decideRes = await apiPost<DecideGatewayResponse>('/decide-gateway', {
+            merchantId: effectiveMerchantId,
+            paymentInfo: {
+              paymentId: paymentId,
+              amount,
+              currency: form.currency,
+              paymentType: 'ORDER_PAYMENT',
+              paymentMethodType,
+              paymentMethod,
+              authType: form.auth_type,
+              cardBrand,
+              cardSwitchProvider: cardBrand,
+              cardType: paymentMethod,
+              cardProgram,
+            },
+            eligibleGatewayList: gateways,
+            rankingAlgorithm: 'SR_BASED_ROUTING',
+            enableMultiObjective: isMultiObjective,
+            eliminationEnabled: eliminationEnabled,
+          })
+
+          const decidedGateway = decideRes.decided_gateway
+          const gwRate = getGwSuccessRate(decidedGateway)
+          const isSuccess = Math.random() * 100 < gwRate
+          const failureMode = getGwFailureMode(decidedGateway)
+          const outcome: TransactionOutcome = isSuccess ? 'CHARGED' : (failureMode === 'timeout' ? 'PENDING_VBV' : 'FAILURE')
+
+          const scoreRes = await apiPost<UpdateScoreResponse>('/update-gateway-score', {
+            merchantId: effectiveMerchantId,
+            gateway: decidedGateway,
+            gatewayReferenceId: null,
+            status: outcome,
+            paymentId: paymentId,
+            enforceDynamicRoutingFailure: null,
+            ...(outcome === 'FAILURE' && { errorInfo: buildSimErrorInfo(decidedGateway) }),
+          })
+
+          let retryGateway: string | undefined
+          let retryStatus: TransactionOutcome | undefined
+
+          if (
+            smartRetryEnabled &&
+            gsmScoringFilterEnabled &&
+            outcome === 'FAILURE' &&
+            scoreRes.gsm_info?.decision === 'retry' &&
+            decideRes.fallback_gateways.length > 0
+          ) {
+            retryGateway = decideRes.fallback_gateways[0]
+            const retryGwRate = getGwSuccessRate(retryGateway)
+            const retrySuccess = Math.random() * 100 < retryGwRate
+            const retryFailureMode = getGwFailureMode(retryGateway)
+            retryStatus = retrySuccess ? 'CHARGED' : (retryFailureMode === 'timeout' ? 'PENDING_VBV' : 'FAILURE')
+            await apiPost('/update-gateway-score', {
+              merchantId: effectiveMerchantId,
+              gateway: retryGateway,
+              gatewayReferenceId: null,
+              status: retryStatus,
+              paymentId: paymentId,
+              enforceDynamicRoutingFailure: null,
+              isSmartRetry: true,
+              ...(retryStatus === 'FAILURE' && { errorInfo: buildSimErrorInfo(retryGateway) }),
+            })
+          }
+
+          const mo = decideRes.multi_objective_info ?? null
+          results.push({
+            paymentId,
+            decidedGateway,
+            status: outcome,
+            timestamp: new Date().toISOString(),
+            routingApproach: decideRes.routing_approach ?? null,
+            gatewayPriorityMap: decideRes.gateway_priority_map ?? null,
+            retryGateway,
+            retryStatus,
+            costSavedBps: mo?.costSavedBps ?? null,
+            costWon: mo?.outcome === 'COST_WON',
+            tolerancePp: mo?.tolerancePp ?? null,
+            amount,
+            currency: form.currency,
+          })
+
+          consecutiveErrors = 0
+
+          const now = Date.now()
+          if (now - lastUIUpdate > 150 || i === total - 1) {
+            setSimulationResults([...results])
+            markExplorerRunDataUpdated()
+            lastUIUpdate = now
+          }
+        } catch (e: unknown) {
+          consecutiveErrors++
+          if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+            handleRunError(e, 'batch', `Simulation stopped after ${MAX_CONSECUTIVE_ERRORS} consecutive backend errors. Check that the server is running.`)
+            return
+          }
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          continue
+        }
+      }
+    } finally {
+      setSimulationResults([...results])
+      setIsSimulating(false)
+    }
+  }
+
+  async function runRuleEvaluation() {
+    if (routingConfigUnavailable) return setError('Routing key config unavailable. Fix /config/routing-keys and retry.')
+    setLoading(true)
+    setError(null)
+    setSetupPrompt(null)
+    setRuleResult(null)
+    setVolumeDistribution([])
+    setVolumeEvaluationLog([])
+    setVolumeProgress(0)
+    const previewPaymentId = `rule_decision_${Date.now()}`
+
+    try {
+      const parameters: Record<string, { type: string; value: string | number | { key: string; value: string } }> = {}
+      ruleParams.forEach(p => {
+        if (p.key) {
+          if (p.type === 'metadata_variant') {
+            parameters[p.key] = {
+              type: p.type,
+              value: { key: p.metadataKey || p.key, value: p.value }
+            }
+          } else if (p.type === 'number') {
+            parameters[p.key] = { type: p.type, value: parseFloat(p.value) || 0 }
+          } else if (p.value !== '') {
+            parameters[p.key] = { type: p.type, value: p.value }
+          }
+        }
+      })
+
+      const res = await apiPost<RuleEvaluateResponse>('/routing/evaluate', {
+        created_by: effectiveMerchantId || 'test_user',
+        payment_id: previewPaymentId,
+        fallback_output: fallbackConnectors.filter(c => c.gateway_name),
+        parameters,
+      })
+
+      setRuleResult(res)
+      markExplorerRunDataUpdated()
+
+      if (res.output.type === 'volume_split' && res.output.splits) {
+        const totalPayments = parseInt(volumePayments) || 100
+        const distribution = res.output.splits.map(item => ({
+          name: item.connector.gateway_name,
+          count: Math.round((item.split / 100) * totalPayments),
+          percentage: item.split,
+        }))
+        setVolumeDistribution(distribution)
+      }
+    } catch (e: unknown) {
+      handleRunError(e, 'rule')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function runVolumeSplit() {
+    if (!effectiveMerchantId) return setError('Sign in with a merchant-linked account to continue')
+    setLoading(true)
+    setError(null)
+    setSetupPrompt(null)
+    setRuleResult(null)
+    setVolumeDistribution([])
+    setVolumeEvaluationLog([])
+    setVolumeProgress(0)
+    const totalPayments = parseInt(volumePayments) || 0
+
+    if (totalPayments <= 0) {
+      setLoading(false)
+      return setError('Total Payments must be greater than 0')
+    }
+
+    try {
+      const batchSize = 10
+      const basePaymentId = `volume_decision_${Date.now()}`
+      const logEntries: VolumePaymentEntry[] = []
+      const counts = new Map<string, number>()
+      let firstDecision: RuleEvaluateResponse | null = null
+      const buildDistribution = (completedPayments: number) =>
+        Array.from(counts.entries())
+          .map(([name, count]) => ({
+            name,
+            count,
+            percentage: Number(((count / Math.max(1, completedPayments)) * 100).toFixed(1)),
+          }))
+          .sort((left, right) => right.count - left.count)
+
+      for (let start = 0; start < totalPayments; start += batchSize) {
+        const chunkSize = Math.min(batchSize, totalPayments - start)
+        const chunkResponses = await Promise.all(
+          Array.from({ length: chunkSize }, async (_, offset) => {
+            const index = start + offset
+            const paymentId = `${basePaymentId}_${index}`
+            const response = await apiPost<RuleEvaluateResponse>('/routing/evaluate', {
+              created_by: effectiveMerchantId,
+              payment_id: paymentId,
+              fallback_output: fallbackConnectors.filter(c => c.gateway_name),
+              parameters: {},
+            })
+
+            return { paymentId, response }
+          }),
+        )
+
+        for (const { paymentId, response } of chunkResponses) {
+          if (response.output.type !== 'volume_split') {
+            throw new Error('Active routing algorithm is not a volume split rule.')
+          }
+
+          const connector = extractVolumeConnector(response)
+          if (!connector) {
+            throw new Error('Volume split evaluation did not return a connector.')
+          }
+
+          if (!firstDecision) {
+            firstDecision = response
+            setRuleResult(response)
+          }
+
+          counts.set(connector, (counts.get(connector) || 0) + 1)
+          logEntries.push({ paymentId, connector })
+        }
+
+        setVolumeProgress(logEntries.length)
+        setVolumeEvaluationLog([...logEntries])
+        setVolumeDistribution(buildDistribution(logEntries.length))
+        markExplorerRunDataUpdated()
+      }
+    } catch (e: unknown) {
+      handleRunError(e, 'volume')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const scoreData = result?.gateway_priority_map
+    ? Object.entries(result.gateway_priority_map)
+      .sort(([, a], [, b]) => b - a)
+      .map(([name, score]) => ({ name, score: Math.round(score * 1000) / 10 }))
+    : []
+
+  const totalSimulationPayments = parseInt(simulationConfig.totalPayments) || 0
+  const completedSimulationCount = simulationResults.length
+  const simulationProgressPercentage =
+    totalSimulationPayments > 0
+      ? Math.round((completedSimulationCount / totalSimulationPayments) * 100)
+      : 0
+  const hasSimulationActivity = isSimulating || completedSimulationCount > 0
+
+  const eligibleGatewaysParsed = useMemo(
+    () => form.eligible_gateways.split(',').map(s => s.trim().toLowerCase()).filter(Boolean),
+    [form.eligible_gateways],
+  )
+
+  const gatewayColorMap = useMemo(
+    () => Object.fromEntries(eligibleGatewaysParsed.map((gw, i) => [gw, GW_PALETTE[i % GW_PALETTE.length]])),
+    [eligibleGatewaysParsed],
+  )
+
+  // Auto-populate errorInfo for any gateway whose config has no error code yet,
+  // once GSM rules have loaded from the API.
+  useEffect(() => {
+    if (gsmRules.length === 0 || eligibleGatewaysParsed.length === 0) return
+    setGatewaySimConfigs(prev => {
+      let changed = false
+      const next = { ...prev }
+      for (const gw of eligibleGatewaysParsed) {
+        if (prev[gw]?.errorInfo?.error_code) continue
+        const config = prev[gw] ?? { ...DEFAULT_GW_SIM_CONFIG }
+        const resolved = resolveSimErrorInfo(gw, config.gsmDecision, config.penalized)
+        if (resolved) {
+          next[gw] = { ...config, errorInfo: { error_code: resolved.errorCode, error_message: resolved.errorMessage, issuer_error_code: '', card_network: '' } }
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [gsmRules, eligibleGatewaysParsed])
+
+  const gatewayStats = useMemo(() => deferredSimulationResults.reduce((acc, curr) => {
+    if (!acc[curr.decidedGateway]) {
+      acc[curr.decidedGateway] = { total: 0, success: 0, failure: 0 }
+    }
+    acc[curr.decidedGateway].total++
+    if (curr.status === 'CHARGED') acc[curr.decidedGateway].success++
+    else acc[curr.decidedGateway].failure++
+    return acc
+  }, {} as Record<string, { total: number; success: number; failure: number }>), [deferredSimulationResults])
+
+  // Latest SR score the routing engine assigned to each gateway (gatewayPriorityMap),
+  // i.e. the "real" success rate plotted in the trend chart — not the observed success/total ratio.
+  const gatewaySrScores = useMemo(() => {
+    const scores: Record<string, number> = {}
+    for (const r of deferredSimulationResults) {
+      if (r.routingApproach?.includes('HEDGING') || !r.gatewayPriorityMap) continue
+      for (const [gw, score] of Object.entries(r.gatewayPriorityMap)) {
+        if (score !== undefined && score !== null) scores[gw] = Math.round((score as number) * 100)
+      }
+    }
+    return scores
+  }, [deferredSimulationResults])
+
+  // Live cost-optimisation tolerance band (pp) — the most recent value the router reported
+  // for this run, falling back to the configured default when no decision carried one.
+  const costRoutingTolerancePp = useMemo(() => {
+    for (let i = deferredSimulationResults.length - 1; i >= 0; i--) {
+      const t = deferredSimulationResults[i].tolerancePp
+      if (t != null) return t
+    }
+    return DEFAULT_COST_ROUTING_TOLERANCE
+  }, [deferredSimulationResults])
+
+  // Single forward pass: carry the last seen non-hedging score for each gateway forward,
+  // sampling every `step` results. O(n) vs the previous O(n × MAX_PTS) backward search.
+  const gatewaySparklines = useMemo(() => {
+    const results = deferredSimulationResults
+    const empty = { series: {} as Record<string, number[]>, paymentNums: [] as number[], yMin: 0, yMax: 100 }
+    if (results.length < 2) return empty
+
+    const MAX_PTS = 200
+    const step = Math.max(1, Math.floor(results.length / MAX_PTS))
+    const gateways = Object.keys(gatewayStats)
+    const lastScore: Record<string, number> = {}
+    const series: Record<string, number[]> = {}
+    gateways.forEach(gw => { series[gw] = [] })
+    const paymentNums: number[] = []
+
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i]
+      if (!r.routingApproach?.includes('HEDGING') && r.gatewayPriorityMap) {
+        for (const gw of gateways) {
+          const score = r.gatewayPriorityMap[gw]
+          if (score !== undefined && score !== null) lastScore[gw] = Math.round(score * 100)
+        }
+      }
+      if (i % step === 0 || i === results.length - 1) {
+        paymentNums.push(i + 1)
+        for (const gw of gateways) series[gw].push(lastScore[gw] ?? 0)
+      }
+    }
+
+    // Compute y-axis range here to avoid flatMap+spread in render
+    let obsMin = 100, obsMax = 0
+    for (const gw of gateways) {
+      for (const v of series[gw]) {
+        if (v > 0) { if (v < obsMin) obsMin = v; if (v > obsMax) obsMax = v }
+      }
+    }
+    if (obsMin > obsMax) { obsMin = 0; obsMax = 100 }
+    const yMin = Math.max(0, obsMin - 2)
+    const yMax = Math.min(100, obsMax + 2)
+
+    return { series, paymentNums, yMin, yMax }
+  }, [deferredSimulationResults, gatewayStats])
+
+  const hedgingHits = useMemo(
+    () => deferredSimulationResults.filter(r => r.routingApproach?.includes('HEDGING')).length,
+    [deferredSimulationResults],
+  )
+
+  const smartRetryStats = useMemo(() => {
+    const triggered = deferredSimulationResults.filter(r => r.retryGateway !== undefined).length
+    const recovered = deferredSimulationResults.filter(r => r.retryStatus === 'CHARGED').length
+    return { triggered, recovered }
+  }, [deferredSimulationResults])
+
+  const totalCostSaved = useMemo(() => {
+    let value = 0
+    let currency = ''
+    for (const r of deferredSimulationResults) {
+      if (r.costWon && r.costSavedBps != null && r.costSavedBps > 0 && r.status === 'CHARGED') {
+        value += (r.costSavedBps / 10000) * r.amount
+        currency = r.currency
+      }
+    }
+    return { value, currency }
+  }, [deferredSimulationResults])
+
+  const debitNetworkRows = debitResult?.debit_routing_output?.co_badged_card_networks_info || []
+  const volumeColorIndex = useMemo(
+    () => new Map(volumeDistribution.map((item, index) => [item.name, index] as const)),
+    [volumeDistribution],
+  )
+  const sortedGatewayStats = useMemo(
+    () => Object.entries(gatewayStats).sort((a, b) => b[1].total - a[1].total),
+    [gatewayStats],
+  )
+  const totalRoutedPayments = useMemo(
+    () => Object.values(gatewayStats).reduce((s, g) => s + g.total, 0),
+    [gatewayStats],
+  )
+  const sortedVolumeDistribution = useMemo(
+    () => [...volumeDistribution].sort((a, b) => b.count - a.count),
+    [volumeDistribution],
+  )
+  const volumeLeader = sortedVolumeDistribution[0]
+  const volumeEvaluationCount = volumeEvaluationLog.length
+  const volumeRunTarget = Number.parseInt(volumePayments, 10) || 0
+  const volumeProgressPercentage =
+    volumeRunTarget > 0 ? Math.min(100, Math.round((volumeProgress / volumeRunTarget) * 100)) : 0
+
+  const auditSummary = useMemo(() => {
+    const results = auditDetail.data?.results || []
+    return results.find((row) => row.payment_id === selectedAuditPaymentId) || results[0] || null
+  }, [auditDetail.data?.results, selectedAuditPaymentId])
+
+  const selectedAuditEvent = useMemo(() => {
+    const timeline = auditDetail.data?.timeline || []
+    return timeline.find((event) => event.id === selectedAuditEventId) || timeline[0] || null
+  }, [auditDetail.data?.timeline, selectedAuditEventId])
+
+  useEffect(() => {
+    if (selectedAuditEvent?.id) {
+      setSelectedAuditEventId(selectedAuditEvent.id)
+      return
+    }
+    const first = auditDetail.data?.timeline?.[0]
+    if (first?.id) {
+      setSelectedAuditEventId(first.id)
+    }
+  }, [auditDetail.data?.timeline, selectedAuditEvent?.id])
+
+  const groupedAuditTimeline = useMemo(() => {
+    const groups: Array<{ phase: string; events: PaymentAuditEvent[] }> = []
+    for (const event of auditDetail.data?.timeline || []) {
+      const phase = eventPhase(event)
+      const current = groups[groups.length - 1]
+      if (!current || current.phase !== phase) {
+        groups.push({ phase, events: [event] })
+      } else {
+        current.events.push(event)
+      }
+    }
+    return groups
+  }, [auditDetail.data?.timeline])
+
+  const auditInspectorModel = useMemo(() => buildInspectorModel(selectedAuditEvent), [selectedAuditEvent])
+
+  const previewSummary = useMemo(() => {
+    const results = previewTraceDetail.data?.results || []
+    return results.find((row) => row.payment_id === selectedPreviewPaymentId) || results[0] || null
+  }, [previewTraceDetail.data?.results, selectedPreviewPaymentId])
+
+  const selectedPreviewEvent = useMemo(() => {
+    const timeline = previewTraceDetail.data?.timeline || []
+    return timeline.find((event) => event.id === selectedPreviewEventId) || timeline[0] || null
+  }, [previewTraceDetail.data?.timeline, selectedPreviewEventId])
+
+  useEffect(() => {
+    if (selectedPreviewEvent?.id) {
+      setSelectedPreviewEventId(selectedPreviewEvent.id)
+      return
+    }
+    const first = previewTraceDetail.data?.timeline?.[0]
+    if (first?.id) {
+      setSelectedPreviewEventId(first.id)
+    }
+  }, [previewTraceDetail.data?.timeline, selectedPreviewEvent?.id])
+
+  const groupedPreviewTimeline = useMemo(() => {
+    const groups: Array<{ phase: string; events: PaymentAuditEvent[] }> = []
+    for (const event of previewTraceDetail.data?.timeline || []) {
+      const phase = eventPhase(event)
+      const current = groups[groups.length - 1]
+      if (!current || current.phase !== phase) {
+        groups.push({ phase, events: [event] })
+      } else {
+        current.events.push(event)
+      }
+    }
+    return groups
+  }, [previewTraceDetail.data?.timeline])
+
+  const previewInspectorModel = useMemo(() => buildInspectorModel(selectedPreviewEvent), [selectedPreviewEvent])
+
+
+  useEffect(() => {
+    const el = txLogRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [deferredSimulationResults.length])
+
+
+  function openAuditModal(paymentId: string) {
+    setSelectedPreviewPaymentId(null)
+    setSelectedPreviewEventId(null)
+    setPreviewInspectorTab('summary')
+    setSelectedAuditPaymentId(paymentId)
+    setSelectedAuditEventId(null)
+    setAuditInspectorTab('summary')
+  }
+
+  function closeAuditModal() {
+    setSelectedAuditPaymentId(null)
+    setSelectedAuditEventId(null)
+    setAuditInspectorTab('summary')
+  }
+
+  function openPreviewModal(paymentId: string, label: string) {
+    setSelectedAuditPaymentId(null)
+    setSelectedAuditEventId(null)
+    setAuditInspectorTab('summary')
+    setPreviewTraceLabel(label)
+    setSelectedPreviewPaymentId(paymentId)
+    setSelectedPreviewEventId(null)
+    setPreviewInspectorTab('summary')
+  }
+
+  function closePreviewModal() {
+    setSelectedPreviewPaymentId(null)
+    setSelectedPreviewEventId(null)
+    setPreviewInspectorTab('summary')
+  }
+
+  function resetCurrentTabState() {
+    const defaults = getDefaultExplorerState()
+
+    // Reset form fields to the first available option from routing config so
+    // required fields like currency are never sent as empty strings.
+    function populatedForm(base: FormState): FormState {
+      const next = { ...base }
+      if (currencyOptions.length > 0 && !currencyOptions.includes(next.currency))
+        next.currency = currencyOptions[0]
+      if (paymentMethodTypeOptions.length > 0 && !paymentMethodTypeOptions.includes(next.payment_method_type))
+        next.payment_method_type = paymentMethodTypeOptions[0]
+      const methodsForType = toUpperOptions(routingKeysConfig[next.payment_method_type.toLowerCase()]?.values || [])
+      if (methodsForType.length > 0 && !methodsForType.includes(next.payment_method))
+        next.payment_method = methodsForType[0]
+      if (authTypeOptions.length > 0 && !authTypeOptions.includes(next.auth_type))
+        next.auth_type = authTypeOptions[0]
+      if (cardBrandOptions.length > 0 && !cardBrandOptions.includes(next.card_brand))
+        next.card_brand = cardBrandOptions[0]
+      return next
+    }
+
+    if (activeTab === 'single') {
+      setForm(populatedForm(defaults.form))
+      setResult(defaults.result)
+      setSingleRunPaymentId(defaults.singleRunPaymentId)
+      setSingleRunOutcome(defaults.singleRunOutcome)
+      setResponseOpen(defaults.responseOpen)
+    } else if (activeTab === 'batch') {
+      setForm({ ...populatedForm(defaults.form), currency: MULTI_OBJECTIVE_CURRENCY })
+      setSimulationConfig(defaults.simulationConfig)
+      setGatewaySimConfigs({})
+      setSimulationResults(defaults.simulationResults)
+      setIsSimulating(false)
+    } else if (activeTab === 'rule') {
+      setRuleResetSignal(n => n + 1)
+    } else if (activeTab === 'volume') {
+      setVolumePayments(defaults.volumePayments)
+      setRuleResult(defaults.ruleResult)
+      setVolumeDistribution(defaults.volumeDistribution)
+      setVolumeEvaluationLog(defaults.volumeEvaluationLog)
+      setVolumeProgress(defaults.volumeProgress)
+      setVolumeResponseOpen(defaults.volumeResponseOpen)
+      setSelectedPreviewPaymentId(null)
+      setSelectedPreviewEventId(null)
+      setPreviewInspectorTab('summary')
+      setPreviewTraceLabel('Volume Split Decision')
+    } else if (activeTab === 'debit') {
+      setDebitForm(defaults.debitForm)
+      setDebitResult(defaults.debitResult)
+      setDebitPaymentId(defaults.debitPaymentId)
+      setDebitResponseOpen(defaults.debitResponseOpen)
+      setSelectedAuditPaymentId(null)
+      setSelectedAuditEventId(null)
+      setAuditInspectorTab('summary')
+    }
+
+    setError(null)
+    setSetupPrompt(null)
+    setLoading(false)
+    setFilterOpen(false)
+    setSelectedAuditPaymentId(null)
+    setSelectedAuditEventId(null)
+    setAuditInspectorTab('summary')
+  }
+
+  const resetButtonLabel =
+    activeTab === 'batch'
+      ? 'Reset Multi Objective Routing'
+      : activeTab === 'rule'
+        ? 'Reset Rule Based Routing'
+        : activeTab === 'volume'
+          ? 'Reset Volume Based Routing'
+          : 'Reset Debit Routing'
+
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-5">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <SurfaceLabel>Simulation console</SurfaceLabel>
+          <div className="mt-2 flex flex-wrap items-center gap-3">
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">Decision Explorer</h1>
+            <Badge variant="blue">{effectiveMerchantId || 'No merchant'}</Badge>
+          </div>
+        </div>
+        <Button size="sm" variant="secondary" onClick={resetCurrentTabState}>
+          <RefreshCw size={14} />
+          {resetButtonLabel}
+        </Button>
+      </div>
+
+      {activeTab === 'rule' && (
+        <RuleEvaluationPanel
+          merchantId={effectiveMerchantId}
+          routingKeysConfig={routingKeysConfig}
+          routingConfigUnavailable={routingConfigUnavailable}
+          routingKeysLoading={routingKeysLoading}
+          resetSignal={ruleResetSignal}
+          onRunComplete={markExplorerRunDataUpdated}
+          onOpenTrace={openPreviewModal}
+        />
+      )}
+
+      {activeTab === 'batch' && (
+        <div className="flex flex-wrap items-end gap-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 dark:border-[#222226] dark:bg-[#0b0b10]">
+          {[
+            { key: 'stripe', label: 'Stripe success rate' },
+            { key: 'adyen', label: 'Adyen success rate' },
+          ].map(({ key, label }) => {
+            const color = gatewayColorMap[key] ?? GW_PALETTE[0]
+            const rate = getGwSuccessRate(key)
+            return (
+              <div key={key} className="flex w-[190px] flex-col gap-1.5">
+                <div className="flex items-center gap-1.5">
+                  <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: color }} />
+                  <SurfaceLabel>{label}</SurfaceLabel>
+                </div>
+                <input
+                  type="text"
+                  value={`${rate}%`}
+                  onChange={e => setGwSuccessRate(key, Math.max(0, Math.min(100, parseInt(e.target.value.replace(/\D/g, ''), 10) || 0)))}
+                  className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm font-semibold text-slate-800 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0d0d13] dark:text-slate-100"
+                />
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={rate}
+                  onChange={e => setGwSuccessRate(key, Number(e.target.value))}
+                  className="h-1 w-full cursor-pointer"
+                  style={{ accentColor: color }}
+                />
+              </div>
+            )
+          })}
+
+          <div className="flex min-w-[240px] flex-1 flex-col gap-1.5">
+            <SurfaceLabel>Experiment variables</SurfaceLabel>
+            <p className="py-1.5 text-sm leading-snug text-slate-700 dark:text-slate-200">
+              {EXPERIMENT_NOTE}
+            </p>
+          </div>
+
+          <Button
+            onClick={isSimulating ? () => { simulationAbortRef.current = true } : runSimulation}
+            disabled={!effectiveMerchantId || routingConfigUnavailable}
+            variant={isSimulating ? 'secondary' : 'primary'}
+            className="ml-auto self-end"
+          >
+            {isSimulating ? <><X size={14} /> Stop</> : <><Play size={14} className="fill-current" /> Run simulation</>}
+          </Button>
+        </div>
+      )}
+
+      <div className={activeTab === 'volume'
+        ? 'grid grid-cols-1 gap-5 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]'
+        : activeTab === 'batch'
+          ? 'grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)]'
+          : 'grid grid-cols-1 gap-6 lg:grid-cols-2'
+      }
+        style={activeTab === 'rule' ? { display: 'none' } : undefined}
+      >
+        <div className={`flex flex-col gap-6 min-w-0 ${activeTab === 'batch' ? '' : 'self-start'}`}>
+        {activeTab === 'batch' && (
+                <Card className="flex-1">
+                  <CardHeader className="!py-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <h3 className="text-sm font-medium text-slate-800 dark:text-white">Gateway Selection Summary</h3>
+                      <div className="flex items-center gap-1.5">
+                        {totalSimulationPayments > 0 && (() => {
+                          const r = 6
+                          const circ = 2 * Math.PI * r
+                          const offset = circ * (1 - simulationProgressPercentage / 100)
+                          return (
+                            <svg width="16" height="16" viewBox="0 0 16 16" className="-rotate-90">
+                              <circle cx="8" cy="8" r={r} fill="none" strokeWidth="2" className="stroke-slate-200 dark:stroke-slate-700" />
+                              <circle
+                                cx="8" cy="8" r={r} fill="none" strokeWidth="2" strokeLinecap="round"
+                                strokeDasharray={circ} strokeDashoffset={offset}
+                                className="stroke-brand-500 transition-[stroke-dashoffset] duration-300"
+                              />
+                            </svg>
+                          )
+                        })()}
+                        <span className="text-[11px] text-slate-500 dark:text-slate-400">
+                          {completedSimulationCount} / {totalSimulationPayments || 0}
+                        </span>
+                        {completedSimulationCount > 0 && (
+                          <>
+                            <span className="text-slate-300 dark:text-slate-600">·</span>
+                            {hedgingHits > 0 ? (
+                              <span className="text-[11px] font-medium text-brand-600 dark:text-sky-400">
+                                {Math.round((hedgingHits / completedSimulationCount) * 100)}% hedged
+                              </span>
+                            ) : (
+                              <UiTooltip text="Enable ENABLE_EXPLORE_AND_EXPLOIT_ON_SRV3_{PMT} or ENABLE_MERCHANT_ON_VOLUME_DISTRIBUTION_FEATURE_SR_V3 in Redis">
+                                <span className="text-[11px] text-amber-500 dark:text-amber-400 cursor-help">0 hedged</span>
+                              </UiTooltip>
+                            )}
+                            {smartRetryEnabled && smartRetryStats.triggered > 0 && (
+                              <>
+                                <span className="text-slate-300 dark:text-slate-600">·</span>
+                                <UiTooltip text={`${smartRetryStats.triggered} retries triggered · ${smartRetryStats.recovered} recovered`}>
+                                  <span className="text-[11px] font-medium text-orange-500 dark:text-orange-400 cursor-help">
+                                    {smartRetryStats.triggered} retried · {smartRetryStats.recovered} recovered
+                                  </span>
+                                </UiTooltip>
+                              </>
+                            )}
+                            {totalCostSaved.value > 0 && totalCostSaved.currency && (
+                              <>
+                                <span className="text-slate-300 dark:text-slate-600">·</span>
+                                <span className="text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+                                  saved {formatCurrencyValue(totalCostSaved.value, totalCostSaved.currency)}
+                                </span>
+                              </>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardBody className="!pt-3 flex flex-1 flex-col">
+                    {sortedGatewayStats.length > 0 ? (() => {
+                      const totalRouted = totalRoutedPayments
+                      const sortedGateways = sortedGatewayStats
+                      const hasAnySpark = sortedGateways.some(([gw]) => (gatewaySparklines.series[gw]?.length ?? 0) >= 2)
+                      return (
+                        <div className="flex flex-1 flex-col gap-4">
+                          {/* per-gateway stat rows */}
+                          <div className="space-y-2">
+                            {sortedGateways.map(([gateway, stats]) => {
+                              const share = totalRouted > 0 ? Math.round((stats.total / totalRouted) * 100) : 0
+                              const observedSr = stats.total > 0 ? Math.round((stats.success / stats.total) * 100) : 0
+                              const srPct = gatewaySrScores[gateway] ?? observedSr
+                              const gwColor = gatewayColorMap[gateway] ?? GW_PALETTE[0]
+                              return (
+                                <div key={gateway} className="space-y-1">
+                                  <div className="flex items-center justify-end gap-1.5">
+                                    <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: gwColor }} />
+                                    <span className="text-xs font-semibold text-slate-700 dark:text-slate-200 truncate shrink-0 w-14 text-left">{gateway}</span>
+                                    <span className={`font-bold tabular-nums text-[11px] w-14 text-right ${srPct >= 80 ? 'text-emerald-600 dark:text-emerald-400' : srPct >= 50 ? 'text-amber-500' : 'text-red-500'}`}>{srPct}% SR</span>
+                                    <span className="text-slate-300 dark:text-slate-600 text-[11px]">·</span>
+                                    <span className="text-slate-400 dark:text-slate-500 tabular-nums text-[11px] w-16 text-right">{share}% routed</span>
+                                    <span className="text-slate-300 dark:text-slate-600 text-[11px]">·</span>
+                                    <span className="tabular-nums text-slate-500 dark:text-slate-400 text-[11px] w-12 text-right">
+                                      <span className="text-emerald-600 dark:text-emerald-400">{stats.success}</span>
+                                      <span className="text-slate-300 dark:text-slate-600 mx-0.5">/</span>
+                                      <span className="text-red-400">{stats.failure}</span>
+                                    </span>
+                                  </div>
+                                </div>
+                              )
+                            })}
+                          </div>
+                          {/* combined multi-line SR trend chart */}
+                          {hasAnySpark && (() => {
+                            const { series, paymentNums } = gatewaySparklines
+                            const chartData = paymentNums.map((n, i) => {
+                              const row: Record<string, number> = { step: n }
+                              sortedGateways.forEach(([gw]) => {
+                                const v = series[gw]?.[i]
+                                if (v != null) row[gw] = v
+                              })
+                              return row
+                            })
+                            // Cost-based routing is eligible for gateways whose SR sits within the
+                            // auth-rate tolerance band of the best gateway's SR — shade that band as
+                            // the eligible area, with a dotted line at its lower threshold. The band
+                            // width comes from the live cost-optimisation tolerance, stored as a
+                            // fraction (e.g. 0.2 = 20 percentage points) so scale it to the 0–100 SR axis.
+                            const srScores = sortedGateways
+                              .map(([gw]) => gatewaySrScores[gw])
+                              .filter((v): v is number => v != null)
+                            const bestSr = srScores.length ? Math.max(...srScores) : null
+                            const bandPp = costRoutingTolerancePp * 100
+                            const costBandThreshold = bestSr != null ? Math.max(0, bestSr - bandPp) : null
+                            return (
+                              <div className="w-full flex-1 min-h-[300px]">
+                                <ResponsiveContainer width="100%" height="100%">
+                                  <LineChart data={chartData} margin={{ top: 16, right: 8, bottom: 20, left: 0 }}>
+                                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:opacity-20" vertical={false} />
+                                    {costBandThreshold != null && (
+                                      <ReferenceArea
+                                        y1={costBandThreshold}
+                                        y2={100}
+                                        fill="#10b981"
+                                        fillOpacity={0.08}
+                                        ifOverflow="extendDomain"
+                                      />
+                                    )}
+                                    {costBandThreshold != null && (
+                                      <ReferenceLine
+                                        y={costBandThreshold}
+                                        stroke="#10b981"
+                                        strokeDasharray="4 4"
+                                        strokeWidth={1.5}
+                                        label={{ value: `Cost-based eligible ≥ ${costBandThreshold.toFixed(costBandThreshold % 1 ? 1 : 0)}% (${bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp band)`, position: 'insideTopLeft', fontSize: 10, fill: '#059669' }}
+                                      />
+                                    )}
+                                    <XAxis
+                                      dataKey="step"
+                                      tick={{ fontSize: 11, fill: '#94a3b8' }}
+                                      tickLine={false}
+                                      axisLine={{ stroke: '#e2e8f0' }}
+                                      minTickGap={28}
+                                      label={{ value: 'Number of Transactions', position: 'insideBottom', offset: -12, fontSize: 11, fill: '#94a3b8' }}
+                                    />
+                                    <YAxis
+                                      domain={[0, 100]}
+                                      tick={{ fontSize: 11, fill: '#94a3b8' }}
+                                      tickLine={false}
+                                      axisLine={{ stroke: '#e2e8f0' }}
+                                      width={44}
+                                      tickFormatter={(v: number) => `${v}%`}
+                                    />
+                                    <Tooltip
+                                      contentStyle={CHART_TOOLTIP_STYLE}
+                                      labelStyle={CHART_TOOLTIP_LABEL_STYLE}
+                                      itemStyle={CHART_TOOLTIP_ITEM_STYLE}
+                                      formatter={(value: number, name: string) => [`${value}%`, name]}
+                                      labelFormatter={(l) => `Payment ${l}`}
+                                    />
+                                    {sortedGateways.map(([gw]) => (
+                                      <Line
+                                        key={gw}
+                                        type="natural"
+                                        dataKey={gw}
+                                        name={gw}
+                                        stroke={gatewayColorMap[gw] ?? GW_PALETTE[0]}
+                                        strokeWidth={2.5}
+                                        dot={false}
+                                        isAnimationActive={false}
+                                        connectNulls
+                                      />
+                                    ))}
+                                  </LineChart>
+                                </ResponsiveContainer>
+                              </div>
+                            )
+                          })()}
+                        </div>
+                      )
+                    })() : (() => {
+                      // Pre-run preview: project flat SR lines from the configured
+                      // gateway success rates so the chart is visible on landing,
+                      // before any simulated payment has been routed.
+                      const previewGateways = eligibleGatewaysParsed
+                      if (previewGateways.length === 0) return null
+                      const previewScores = previewGateways.map(gw => ({ gw, sr: getGwSuccessRate(gw) }))
+                      const bestSr = previewScores.reduce((m, g) => Math.max(m, g.sr), 0)
+                      const bandPp = DEFAULT_COST_ROUTING_TOLERANCE * 100
+                      const costBandThreshold = Math.max(0, bestSr - bandPp)
+                      const target = totalSimulationPayments || Number(SIMULATION_TOTAL_PAYMENTS)
+                      const chartData = [1, target].map(step => {
+                        const row: Record<string, number> = { step }
+                        previewScores.forEach(({ gw, sr }) => { row[gw] = sr })
+                        return row
+                      })
+                      return (
+                        <div className="flex flex-1 flex-col gap-4">
+                          <div className="space-y-2">
+                            {previewScores.map(({ gw, sr }) => {
+                              const gwColor = gatewayColorMap[gw] ?? GW_PALETTE[0]
+                              return (
+                                <div key={gw} className="space-y-1">
+                                  <div className="flex items-center justify-end gap-1.5">
+                                    <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: gwColor }} />
+                                    <span className="text-xs font-semibold text-slate-700 dark:text-slate-200 truncate shrink-0 w-14 text-left">{gw}</span>
+                                    <span className={`font-bold tabular-nums text-[11px] w-14 text-right ${sr >= 80 ? 'text-emerald-600 dark:text-emerald-400' : sr >= 50 ? 'text-amber-500' : 'text-red-500'}`}>{sr}% SR</span>
+                                    <span className="text-slate-300 dark:text-slate-600 text-[11px]">·</span>
+                                    <span className="text-slate-400 dark:text-slate-500 tabular-nums text-[11px] w-16 text-right">0% routed</span>
+                                  </div>
+                                </div>
+                              )
+                            })}
+                          </div>
+                          <div className="w-full flex-1 min-h-[300px]">
+                            <ResponsiveContainer width="100%" height="100%">
+                              <LineChart data={chartData} margin={{ top: 16, right: 8, bottom: 20, left: 0 }}>
+                                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:opacity-20" vertical={false} />
+                                <ReferenceArea y1={costBandThreshold} y2={100} fill="#10b981" fillOpacity={0.08} ifOverflow="extendDomain" />
+                                <ReferenceLine
+                                  y={costBandThreshold}
+                                  stroke="#10b981"
+                                  strokeDasharray="4 4"
+                                  strokeWidth={1.5}
+                                  label={{ value: `Cost-based eligible ≥ ${costBandThreshold.toFixed(costBandThreshold % 1 ? 1 : 0)}% (${bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp band)`, position: 'insideTopLeft', fontSize: 10, fill: '#059669' }}
+                                />
+                                <XAxis
+                                  dataKey="step"
+                                  tick={{ fontSize: 11, fill: '#94a3b8' }}
+                                  tickLine={false}
+                                  axisLine={{ stroke: '#e2e8f0' }}
+                                  minTickGap={28}
+                                  label={{ value: 'Number of Transactions', position: 'insideBottom', offset: -12, fontSize: 11, fill: '#94a3b8' }}
+                                />
+                                <YAxis
+                                  domain={[0, 100]}
+                                  tick={{ fontSize: 11, fill: '#94a3b8' }}
+                                  tickLine={false}
+                                  axisLine={{ stroke: '#e2e8f0' }}
+                                  width={44}
+                                  tickFormatter={(v: number) => `${v}%`}
+                                />
+                                {previewScores.map(({ gw }) => (
+                                  <Line
+                                    key={gw}
+                                    type="monotone"
+                                    dataKey={gw}
+                                    name={gw}
+                                    stroke={gatewayColorMap[gw] ?? GW_PALETTE[0]}
+                                    strokeWidth={2.5}
+                                    strokeDasharray="5 4"
+                                    dot={false}
+                                    isAnimationActive={false}
+                                    connectNulls
+                                  />
+                                ))}
+                              </LineChart>
+                            </ResponsiveContainer>
+                          </div>
+                          <p className="pt-1 text-center text-[11px] text-slate-400">
+                            Projected from configured success rates · run a simulation to see live routing.
+                          </p>
+                        </div>
+                      )
+                    })()}
+                    {Object.keys(gatewayStats).length === 1 && eligibleGatewaysParsed.length > 1 && (
+                      <p className="text-[11px] text-slate-400 pt-1">
+                        SR routing concentrates traffic on the highest-scoring gateway. Run with a "Gateway Down" scenario to see score drop and traffic shift to the next gateway.
+                      </p>
+                    )}
+                  </CardBody>
+                </Card>
+        )}
+        {activeTab !== 'batch' && (
+        <Card className="!rounded-2xl">
+          <CardHeader className="!px-5 !py-4">
+            <div>
+              <SurfaceLabel>
+                {activeTab === 'rule' ? 'Rule Evaluation' :
+                  activeTab === 'volume' ? 'Volume Split' :
+                    activeTab === 'debit' ? 'Network Routing' :
+                      'Simulation'}
+              </SurfaceLabel>
+              <h2 className="mt-1.5 font-medium text-slate-800 dark:text-white">
+                {activeTab === 'rule' ? 'Rule Evaluation Parameters' :
+                  activeTab === 'volume' ? 'Volume Split Configuration' :
+                    activeTab === 'debit' ? 'Debit Routing Parameters' :
+                      'Auth-Rate Based Routing Parameters'}
+              </h2>
+            </div>
+          </CardHeader>
+          <CardBody className="space-y-3 !px-5 !py-4">
+            {!effectiveMerchantId && (
+              <p className="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                Set a merchant ID in the top bar first.
+              </p>
+            )}
+            {activeTab !== 'volume' && activeTab !== 'debit' && routingKeysLoading && (
+              <p className="text-xs text-slate-600 bg-slate-50 border border-slate-200 rounded px-3 py-2">
+                Loading routing config from backend...
+              </p>
+            )}
+            {activeTab !== 'volume' && activeTab !== 'debit' && routingConfigUnavailable && (
+              <ErrorMessage error="Routing config unavailable from /config/routing-keys. Parameter forms are disabled." />
+            )}
+
+            {activeTab === 'rule' ? (
+              <>
+                {routingKeysLoading && (
+                  <p className="text-sm text-slate-500">Loading routing keys from backend...</p>
+                )}
+                {routingConfigUnavailable && (
+                  <ErrorMessage error="Routing keys are unavailable from backend (/config/routing-keys). Rule Evaluation is disabled." />
+                )}
+
+                {/* Parameters */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-[#4e5870]">Parameters</p>
+                  </div>
+                  <div className="space-y-1.5">
+                    {ruleParams.map((param, idx) => (
+                      <div key={idx} className="space-y-1.5">
+                        <div className="group flex items-center gap-0 rounded-xl border border-slate-200 dark:border-[#1e2330] bg-white dark:bg-[#0c0f17] overflow-hidden transition-shadow hover:shadow-sm">
+                          <select
+                            value={param.key}
+                            onChange={e => updateRuleParamKey(idx, e.target.value)}
+                            disabled={routingConfigUnavailable || routingKeysLoading}
+                            className="flex-1 min-w-0 bg-transparent px-3 py-2.5 text-sm font-medium text-slate-700 dark:text-[#c8d0de] focus:outline-none cursor-pointer appearance-none"
+                          >
+                            {routingKeyNames.length === 0 ? (
+                              <option value="">No keys available</option>
+                            ) : (
+                              routingKeyNames.map(name => <option key={name} value={name}>{name}</option>)
+                            )}
+                          </select>
+                          <span className="shrink-0 border-x border-slate-100 dark:border-[#1e2330] bg-slate-50 dark:bg-[#10131c] px-2.5 py-2.5 text-[11px] font-bold text-slate-300 dark:text-[#3a4258] select-none">=</span>
+                          {param.type === 'enum_variant' ? (
+                            <select
+                              value={param.value}
+                              onChange={e => updateRuleParam(idx, 'value', e.target.value)}
+                              className="flex-1 min-w-0 bg-transparent px-3 py-2.5 text-sm text-slate-600 dark:text-[#a8b4c8] focus:outline-none cursor-pointer appearance-none"
+                            >
+                              {(routingKeysConfig[param.key]?.values || []).map(v => (
+                                <option key={v} value={v}>{v}</option>
+                              ))}
+                            </select>
+                          ) : param.type === 'number' ? (
+                            <input
+                              type="number"
+                              placeholder="Value"
+                              value={param.value}
+                              onChange={e => updateRuleParam(idx, 'value', e.target.value)}
+                              className="flex-1 min-w-0 bg-transparent px-3 py-2.5 text-sm text-slate-600 dark:text-[#a8b4c8] focus:outline-none"
+                            />
+                          ) : param.type !== 'metadata_variant' ? (
+                            <input
+                              placeholder="Value"
+                              value={param.value}
+                              onChange={e => updateRuleParam(idx, 'value', e.target.value)}
+                              className="flex-1 min-w-0 bg-transparent px-3 py-2.5 text-sm text-slate-600 dark:text-[#a8b4c8] focus:outline-none"
+                            />
+                          ) : (
+                            <span className="flex-1 px-3 py-2.5 text-sm text-slate-400 dark:text-[#3a4258] italic">see below</span>
+                          )}
+                          <button
+                            onClick={() => removeRuleParam(idx)}
+                            className="shrink-0 px-2.5 py-2.5 text-slate-300 dark:text-[#2a3040] hover:text-red-400 dark:hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                          >
+                            <Trash2 size={13} />
+                          </button>
+                        </div>
+                        {param.type === 'metadata_variant' && (
+                          <div className="ml-3 flex gap-1.5">
+                            <input
+                              placeholder="Metadata key"
+                              value={param.metadataKey || ''}
+                              onChange={e => updateRuleParamMetadataKey(idx, e.target.value)}
+                              className="flex-1 rounded-lg border border-slate-200 dark:border-[#1e2330] bg-white dark:bg-[#0c0f17] px-3 py-2 text-sm text-slate-600 dark:text-[#a8b4c8] focus:outline-none focus:ring-1 focus:ring-brand-500"
+                            />
+                            <input
+                              placeholder="Metadata value"
+                              value={param.value}
+                              onChange={e => updateRuleParam(idx, 'value', e.target.value)}
+                              className="flex-1 rounded-lg border border-slate-200 dark:border-[#1e2330] bg-white dark:bg-[#0c0f17] px-3 py-2 text-sm text-slate-600 dark:text-[#a8b4c8] focus:outline-none focus:ring-1 focus:ring-brand-500"
+                            />
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                  <button
+                    onClick={addRuleParam}
+                    disabled={routingConfigUnavailable || routingKeysLoading || routingKeyNames.length === 0}
+                    className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-medium text-brand-500 hover:bg-brand-50 dark:hover:bg-brand-500/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <Plus size={12} /> Add Parameter
+                  </button>
+                </div>
+
+                {/* Fallback Gateways */}
+                <div className="space-y-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-[#4e5870]">Fallback Gateways</p>
+                  <div className="space-y-1.5">
+                    {fallbackConnectors.map((connector, idx) => (
+                      <div key={idx} className="group flex items-center gap-0 rounded-xl border border-slate-200 dark:border-[#1e2330] bg-white dark:bg-[#0c0f17] overflow-hidden transition-shadow hover:shadow-sm">
+                        <span className="shrink-0 flex items-center justify-center w-8 self-stretch bg-slate-50 dark:bg-[#10131c] border-r border-slate-100 dark:border-[#1e2330] text-[10px] font-bold text-slate-300 dark:text-[#3a4258] select-none">
+                          {idx + 1}
+                        </span>
+                        <input
+                          placeholder="gateway name"
+                          value={connector.gateway_name}
+                          onChange={e => updateFallbackConnector(idx, 'gateway_name', e.target.value)}
+                          className="flex-1 min-w-0 bg-transparent px-3 py-2.5 text-sm font-medium text-slate-700 dark:text-[#c8d0de] focus:outline-none"
+                        />
+                        <span className="shrink-0 border-x border-slate-100 dark:border-[#1e2330] bg-slate-50 dark:bg-[#10131c] px-2 py-2.5 text-[11px] font-bold text-slate-300 dark:text-[#3a4258] select-none">/</span>
+                        <input
+                          placeholder="gateway id (optional)"
+                          value={connector.gateway_id || ''}
+                          onChange={e => updateFallbackConnector(idx, 'gateway_id', e.target.value)}
+                          className="flex-1 min-w-0 bg-transparent px-3 py-2.5 text-sm text-slate-500 dark:text-[#8090a8] focus:outline-none"
+                        />
+                        <button
+                          onClick={() => removeFallbackConnector(idx)}
+                          className="shrink-0 px-2.5 py-2.5 text-slate-300 dark:text-[#2a3040] hover:text-red-400 dark:hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                        >
+                          <Trash2 size={13} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <button
+                    onClick={addFallbackConnector}
+                    className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-medium text-brand-500 hover:bg-brand-50 dark:hover:bg-brand-500/10 transition-colors"
+                  >
+                    <Plus size={12} /> Add Gateway
+                  </button>
+                </div>
+              </>
+            ) : activeTab === 'debit' ? (
+              <div className="space-y-4">
+                {debitRoutingFlag.isLoading ? (
+                  <p className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:border-[#222226] dark:bg-[#10131a] dark:text-[#aab5c8]">
+                    <Spinner size={14} />
+                    Loading debit routing flag...
+                  </p>
+                ) : debitRoutingFlag.isEnabled ? (
+                  <p className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300">
+                    Debit routing is enabled. This tab will call /decide-gateway with NTW_BASED_ROUTING.
+                  </p>
+                ) : (
+                  <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-3 text-xs text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <span>Debit routing is disabled.</span>
+                      <Button size="sm" variant="secondary" onClick={enableDebitRoutingForExplorer} disabled={!effectiveMerchantId || loading}>
+                        Enable Debit Routing
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Amount</label>
+                    <input
+                      value={debitForm.amount}
+                      onChange={e => setDebitField('amount', e.target.value)}
+                      className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Currency</label>
+                    <input
+                      value={debitForm.currency}
+                      onChange={e => setDebitField('currency', e.target.value.toUpperCase())}
+                      className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Auth Type</label>
+                    <select
+                      value={debitForm.auth_type}
+                      onChange={e => setDebitField('auth_type', e.target.value)}
+                      className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    >
+                      <option value="THREE_DS">THREE_DS</option>
+                      <option value="NO_THREE_DS">NO_THREE_DS</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Card Type</label>
+                    <select
+                      value={debitForm.card_type}
+                      onChange={e => setDebitField('card_type', e.target.value as DebitRoutingFormState['card_type'])}
+                      className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    >
+                      <option value="debit">Debit</option>
+                      <option value="credit">Credit</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-slate-600 mb-1">Eligible Gateways (comma-separated)</label>
+                  <input
+                    value={debitForm.eligible_gateways}
+                    onChange={e => setDebitField('eligible_gateways', e.target.value)}
+                    placeholder="stripe, adyen"
+                    className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Merchant Category Code</label>
+                    <input
+                      value={debitForm.merchant_category_code}
+                      onChange={e => setDebitField('merchant_category_code', e.target.value)}
+                      className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Acquirer Country</label>
+                    <input
+                      value={debitForm.acquirer_country}
+                      onChange={e => setDebitField('acquirer_country', e.target.value.toUpperCase())}
+                      className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-slate-600 mb-1">Co-badged Networks (comma-separated)</label>
+                  <input
+                    value={debitForm.co_badged_networks}
+                    onChange={e => setDebitField('co_badged_networks', e.target.value)}
+                    placeholder="VISA, NYCE, PULSE, STAR"
+                    className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Issuer Country</label>
+                    <input
+                      value={debitForm.issuer_country}
+                      onChange={e => setDebitField('issuer_country', e.target.value.toUpperCase())}
+                      className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2 pt-6">
+                    <input
+                      id="debit-is-regulated"
+                      type="checkbox"
+                      checked={debitForm.is_regulated}
+                      onChange={e => setDebitField('is_regulated', e.target.checked)}
+                      className="h-4 w-4 rounded border-slate-300"
+                    />
+                    <label htmlFor="debit-is-regulated" className="text-sm text-slate-600 dark:text-[#aab5c8]">
+                      Regulated debit card
+                    </label>
+                  </div>
+                </div>
+
+                {debitForm.is_regulated && (
+                  <div>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Regulated Name</label>
+                    <input
+                      value={debitForm.regulated_name}
+                      onChange={e => setDebitField('regulated_name', e.target.value)}
+                      placeholder="GOVERNMENT NON-EXEMPT INTERCHANGE FEE (WITH FRAUD)"
+                      className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    />
+                  </div>
+                )}
+
+                <p className="text-xs text-slate-500">
+                  The request sends debit details inside paymentInfo.metadata because the backend debit router parses co-badged card data from metadata.
+                </p>
+              </div>
+            ) : activeTab === 'volume' ? (
+              <div className="space-y-4">
+                <div>
+                  <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-[#7f8ca3]">
+                    Evaluation count
+                  </label>
+                  <div className="flex gap-2">
+                    <div className="flex flex-1 items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-[#283241] dark:bg-[#101722]">
+                      <input
+                        type="number"
+                        min="1"
+                        inputMode="numeric"
+                        value={volumePayments}
+                        onChange={e => setVolumePayments(e.target.value)}
+                        className="min-w-0 flex-1 bg-transparent text-xl font-semibold text-slate-950 outline-none dark:text-white"
+                      />
+                      <span className="shrink-0 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-500 dark:bg-[#1d2633] dark:text-[#91a0b8]">
+                        runs
+                      </span>
+                    </div>
+                    <Button
+                      onClick={runVolumeSplit}
+                      disabled={loading || !effectiveMerchantId}
+                      className="shrink-0 dark:bg-sky-500 dark:text-white dark:hover:bg-sky-400"
+                    >
+                      {loading ? <><Spinner size={14} /> Running…</> : <><PieChartIcon size={14} /> Run</>}
+                    </Button>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-slate-500 dark:text-[#8f9bb0]">
+                    Samples the active volume split strategy through <code>/routing/evaluate</code> and records each decision trace.
+                  </p>
+                </div>
+
+                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-[#283241] dark:bg-[#0b111a]">
+                  <div className="flex items-center justify-between text-xs">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-[#77849a]">Target</span>
+                      <span className="font-semibold text-slate-900 dark:text-white">{volumeRunTarget || '--'}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-[#77849a]">Completed</span>
+                      <span className="font-semibold text-slate-900 dark:text-white">
+                        {loading ? volumeProgress : volumeEvaluationCount || '--'}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200 dark:bg-[#1d2633]">
+                    <div
+                      className={`h-full rounded-full transition-[width] ${loading ? 'bg-sky-500' : 'bg-slate-400 dark:bg-[#3a4a5c]'}`}
+                      style={{
+                        width: `${loading
+                          ? volumeProgressPercentage
+                          : (volumeEvaluationCount && volumeRunTarget ? Math.min(100, Math.round((volumeEvaluationCount / volumeRunTarget) * 100)) : 0)}%`
+                      }}
+                    />
+                  </div>
+                  {loading && (
+                    <p className="mt-1 text-right text-[10px] font-semibold text-sky-600 dark:text-sky-300">
+                      {volumeProgressPercentage}%
+                    </p>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <>
+                {activeTab === 'single' && (
+                  <>
+                    <div>
+                      <label className="block text-xs font-medium text-slate-600 mb-1">Transaction Outcome</label>
+                      <select
+                        value={singleRunOutcome}
+                        onChange={e => setSingleRunOutcome(e.target.value as TransactionOutcome)}
+                        className="w-full border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500"
+                      >
+                        <option value="CHARGED">Success (CHARGED)</option>
+                        <option value="FAILURE">Failure (FAILURE)</option>
+                      </select>
+                      <p className="mt-1 text-xs text-slate-500">
+                        After deciding the gateway, single test will post feedback with this outcome so the payment appears in Decision Audit.
+                      </p>
+                    </div>
+                    {singleRunOutcome === 'FAILURE' && <ErrorInfoFields info={errorInfo} onChange={setErrorField} rules={gsmRules} />}
+                  </>
+                )}
+              </>
+            )}
+          </CardBody>
+          <div className="border-t border-slate-200 dark:border-[#2a303a] px-5 py-4 space-y-3">
+            <ErrorMessage error={error} />
+            {activeTab === 'rule' ? (
+              <Button onClick={runRuleEvaluation} disabled={loading || routingConfigUnavailable} className="w-full justify-center">
+                {loading ? <><Spinner size={14} /> Evaluating…</> : <><Play size={14} /> Evaluate Rules</>}
+              </Button>
+            ) : activeTab === 'debit' ? (
+              <Button
+                onClick={runDebitRouting}
+                disabled={loading || !effectiveMerchantId || debitRoutingFlag.isLoading || !debitRoutingFlag.isEnabled}
+                className="w-full justify-center"
+              >
+                {loading ? <><Spinner size={14} /> Running Debit Routing…</> : <><Network size={14} /> Run Debit Routing</>}
+              </Button>
+            ) : activeTab === 'volume' ? null : (
+              <>
+                {FEATURE_FLAGS.SMART_RETRY_IN_SIMULATION && (
+                  <label className={`flex items-center gap-2 select-none ${gsmScoringFilterEnabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}>
+                    <input
+                      type="checkbox"
+                      checked={smartRetryEnabled}
+                      onChange={e => setSmartRetryEnabled(e.target.checked)}
+                      disabled={!gsmScoringFilterEnabled}
+                      className="rounded border-slate-300 dark:border-slate-600 disabled:cursor-not-allowed"
+                    />
+                    <span className="text-xs text-slate-600 dark:text-slate-400">
+                      Smart retry — on GSM <code className="text-[11px]">retry</code> decision, attempt next fallback gateway
+                      {!gsmScoringFilterEnabled && <span className="ml-1 text-amber-500">(enable GSM scoring filter first)</span>}
+                    </span>
+                  </label>
+                )}
+                <Button onClick={run} disabled={loading || !effectiveMerchantId || routingConfigUnavailable} className="w-full justify-center">
+                  {loading ? <><Spinner size={14} /> Running…</> : <><Play size={14} /> Run Single Transaction</>}
+                </Button>
+              </>
+            )}
+          </div>
+        </Card>
+        )}
+        </div>
+
+        <div className="min-w-0 flex flex-col gap-4">
+          {activeTab === 'debit' ? (
+            debitResult ? (
+              <>
+                <Card>
+                  <CardHeader>
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <h3 className="text-sm font-medium text-slate-800 dark:text-white">Debit Routing Result</h3>
+                        <p className="mt-1 text-xs text-slate-500 dark:text-[#9ca7ba]">
+                          Real response from <code>/decide-gateway</code> using <code>NTW_BASED_ROUTING</code>.
+                        </p>
+                      </div>
+                      {debitPaymentId ? (
+                        <Button size="sm" variant="secondary" onClick={() => openAuditModal(debitPaymentId)}>
+                          View audit
+                        </Button>
+                      ) : null}
+                    </div>
+                  </CardHeader>
+                  <CardBody className="space-y-4">
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="rounded-lg bg-slate-50 p-3 dark:bg-[#111114]">
+                        <p className="text-xs text-slate-500">routing_approach</p>
+                        <p className="mt-1 font-semibold text-slate-900 dark:text-white">{debitResult.routing_approach}</p>
+                      </div>
+                      <div className="rounded-lg bg-slate-50 p-3 dark:bg-[#111114]">
+                        <p className="text-xs text-slate-500">request payment_id</p>
+                        <p className="mt-1 font-mono text-xs text-slate-900 dark:text-white">{debitPaymentId}</p>
+                      </div>
+                    </div>
+
+                    {debitResult.debit_routing_output ? (
+                      <>
+                        <div className="grid grid-cols-3 gap-3">
+                          <div className="rounded-lg border border-slate-200 p-3 dark:border-[#222226]">
+                            <p className="text-xs text-slate-500">Issuer country</p>
+                            <p className="mt-1 text-lg font-semibold text-slate-900 dark:text-white">{debitResult.debit_routing_output.issuer_country}</p>
+                          </div>
+                          <div className="rounded-lg border border-slate-200 p-3 dark:border-[#222226]">
+                            <p className="text-xs text-slate-500">Regulated</p>
+                            <p className="mt-1 text-lg font-semibold text-slate-900 dark:text-white">{debitResult.debit_routing_output.is_regulated ? 'Yes' : 'No'}</p>
+                          </div>
+                          <div className="rounded-lg border border-slate-200 p-3 dark:border-[#222226]">
+                            <p className="text-xs text-slate-500">Card type</p>
+                            <p className="mt-1 text-lg font-semibold text-slate-900 dark:text-white">{debitResult.debit_routing_output.card_type}</p>
+                          </div>
+                        </div>
+
+                        <Card>
+                          <CardHeader>
+                            <h3 className="text-sm font-medium text-slate-800 dark:text-white">Ranked Debit Networks</h3>
+                          </CardHeader>
+                          <CardBody className="p-0">
+                            <table className="w-full text-sm">
+                              <thead className="bg-slate-50 text-xs text-slate-500 dark:bg-[#111114]">
+                                <tr>
+                                  <th className="px-4 py-2 text-left">Rank</th>
+                                  <th className="px-4 py-2 text-left">Network</th>
+                                  <th className="px-4 py-2 text-right">Saving %</th>
+                                </tr>
+                              </thead>
+                              <tbody className="divide-y divide-slate-100 dark:divide-[#222226]">
+                                {debitNetworkRows.map((row, idx) => (
+                                  <tr key={`${row.network}-${idx}`} className="hover:bg-slate-50 dark:hover:bg-[#111114]">
+                                    <td className="px-4 py-2 font-mono text-xs text-slate-500">#{idx + 1}</td>
+                                    <td className="px-4 py-2 font-medium text-slate-900 dark:text-white">{row.network}</td>
+                                    <td className="px-4 py-2 text-right text-slate-700 dark:text-[#d8e1ef]">{row.saving_percentage.toFixed(2)}%</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </CardBody>
+                        </Card>
+                      </>
+                    ) : (
+                      <ErrorMessage error="Debit routing output was not returned. Check the raw response for backend details." />
+                    )}
+
+                    <div className="border-t border-slate-200 pt-3 dark:border-[#222226]">
+                      <button
+                        type="button"
+                        onClick={() => setDebitResponseOpen(!debitResponseOpen)}
+                        className="flex items-center gap-1 text-xs font-medium text-slate-500 hover:text-slate-700"
+                      >
+                        {debitResponseOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                        Raw response
+                      </button>
+                      {debitResponseOpen && (
+                        <pre className="mt-3 max-h-96 overflow-auto rounded-lg border border-slate-200/80 bg-slate-50/90 p-4 font-mono text-xs leading-6 text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),0_16px_30px_-28px_rgba(15,23,42,0.18)] dark:border-[#2a303a] dark:bg-[#0b1017] dark:text-[#d8e1ef] dark:shadow-none">
+                          {JSON.stringify(debitResult, null, 2)}
+                        </pre>
+                      )}
+                    </div>
+                  </CardBody>
+                </Card>
+              </>
+            ) : (
+              <Card>
+                <CardBody className="py-12 text-center">
+                  <Network size={32} className="mx-auto mb-3 text-slate-300" />
+                  <p className="text-sm text-slate-500">Enable debit routing, keep the default debit metadata, and click "Run Debit Routing" to inspect ranked networks.</p>
+                </CardBody>
+              </Card>
+            )
+          ) : activeTab === 'volume' ? (
+            volumeDistribution.length > 0 ? (
+              <div className="space-y-5">
+                <section className="rounded-2xl border border-slate-200 bg-white shadow-[0_18px_60px_-46px_rgba(15,23,42,0.2)] dark:border-[#283241] dark:bg-[#101722]">
+                  <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-[#263141]">
+                    <div className="min-w-0">
+                      <h3 className="text-sm font-semibold text-slate-900 dark:text-white">Distribution analysis</h3>
+                      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+                        <span className="text-xs text-slate-500 dark:text-[#8f9bb0]">
+                          <span className="font-semibold text-slate-700 dark:text-[#c5d0e0]">{volumeEvaluationCount}</span> evaluations
+                        </span>
+                        {volumeLeader && (
+                          <>
+                            <span className="text-slate-300 dark:text-[#3a4455]">·</span>
+                            <span className="text-xs text-slate-500 dark:text-[#8f9bb0]">
+                              leader <span className="font-semibold text-slate-700 dark:text-[#c5d0e0]">{volumeLeader.name}</span> at{' '}
+                              <span className="font-semibold text-slate-700 dark:text-[#c5d0e0]">{volumeLeader.percentage}%</span>
+                            </span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    {ruleResult?.payment_id ? (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => openPreviewModal(ruleResult.payment_id!, 'Volume Split Decision')}
+                      >
+                        View first trace
+                      </Button>
+                    ) : null}
+                  </div>
+
+                  <div className="space-y-4 px-5 py-4">
+                    <div>
+                      <div className="flex items-center justify-between text-xs text-slate-500 dark:text-[#8f9bb0]">
+                        <span>Observed percentage split</span>
+                        <span>{sortedVolumeDistribution.length} gateways</span>
+                      </div>
+                      <div className="mt-2 flex h-2.5 overflow-hidden rounded-full bg-slate-100 dark:bg-[#1d2633]">
+                        {sortedVolumeDistribution.map((item) => (
+                          <div
+                            key={item.name}
+                            className="h-full transition-all duration-300"
+                            style={{
+                              width: `${item.percentage}%`,
+                              backgroundColor: COLORS[(volumeColorIndex.get(item.name) ?? 0) % COLORS.length],
+                            }}
+                            title={`${item.name}: ${item.percentage}%`}
+                          />
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                      {sortedVolumeDistribution.map((item) => {
+                        const color = COLORS[(volumeColorIndex.get(item.name) ?? 0) % COLORS.length]
+                        return (
+                          <div key={item.name} className="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3 dark:border-[#263141] dark:bg-[#0c121c]">
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="flex min-w-0 items-center gap-2">
+                                <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+                                <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{item.name}</p>
+                              </div>
+                              <p className="shrink-0 text-sm font-semibold text-slate-900 dark:text-white">{item.percentage}%</p>
+                            </div>
+                            <p className="mt-0.5 pl-[18px] text-xs text-slate-500 dark:text-[#8290a5]">{item.count} payments</p>
+                            <div className="mt-2.5 h-1 overflow-hidden rounded-full bg-slate-200 dark:bg-[#1d2633]">
+                              <div className="h-full rounded-full" style={{ width: `${item.percentage}%`, backgroundColor: color }} />
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                </section>
+
+                <section className="rounded-2xl border border-slate-200 bg-white dark:border-[#283241] dark:bg-[#101722]">
+                    <div className="border-b border-slate-200 px-5 py-4 dark:border-[#263141]">
+                      <h3 className="text-sm font-semibold text-slate-900 dark:text-white">Evaluation sequence</h3>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8f9bb0]">Click any row to inspect the captured decision trace.</p>
+                    </div>
+                    <div className="max-h-[360px] overflow-auto">
+                      <table className="w-full text-sm">
+                        <thead className="sticky top-0 bg-slate-50 text-xs text-slate-500 dark:bg-[#0b111a] dark:text-[#8290a5]">
+                          <tr>
+                            <th className="w-16 px-4 py-2 text-left">#</th>
+                            <th className="px-4 py-2 text-left">payment_id</th>
+                            <th className="px-4 py-2 text-left">gateway</th>
+                            <th className="w-24 px-4 py-2 text-right">trace</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100 dark:divide-[#263141]">
+                          {volumeEvaluationLog.slice(-200).map((entry, idx) => {
+                            const absIdx = Math.max(0, volumeEvaluationLog.length - 200) + idx
+                            return (
+                            <tr
+                              key={entry.paymentId}
+                              className="cursor-pointer transition hover:bg-slate-50 dark:hover:bg-[#151d2a]"
+                              onClick={() => openPreviewModal(entry.paymentId, 'Volume Split Decision')}
+                            >
+                              <td className="px-4 py-2 font-mono text-xs text-slate-500">{absIdx + 1}</td>
+                              <td className="max-w-[260px] truncate px-4 py-2 font-mono text-xs text-slate-600 dark:text-[#aab5c8]">{entry.paymentId}</td>
+                              <td className="px-4 py-2">
+                                <div className="flex items-center gap-2">
+                                  <span
+                                    className="h-2 w-2 rounded-full"
+                                    style={{ backgroundColor: COLORS[(volumeColorIndex.get(entry.connector) ?? 0) % COLORS.length] }}
+                                  />
+                                  <span className="font-medium text-slate-900 dark:text-white">{entry.connector}</span>
+                                </div>
+                              </td>
+                              <td className="px-4 py-2 text-right">
+                                <button
+                                  type="button"
+                                  className="text-xs font-semibold text-brand-600 hover:text-brand-700 dark:text-sky-300"
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    openPreviewModal(entry.paymentId, 'Volume Split Decision')
+                                  }}
+                                >
+                                  Open
+                                </button>
+                              </td>
+                            </tr>
+                          )})}
+                        </tbody>
+                      </table>
+                    </div>
+                  </section>
+
+                <section className="rounded-2xl border border-slate-200 bg-white dark:border-[#283241] dark:bg-[#101722]">
+                  <button
+                    onClick={() => setVolumeResponseOpen(o => !o)}
+                    className="flex w-full items-center justify-between px-5 py-4 text-sm font-semibold text-slate-900 dark:text-white"
+                  >
+                    <span className="flex items-center gap-2">
+                      <Code size={14} />
+                      API response
+                    </span>
+                    {volumeResponseOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                  </button>
+                  {volumeResponseOpen && ruleResult && (
+                    <pre className="max-h-96 overflow-auto border-t border-slate-200 bg-slate-50 p-4 text-xs text-slate-700 dark:border-[#263141] dark:bg-[#070b12] dark:text-[#b7c2d6]">
+                      {JSON.stringify(ruleResult, null, 2)}
+                    </pre>
+                  )}
+                </section>
+              </div>
+            ) : (
+              <section className="flex min-h-[360px] items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-slate-50/70 px-8 py-12 text-center dark:border-[#2a303a] dark:bg-[#101722]/70">
+                <div className="max-w-sm">
+                  <PieChartIcon size={30} className="mx-auto text-slate-300 dark:text-[#536075]" />
+                  <h3 className="mt-4 text-sm font-semibold text-slate-900 dark:text-white">No volume results yet</h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-500 dark:text-[#9aa6bb]">
+                    Set the run size and run the volume split check to view distribution and traces.
+                  </p>
+                </div>
+              </section>
+            )
+          ) : activeTab === 'rule' ? (
+            ruleResult ? (
+              <>
+                <Card>
+                  <CardBody>
+                    <div className="flex items-start justify-between mb-3">
+                      <div>
+                        <p className="text-xs text-slate-500 uppercase tracking-wide mb-1">Status</p>
+                        <p className="text-2xl font-bold text-slate-900">{ruleResult.status}</p>
+                        <p className="text-xs text-slate-500 mt-1">output_type: {ruleResult.output.type}</p>
+                      </div>
+                      {ruleResult.payment_id ? (
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => openPreviewModal(ruleResult.payment_id!, 'Rule Evaluation Decision')}
+                        >
+                          View decision trace
+                        </Button>
+                      ) : null}
+                    </div>
+
+                    {ruleResult.output.type === 'single' && ruleResult.output.connector && (
+                      <div className="border-t border-slate-200 dark:border-[#1c1c24] pt-3">
+                        <p className="text-xs text-slate-400 mb-1">Selected gateway_name</p>
+                        <p className="text-lg font-semibold">{ruleResult.output.connector.gateway_name}</p>
+                        {ruleResult.output.connector.gateway_id && (
+                          <p className="text-xs text-slate-500">gateway_id: {ruleResult.output.connector.gateway_id}</p>
+                        )}
+                      </div>
+                    )}
+
+                    {ruleResult.output.type === 'priority' && ruleResult.output.connectors && (
+                      <div className="border-t border-slate-200 dark:border-[#1c1c24] pt-3">
+                        <p className="text-xs text-slate-400 mb-2">Priority gateway_name list</p>
+                        <div className="space-y-1">
+                          {ruleResult.output.connectors.map((gw, idx) => (
+                            <div key={idx} className="flex items-center gap-2 text-sm">
+                              <span className="w-5 h-5 rounded-full bg-brand-500 text-white text-xs flex items-center justify-center">{idx + 1}</span>
+                              <span className="font-medium">{gw.gateway_name}</span>
+                              {gw.gateway_id && <span className="text-xs text-slate-500">({gw.gateway_id})</span>}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {ruleResult.output.type === 'volume_split' && (
+                      <div className="border-t border-slate-200 dark:border-[#1c1c24] pt-3">
+                        <p className="text-xs text-slate-400 mb-2">Volume Split Result</p>
+                        <p className="text-sm text-slate-600">See Volume Split tab for detailed visualization.</p>
+                      </div>
+                    )}
+                  </CardBody>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <button
+                      onClick={() => setResponseOpen(o => !o)}
+                      className="flex items-center justify-between w-full text-sm font-medium text-slate-800"
+                    >
+                      <span className="flex items-center gap-2">
+                        <Code size={14} />
+                        API Response
+                      </span>
+                      {responseOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                    </button>
+                  </CardHeader>
+                  {responseOpen && (
+                    <CardBody className="p-0">
+                      <pre className="text-xs text-slate-600 bg-slate-50 dark:bg-[#0a0a0f] p-4 overflow-auto max-h-96 font-mono">
+                        {JSON.stringify(ruleResult, null, 2)}
+                      </pre>
+                    </CardBody>
+                  )}
+                </Card>
+              </>
+            ) : (
+              <Card>
+                <CardBody className="py-16 text-center">
+                  <Play size={32} className="text-gray-300 mx-auto mb-3" />
+                  <p className="text-slate-400 text-sm">Configure rule parameters and click "Evaluate Rules" to test routing.</p>
+                </CardBody>
+              </Card>
+            )
+          ) : activeTab === 'batch' ? (
+            <>
+              {/* Events — backend stream not wired yet, shows empty state */}
+              <Card>
+                <CardHeader className="flex flex-row items-center gap-2.5">
+                  <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.18)]" />
+                  <h3 className="text-sm font-medium text-slate-800 dark:text-white">Events</h3>
+                </CardHeader>
+                <CardBody className="py-12 text-center">
+                  <p className="text-sm text-slate-500 dark:text-slate-400">No events yet</p>
+                  <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                    Event stream will appear here once the backend is available.
+                  </p>
+                </CardBody>
+              </Card>
+              {hasSimulationActivity ? (
+              <>
+                <Card>
+                  <CardHeader className="flex flex-row items-center justify-between gap-3">
+                    <h3 className="text-sm font-medium text-slate-800 dark:text-white">Transaction Log</h3>
+                    {deferredSimulationResults.length > 0 && (
+                      <span className="text-xs text-slate-400 tabular-nums">{deferredSimulationResults.length} transactions</span>
+                    )}
+                  </CardHeader>
+                  <CardBody className="p-0">
+
+                    {deferredSimulationResults.length > 0 ? (
+                      <div ref={txLogRef} className="max-h-[480px] overflow-y-auto overflow-x-hidden">
+                        <table className="w-full text-sm">
+                          <thead className="bg-slate-50 dark:bg-[#0a0a0f] text-[11px] text-slate-400 dark:text-slate-500 sticky top-0 border-b border-slate-100 dark:border-[#1c1c24]">
+                            <tr>
+                              <th className="text-left px-2 py-2 w-8">#</th>
+                              <th className="text-left px-2 py-2">Amount</th>
+                              <th className="text-left px-2 py-2 whitespace-nowrap">Gateway</th>
+                              <th className="text-left px-2 py-2">Routing</th>
+                              <th className="text-left px-2 py-2">Outcome</th>
+                              <th className="text-right px-2 py-2 whitespace-nowrap">Cost Savings</th>
+                              {smartRetryEnabled && <th className="text-left px-2 py-2 whitespace-nowrap">Retry Gateway</th>}
+                              {smartRetryEnabled && <th className="text-left px-2 py-2">Retry Outcome</th>}
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-slate-100 dark:divide-[#1a1a22]">
+                            {deferredSimulationResults.map((res, idx) => {
+                              const absIdx = idx
+                              return (
+                              <tr
+                                key={res.paymentId}
+                                className="group cursor-pointer hover:bg-slate-50 dark:hover:bg-[#0d0d14] transition-colors"
+                                onClick={() => openAuditModal(res.paymentId)}
+                              >
+                                <td className="px-2 py-2 text-[11px] text-slate-400 tabular-nums">{absIdx + 1}</td>
+                                <td className="px-2 py-2 whitespace-nowrap">
+                                  <span className="block font-mono text-xs text-slate-700 dark:text-slate-300 tabular-nums group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
+                                    {formatCurrencyValue(res.amount, res.currency)}
+                                  </span>
+                                </td>
+                                <td className="px-2 py-2 text-xs font-medium text-slate-600 dark:text-slate-300 whitespace-nowrap">{res.decidedGateway}</td>
+                                <td className="px-2 py-2">
+                                  {res.routingApproach?.includes('HEDGING') ? (
+                                    <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-900/20 dark:text-amber-300 dark:ring-amber-800">Hedging</span>
+                                  ) : res.routingApproach === 'SR_SELECTION_MULTI_OBJECTIVE' ? (
+                                    <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-300 dark:ring-emerald-800">Cost Based</span>
+                                  ) : res.routingApproach === 'SR_SELECTION_V3_ROUTING' ? (
+                                    <span className="inline-flex items-center rounded-full bg-brand-50 px-2 py-0.5 text-[11px] font-medium text-brand-700 ring-1 ring-inset ring-brand-200 dark:bg-brand-900/20 dark:text-brand-300 dark:ring-brand-800">Auth Based</span>
+                                  ) : (
+                                    <span className="text-[11px] text-slate-400">{res.routingApproach ?? '—'}</span>
+                                  )}
+                                </td>
+                                <td className="px-2 py-2">
+                                  <span className={`text-xs font-semibold ${res.status === 'CHARGED' ? 'text-emerald-600 dark:text-emerald-400' : res.status === 'PENDING_VBV' ? 'text-amber-600 dark:text-amber-400' : 'text-red-500 dark:text-red-400'}`}>{res.status}</span>
+                                </td>
+                                <td className="px-2 py-2 text-right whitespace-nowrap">
+                                  {res.costWon && res.costSavedBps != null && res.costSavedBps > 0 && res.status === 'CHARGED' ? (
+                                    <span className="font-mono text-xs text-emerald-700 dark:text-emerald-400 tabular-nums">
+                                      {formatSavingsCurrency(res.costSavedBps, res.amount, res.currency)}
+                                    </span>
+                                  ) : null}
+                                </td>
+                                {smartRetryEnabled && (
+                                  <td className="px-2 py-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                                    {res.retryGateway ?? '—'}
+                                  </td>
+                                )}
+                                {smartRetryEnabled && (
+                                  <td className="px-2 py-2">
+                                    {res.retryStatus ? (
+                                      <Badge variant={res.retryStatus === 'CHARGED' ? 'green' : res.retryStatus === 'PENDING_VBV' ? 'orange' : 'red'}>
+                                        {res.retryStatus}
+                                      </Badge>
+                                    ) : <span className="text-xs text-slate-400">—</span>}
+                                  </td>
+                                )}
+                              </tr>
+                            )})}
+                          </tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-3 px-4 py-6 text-sm text-slate-500">
+                        <Spinner size={16} />
+                        Waiting for the first simulated payment result…
+                      </div>
+                    )}
+                  </CardBody>
+                </Card>
+              </>
+            ) : (
+              <div className="space-y-3">
+                <button
+                  type="button"
+                  onClick={() => setShowPenaltyGuide(v => !v)}
+                  className="flex items-center gap-2 rounded-lg border border-slate-200 dark:border-[#222226] bg-white dark:bg-[#0c0f17] px-3 py-2 text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-[#131720] transition-colors w-full"
+                >
+                  <span className={`transition-transform ${showPenaltyGuide ? 'rotate-90' : ''}`}>▶</span>
+                  Penalty Classification Guide
+                </button>
+                {showPenaltyGuide && (
+                  <PenaltyClassificationGuide
+                    merchantId={effectiveMerchantId}
+                    gsmRules={gsmRules}
+                    decideParams={{
+                      amount: form.amount,
+                      currency: form.currency,
+                      paymentMethodType: form.payment_method_type,
+                      paymentMethod: form.payment_method,
+                      authType: form.auth_type,
+                      cardBrand: form.card_brand,
+                      rankingAlgorithm: 'SR_BASED_ROUTING',
+                      eligibleGateways: form.eligible_gateways,
+                    }}
+                  />
+                )}
+              </div>
+            )}
+            </>
+          ) : (
+            result ? (
+              <>
+                <Card>
+                  <CardBody>
+                    <div className="flex items-start justify-between mb-3">
+                      <div>
+                        <p className="text-xs text-slate-500 uppercase tracking-wide mb-1">Decided Gateway</p>
+                        <p className="text-3xl font-bold text-slate-900">{result.decided_gateway}</p>
+                      </div>
+                      <div className="text-right space-y-2">
+                        <div>
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${approachColor(result.routing_approach)}`}>
+                            {result.routing_approach}
+                          </span>
+                        </div>
+                        {singleRunPaymentId ? (
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            onClick={() => openAuditModal(singleRunPaymentId)}
+                          >
+                            View audit
+                          </Button>
+                        ) : null}
+                        {result.is_scheduled_outage && <Badge variant="red">Scheduled Outage</Badge>}
+                        {singleRunPaymentId ? (
+                          <Badge variant={singleRunOutcome === 'CHARGED' ? 'green' : 'red'}>
+                            {singleRunOutcome}
+                          </Badge>
+                        ) : null}
+                        {result.latency != null && (
+                          <p className="text-xs text-slate-400">{result.latency}ms</p>
+                        )}
+                      </div>
+                    </div>
+                    {singleRunPaymentId ? (
+                      <div className="mb-3 rounded-[18px] border border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-[#1c1c23] dark:bg-[#0b0b10]">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-[#8a8a93]">
+                          Payment ID
+                        </p>
+                        <p className="mt-2 font-mono text-sm text-slate-900 dark:text-white">{singleRunPaymentId}</p>
+                        <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                          Feedback recorded as {singleRunOutcome}. Open audit to inspect the full decide and update flow.
+                        </p>
+                      </div>
+                    ) : null}
+                    {result.routing_dimension && (
+                      <div className="flex gap-4 text-sm text-slate-600 border-t border-slate-200 dark:border-[#1c1c24] pt-3">
+                        <div>
+                          <span className="text-xs text-slate-400">Dimension</span>
+                          <p className="font-medium">{result.routing_dimension}</p>
+                        </div>
+                        {result.routing_dimension_level && (
+                          <div>
+                            <span className="text-xs text-slate-400">Level</span>
+                            <p className="font-medium">{result.routing_dimension_level}</p>
+                          </div>
+                        )}
+                        <div>
+                          <span className="text-xs text-slate-400">Reset</span>
+                          <p className="font-medium">{result.reset_approach}</p>
+                        </div>
+                      </div>
+                    )}
+                  </CardBody>
+                </Card>
+
+                {result.multi_objective_info && (
+                  <MultiObjectiveDecisionPanel info={result.multi_objective_info} />
+                )}
+
+                {scoreData.length > 0 && (
+                  <Card>
+                    <CardHeader>
+                      <div className="flex items-center justify-between">
+                        <h3 className="text-sm font-medium text-slate-800">Gateway Scores</h3>
+                        <Button size="sm" variant="ghost" onClick={run} className="text-xs">
+                          <RefreshCw size={12} /> Refresh
+                        </Button>
+                      </div>
+                    </CardHeader>
+                    <CardBody>
+                      <ResponsiveContainer width="100%" height={scoreData.length * 40 + 20}>
+                        <BarChart data={scoreData} layout="vertical" margin={{ left: 10, right: 30 }}>
+                          <XAxis type="number" domain={[0, 100]} tickFormatter={v => `${v}%`} tick={{ fontSize: 11, fill: '#66667a' }} axisLine={{ stroke: '#1c1c24' }} tickLine={false} />
+                          <YAxis type="category" dataKey="name" tick={{ fontSize: 12, fill: '#8e8ea0' }} width={60} axisLine={false} tickLine={false} />
+                          <Tooltip
+                            formatter={v => `${v}%`}
+                            contentStyle={CHART_TOOLTIP_STYLE}
+                            labelStyle={CHART_TOOLTIP_LABEL_STYLE}
+                            itemStyle={CHART_TOOLTIP_ITEM_STYLE}
+                          />
+                          <Bar dataKey="score" radius={[0, 4, 4, 0]}>
+                            {scoreData.map((entry, i) => (
+                              <Cell
+                                key={i}
+                                fill={
+                                  entry.name === result.decided_gateway
+                                    ? '#0069ED'
+                                    : entry.score < 30 ? '#ef4444'
+                                      : entry.score < 60 ? '#f59e0b'
+                                        : '#10b981'
+                                }
+                              />
+                            ))}
+                          </Bar>
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </CardBody>
+                  </Card>
+                )}
+
+                {result.filter_wise_gateways && (
+                  <Card>
+                    <CardHeader>
+                      <button
+                        onClick={() => setFilterOpen(o => !o)}
+                        className="flex items-center justify-between w-full text-sm font-medium text-slate-800"
+                      >
+                        Filter Chain
+                        {filterOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                      </button>
+                    </CardHeader>
+                    {filterOpen && (
+                      <CardBody className="space-y-2">
+                        {Object.entries(result.filter_wise_gateways).map(([filter, gateways]) => (
+                          <div key={filter} className="flex items-start gap-3">
+                            <span className="text-xs font-mono bg-slate-100 dark:bg-[#111118] text-slate-600 rounded-md px-2 py-0.5 mt-0.5 shrink-0 border border-slate-200 dark:border-[#1c1c24]">{filter}</span>
+                            <div className="flex flex-wrap gap-1">
+                              {Array.isArray(gateways)
+                                ? gateways.map(gw => (
+                                  <span key={gw} className="text-xs bg-blue-500/10 text-blue-400 ring-1 ring-inset ring-blue-500/20 rounded-md px-2 py-0.5">{gw}</span>
+                                ))
+                                : <span className="text-xs text-slate-400">—</span>
+                              }
+                            </div>
+                          </div>
+                        ))}
+                      </CardBody>
+                    )}
+                  </Card>
+                )}
+
+                <Card>
+                  <CardHeader>
+                    <button
+                      onClick={() => setResponseOpen(o => !o)}
+                      className="flex items-center justify-between w-full text-sm font-medium text-slate-800"
+                    >
+                      <span className="flex items-center gap-2">
+                        <Code size={14} />
+                        API Response
+                      </span>
+                      {responseOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                    </button>
+                  </CardHeader>
+                  {responseOpen && (
+                    <CardBody className="p-0">
+                      <pre className="text-xs text-slate-600 bg-slate-50 dark:bg-[#0a0a0f] p-4 overflow-auto max-h-96 font-mono">
+                        {JSON.stringify(result, null, 2)}
+                      </pre>
+                    </CardBody>
+                  )}
+                </Card>
+              </>
+            ) : (
+              <Card>
+                <CardBody className="py-16 text-center">
+                  <Play size={32} className="text-gray-300 mx-auto mb-3" />
+                  <p className="text-slate-400 text-sm">Fill in the parameters and click "Run Single Transaction" to decide a gateway, post feedback, and inspect the audit trail.</p>
+                </CardBody>
+              </Card>
+            )
+          )}
+        </div>
+      </div>
+
+      {setupPrompt && (
+        <div className="fixed bottom-0 left-0 right-0 top-[76px] z-[140] flex items-center justify-center p-4">
+          <button
+            type="button"
+            aria-label="Close setup prompt"
+            className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm"
+            onClick={() => setSetupPrompt(null)}
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="decision-explorer-setup-title"
+            className="relative w-full max-w-[440px] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl dark:border-[#283241] dark:bg-[#101722]"
+          >
+            <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-sky-400/50 to-transparent" />
+            <div className="p-6">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex items-start gap-4">
+                  <div className="rounded-2xl border border-sky-500/20 bg-sky-500/10 p-3 text-sky-500 dark:text-sky-300">
+                    <Settings size={22} />
+                  </div>
+                  <div>
+                    <SurfaceLabel>Setup required</SurfaceLabel>
+                    <h2 id="decision-explorer-setup-title" className="mt-2 text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">
+                      {setupPrompt.title}
+                    </h2>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  aria-label="Close setup prompt"
+                  className="rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-[#1a2230] dark:hover:text-white"
+                  onClick={() => setSetupPrompt(null)}
+                >
+                  <X size={16} />
+                </button>
+              </div>
+
+              <p className="mt-4 text-sm leading-6 text-slate-500 dark:text-[#9aa6bb]">
+                {setupPrompt.body}
+              </p>
+
+              {setupPrompt.detail ? (
+                <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 px-3 py-3 font-mono text-xs leading-5 text-slate-500 dark:border-[#283241] dark:bg-[#0b111a] dark:text-[#9aa6bb]">
+                  {setupPrompt.detail}
+                </div>
+              ) : null}
+
+              <div className="mt-6 flex flex-wrap justify-end gap-2">
+                <Button variant="secondary" onClick={() => setSetupPrompt(null)}>
+                  Dismiss
+                </Button>
+                {setupPrompt.configurePath && (
+                  <Button onClick={() => { setSetupPrompt(null); navigate(setupPrompt.configurePath!) }}>
+                    Configure
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {selectedAuditPaymentId && (
+        <div className="fixed bottom-0 left-64 right-0 top-[76px] z-[130] p-8">
+          <button
+            type="button"
+            aria-label="Close payment audit"
+            className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm"
+            onClick={closeAuditModal}
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="decision-explorer-audit-title"
+            className="relative mx-auto flex h-full w-full max-w-7xl flex-col overflow-hidden rounded-[30px] border border-slate-200 bg-white shadow-2xl dark:border-[#1c1c23] dark:bg-[#09090d]"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-4 border-b border-slate-200 bg-slate-50/90 px-6 py-5 dark:border-[#1c1c23] dark:bg-[#0b0b10]">
+              <div className="min-w-0">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-[#8a8a93]">
+                  Simulation Audit
+                </p>
+                <h2
+                  id="decision-explorer-audit-title"
+                  className="mt-2 truncate text-2xl font-semibold text-slate-900 dark:text-white"
+                >
+                  {selectedAuditPaymentId}
+                </h2>
+                <p className="mt-2 max-w-3xl text-sm text-slate-500 dark:text-[#8a8a93]">
+                  Inspect the exact decision trail for this simulated payment, including request payloads, API responses, score context, and the final transaction outcome.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {auditSummary?.latest_gateway ? <Badge variant="green">{auditSummary.latest_gateway}</Badge> : null}
+                {auditSummary?.latest_status ? (
+                  <Badge variant={summaryBadgeVariant(auditSummary.latest_status)}>
+                    {humanizeAuditValue(auditSummary.latest_status)}
+                  </Badge>
+                ) : null}
+                {auditSummary?.event_count ? <Badge variant="gray">{auditSummary.event_count} events</Badge> : null}
+                <Button size="sm" variant="secondary" onClick={() => auditDetail.mutate()}>
+                  <RefreshCw size={12} />
+                  Refresh
+                </Button>
+                <Button size="sm" variant="ghost" onClick={closeAuditModal}>
+                  <X size={14} />
+                  Close
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid min-h-0 flex-1 gap-0 xl:grid-cols-[340px_minmax(0,1fr)]">
+              <div className="flex min-h-0 flex-col border-b border-slate-200 bg-slate-50/70 xl:border-b-0 xl:border-r dark:border-[#1c1c23] dark:bg-[#08080b]">
+                <div className="border-b border-slate-200 px-6 py-4 dark:border-[#1c1c23]">
+                  <h3 className="text-sm font-semibold text-slate-900 dark:text-white">Audit Timeline</h3>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                    Choose a step to inspect its request, response, and scoring context.
+                  </p>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+                  {auditDetail.isLoading && !auditDetail.data ? (
+                    <div className="flex items-center gap-2 px-2 text-sm text-slate-500 dark:text-[#8a8a93]">
+                      <Spinner size={16} />
+                      Loading payment audit…
+                    </div>
+                  ) : auditDetail.error ? (
+                    <ErrorMessage error={auditDetail.error.message} />
+                  ) : groupedAuditTimeline.length ? (
+                    <div className="space-y-4">
+                      {groupedAuditTimeline.map((group) => (
+                        <section key={group.phase} className="space-y-2">
+                          <div className="px-2">
+                            <Badge variant={phaseBadgeVariant(group.phase)}>{group.phase}</Badge>
+                          </div>
+                          <div className="space-y-2">
+                            {group.events.map((event) => (
+                              <button
+                                key={event.id}
+                                type="button"
+                                onClick={() => {
+                                  setSelectedAuditEventId(event.id)
+                                  setAuditInspectorTab('summary')
+                                }}
+                                className={`w-full rounded-[22px] border px-4 py-3 text-left transition ${
+                                  selectedAuditEvent?.id === event.id
+                                    ? 'border-brand-500/50 bg-brand-500/8'
+                                    : 'border-slate-200 bg-white hover:border-slate-300 dark:border-[#1d1d23] dark:bg-[#0c0c10] dark:hover:border-[#2a2a31]'
+                                }`}
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="min-w-0">
+                                    <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
+                                      {stageLabel(event)}
+                                    </p>
+                                    <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                                      {formatDateTime(event.created_at_ms)}
+                                    </p>
+                                  </div>
+                                  <Badge variant={badgeVariantForEvent(event)}>
+                                    {humanizeAuditValue(event.status) || eventTypeLabel(event.flow_type)}
+                                  </Badge>
+                                </div>
+                                <div className="mt-3 flex flex-wrap gap-2">
+                                  <Badge variant="gray">{routeLabel(event.route)}</Badge>
+                                  {event.gateway ? <Badge variant="green">{event.gateway}</Badge> : null}
+                                  {event.request_id ? <Badge variant="blue">Request</Badge> : null}
+                                </div>
+                              </button>
+                            ))}
+                          </div>
+                        </section>
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyAuditState
+                      title="No audit trail captured yet"
+                      body="Run a simulated payment and gateway update first, then reopen the row once the audit payload is available."
+                    />
+                  )}
+                </div>
+              </div>
+
+              <div className="flex min-h-0 flex-col">
+                <div className="border-b border-slate-200 px-6 py-4 dark:border-[#1c1c23]">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+                        {selectedAuditEvent ? stageLabel(selectedAuditEvent) : 'Audit Inspector'}
+                      </h3>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                        {selectedAuditEvent
+                          ? `${routeLabel(selectedAuditEvent.route)} · ${formatDateTime(selectedAuditEvent.created_at_ms)}`
+                          : 'Select an event from the left to inspect payloads.'}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {selectedAuditEvent?.gateway ? <Badge variant="green">{selectedAuditEvent.gateway}</Badge> : null}
+                      {selectedAuditEvent?.status ? (
+                        <Badge variant={badgeVariantForEvent(selectedAuditEvent)}>
+                          {humanizeAuditValue(selectedAuditEvent.status)}
+                        </Badge>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {(['summary', 'input', 'response', 'raw'] as AuditInspectorTab[]).map((tab) => (
+                      <button
+                        key={tab}
+                        type="button"
+                        onClick={() => setAuditInspectorTab(tab)}
+                        className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] transition ${sectionButtonClass(auditInspectorTab === tab)}`}
+                      >
+                        {tab === 'raw' ? 'Raw JSON' : humanizeAuditValue(tab)}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+                  {auditDetail.isLoading && !auditDetail.data ? (
+                    <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-[#8a8a93]">
+                      <Spinner size={16} />
+                      Loading inspector…
+                    </div>
+                  ) : auditInspectorModel ? (
+                    <div className="space-y-5">
+                      {auditInspectorTab === 'summary' ? (
+                        <>
+                          <InspectorKeyValueGrid rows={auditInspectorModel.summaryRows} />
+                          {auditInspectorModel.selectionReason ? (
+                            <div className="rounded-[22px] border border-slate-200 bg-slate-50/80 px-5 py-4 dark:border-[#1d1d23] dark:bg-[#0b0b10]">
+                              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-[#8a8a93]">
+                                Selection Reason
+                              </p>
+                              <p className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">
+                                {stringifyValue(auditInspectorModel.selectionReason)}
+                              </p>
+                            </div>
+                          ) : null}
+                          <InspectorJsonPanel
+                            title="Score Context"
+                            value={auditInspectorModel.scoreContext}
+                            emptyMessage="No scoring context was captured for this event."
+                          />
+                          {auditInspectorModel.signalRecord ? (
+                            <InspectorJsonPanel
+                              title="Additional Signals"
+                              value={auditInspectorModel.signalRecord}
+                              emptyMessage="No additional signals were captured for this event."
+                            />
+                          ) : null}
+                        </>
+                      ) : null}
+
+                      {auditInspectorTab === 'input' ? (
+                        <InspectorJsonPanel
+                          title="Request Payload"
+                          value={auditInspectorModel.requestPayload}
+                          emptyMessage="This step did not persist a request payload."
+                        />
+                      ) : null}
+
+                      {auditInspectorTab === 'response' ? (
+                        <InspectorJsonPanel
+                          title="Response Payload"
+                          value={auditInspectorModel.responsePayload}
+                          emptyMessage="This step did not persist a response payload."
+                        />
+                      ) : null}
+
+                      {auditInspectorTab === 'raw' ? (
+                        <InspectorJsonPanel
+                          title="Raw Event JSON"
+                          value={auditInspectorModel.rawEvent}
+                          emptyMessage="No raw event payload is available."
+                        />
+                      ) : null}
+                    </div>
+                  ) : (
+                    <EmptyAuditState
+                      title="Select a timeline step"
+                      body="Choose one of the audit events on the left to inspect its request, response, and score context."
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {selectedPreviewPaymentId && (
+        <div className="fixed bottom-0 left-64 right-0 top-[76px] z-[130] p-8">
+          <button
+            type="button"
+            aria-label="Close decision trace"
+            className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm"
+            onClick={closePreviewModal}
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="decision-explorer-preview-title"
+            className="relative mx-auto flex h-full w-full max-w-7xl flex-col overflow-hidden rounded-[30px] border border-slate-200 bg-white shadow-2xl dark:border-[#1c1c23] dark:bg-[#09090d]"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-4 border-b border-slate-200 bg-slate-50/90 px-6 py-5 dark:border-[#1c1c23] dark:bg-[#0b0b10]">
+              <div className="min-w-0">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-[#8a8a93]">
+                  Decision Trace
+                </p>
+                <h2
+                  id="decision-explorer-preview-title"
+                  className="mt-2 truncate text-2xl font-semibold text-slate-900 dark:text-white"
+                >
+                  {selectedPreviewPaymentId}
+                </h2>
+                <p className="mt-2 max-w-3xl text-sm text-slate-500 dark:text-[#8a8a93]">
+                  {previewTraceLabel}. This trace was captured from <code className="font-mono text-xs">/routing/evaluate</code> and is kept separate from auth-rate transaction outcomes.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {previewSummary?.latest_gateway ? <Badge variant="green">{previewSummary.latest_gateway}</Badge> : null}
+                {previewSummary?.latest_status ? (
+                  <Badge variant={summaryBadgeVariant(previewSummary.latest_status)}>
+                    {humanizeAuditValue(previewSummary.latest_status)}
+                  </Badge>
+                ) : null}
+                {previewSummary?.event_count ? <Badge variant="gray">{previewSummary.event_count} events</Badge> : null}
+                <Button size="sm" variant="secondary" onClick={() => previewTraceDetail.mutate()}>
+                  <RefreshCw size={12} />
+                  Refresh
+                </Button>
+                <Button size="sm" variant="ghost" onClick={closePreviewModal}>
+                  <X size={14} />
+                  Close
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid min-h-0 flex-1 gap-0 xl:grid-cols-[340px_minmax(0,1fr)]">
+              <div className="flex min-h-0 flex-col border-b border-slate-200 bg-slate-50/70 xl:border-b-0 xl:border-r dark:border-[#1c1c23] dark:bg-[#08080b]">
+                <div className="border-b border-slate-200 px-6 py-4 dark:border-[#1c1c23]">
+                  <h3 className="text-sm font-semibold text-slate-900 dark:text-white">Decision Timeline</h3>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                    Choose a decision step to inspect its request, response, and routing output.
+                  </p>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+                  {previewTraceDetail.isLoading && !previewTraceDetail.data ? (
+                    <div className="flex items-center gap-2 px-2 text-sm text-slate-500 dark:text-[#8a8a93]">
+                      <Spinner size={16} />
+                      Loading decision trace…
+                    </div>
+                  ) : previewTraceDetail.error && isTraceIndexingError(previewTraceDetail.error) && selectedPreviewPaymentId ? (
+                    <PendingAuditState
+                      title="Decision trace still indexing"
+                      body="The routing decision succeeded, but the trace row is still being processed. The modal will update once the analytics event is available."
+                    />
+                  ) : previewTraceDetail.error ? (
+                    <ErrorMessage error={previewTraceDetail.error.message} />
+                  ) : groupedPreviewTimeline.length ? (
+                    <div className="space-y-4">
+                      {groupedPreviewTimeline.map((group) => (
+                        <section key={group.phase} className="space-y-2">
+                          <div className="px-2">
+                            <Badge variant={phaseBadgeVariant(group.phase)}>{group.phase}</Badge>
+                          </div>
+                          <div className="space-y-2">
+                            {group.events.map((event) => (
+                              <button
+                                key={event.id}
+                                type="button"
+                                onClick={() => {
+                                  setSelectedPreviewEventId(event.id)
+                                  setPreviewInspectorTab('summary')
+                                }}
+                                className={`w-full rounded-[22px] border px-4 py-3 text-left transition ${
+                                  selectedPreviewEvent?.id === event.id
+                                    ? 'border-brand-500/50 bg-brand-500/8'
+                                    : 'border-slate-200 bg-white hover:border-slate-300 dark:border-[#1d1d23] dark:bg-[#0c0c10] dark:hover:border-[#2a2a31]'
+                                }`}
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="min-w-0">
+                                    <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
+                                      {stageLabel(event)}
+                                    </p>
+                                    <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                                      {formatDateTime(event.created_at_ms)}
+                                    </p>
+                                  </div>
+                                  <Badge variant={badgeVariantForEvent(event)}>
+                                    {humanizeAuditValue(event.status) || eventTypeLabel(event.flow_type)}
+                                  </Badge>
+                                </div>
+                                <div className="mt-3 flex flex-wrap gap-2">
+                                  <Badge variant="gray">{routeLabel(event.route)}</Badge>
+                                  {event.gateway ? <Badge variant="green">{event.gateway}</Badge> : null}
+                                </div>
+                              </button>
+                            ))}
+                          </div>
+                        </section>
+                      ))}
+                    </div>
+                  ) : selectedPreviewPaymentId ? (
+                    <PendingAuditState
+                      title={
+                        previewSummary
+                          ? 'Decision summary available'
+                          : 'Decision trace still arriving'
+                      }
+                      body={
+                        previewSummary
+                          ? 'The decision summary is available. The step-by-step timeline will appear as soon as the latest events are ready.'
+                          : 'This decision was just logged. Waiting for the decision trace details to become available.'
+                      }
+                    />
+                  ) : (
+                    <EmptyAuditState
+                      title="No decision trace captured yet"
+                      body="Run Rule-Based or Volume Split evaluation first, then open the decision trace once the request has been logged."
+                    />
+                  )}
+                </div>
+              </div>
+
+              <div className="flex min-h-0 flex-col">
+                <div className="border-b border-slate-200 px-6 py-4 dark:border-[#1c1c23]">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+                        {selectedPreviewEvent ? stageLabel(selectedPreviewEvent) : 'Decision Inspector'}
+                      </h3>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                        {selectedPreviewEvent
+                          ? `${routeLabel(selectedPreviewEvent.route)} · ${formatDateTime(selectedPreviewEvent.created_at_ms)}`
+                          : 'Select an event from the left to inspect the decision payload.'}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {selectedPreviewEvent?.gateway ? <Badge variant="green">{selectedPreviewEvent.gateway}</Badge> : null}
+                      {selectedPreviewEvent?.status ? (
+                        <Badge variant={badgeVariantForEvent(selectedPreviewEvent)}>
+                          {humanizeAuditValue(selectedPreviewEvent.status)}
+                        </Badge>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {(['summary', 'input', 'response', 'raw'] as AuditInspectorTab[]).map((tab) => (
+                      <button
+                        key={tab}
+                        type="button"
+                        onClick={() => setPreviewInspectorTab(tab)}
+                        className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] transition ${sectionButtonClass(previewInspectorTab === tab)}`}
+                      >
+                        {tab === 'raw' ? 'Raw JSON' : humanizeAuditValue(tab)}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+                  {previewTraceDetail.isLoading && !previewTraceDetail.data ? (
+                    <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-[#8a8a93]">
+                      <Spinner size={16} />
+                      Loading decision inspector…
+                    </div>
+                  ) : previewInspectorModel ? (
+                    <div className="space-y-5">
+                      {previewInspectorTab === 'summary' ? (
+                        <>
+                          <InspectorKeyValueGrid rows={previewInspectorModel.summaryRows} />
+                          <InspectorJsonPanel
+                            title="Decision Signals"
+                            value={previewInspectorModel.signalRecord}
+                            emptyMessage="No extra decision metadata was captured for this evaluation."
+                          />
+                        </>
+                      ) : null}
+
+                      {previewInspectorTab === 'input' ? (
+                        <InspectorJsonPanel
+                          title="Request Payload"
+                          value={previewInspectorModel.requestPayload}
+                          emptyMessage="No request payload was captured for this decision."
+                        />
+                      ) : null}
+
+                      {previewInspectorTab === 'response' ? (
+                        <InspectorJsonPanel
+                          title="Response Payload"
+                          value={previewInspectorModel.responsePayload}
+                          emptyMessage="No response payload was captured for this decision."
+                        />
+                      ) : null}
+
+                      {previewInspectorTab === 'raw' ? (
+                        <InspectorJsonPanel
+                          title="Raw Event JSON"
+                          value={previewInspectorModel.rawEvent}
+                          emptyMessage="No raw event payload is available for this decision."
+                        />
+                      ) : null}
+                    </div>
+                  ) : selectedPreviewPaymentId && !(previewTraceDetail.data?.timeline?.length || 0) ? (
+                    <PendingAuditState
+                      title={
+                        previewSummary
+                          ? 'Waiting for detailed decision step'
+                          : 'Waiting for decision step'
+                      }
+                      body={
+                        previewSummary
+                          ? 'The decision record is available. Request and response payloads will appear as soon as the first timeline event is ready.'
+                          : 'Request and response payloads will appear as soon as the first decision event is ready.'
+                      }
+                    />
+                  ) : (
+                    <EmptyAuditState
+                      title="Select a decision step"
+                      body="Choose one of the decision events on the left to inspect its request and response payload."
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MultiObjectiveDecisionPanel({ info }: { info: MultiObjectiveInfo }) {
+  const isCostWin = info.outcome === 'COST_WON'
+  const tone = isCostWin
+    ? 'border-cyan-200 bg-cyan-50/60 dark:border-cyan-900 dark:bg-cyan-950/30'
+    : 'border-slate-200 bg-slate-50/60 dark:border-[#1c1c24] dark:bg-[#0b0b10]'
+  const pillTone = isCostWin
+    ? 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/40 dark:text-cyan-200'
+    : 'bg-slate-200 text-slate-700 dark:bg-[#1f1f29] dark:text-slate-200'
+  return (
+    <Card>
+      <CardBody>
+        <div className={`rounded-2xl border px-4 py-3 ${tone}`}>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                Multi-Objective Decision
+              </span>
+              <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${pillTone}`}>
+                {isCostWin ? 'Cost won' : 'Auth won'}
+              </span>
+            </div>
+            <div className="text-right">
+              <span className="text-[11px] uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                Tolerance band
+              </span>
+              <p className="font-mono text-sm font-semibold text-slate-800 dark:text-slate-100">
+                {info.tolerancePp.toFixed(2)} pp
+              </p>
+            </div>
+          </div>
+
+          <p className="mt-3 text-sm text-slate-700 dark:text-slate-200 leading-relaxed">
+            {info.reason}
+          </p>
+
+          {isCostWin && info.costSavedBps != null && (
+            <div className="mt-3 inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200">
+              <span>Cost saved</span>
+              <span className="font-mono">{info.costSavedBps.toFixed(2)} bps</span>
+            </div>
+          )}
+
+          {(info.srHead || info.chosen) && (
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {info.srHead && (
+                <MultiObjectivePspCard
+                  label={isCostWin ? 'SR head (would have picked)' : 'SR head (kept)'}
+                  summary={info.srHead}
+                />
+              )}
+              {info.chosen && (
+                <MultiObjectivePspCard
+                  label={isCostWin ? 'Chosen by cost' : 'Final pick'}
+                  summary={info.chosen}
+                  emphasis={isCostWin}
+                />
+              )}
+            </div>
+          )}
+
+          <p className="mt-3 text-[11px] text-slate-500 dark:text-slate-400">
+            {info.qualifiedCount} PSP{info.qualifiedCount === 1 ? '' : 's'} qualified under the band.
+          </p>
+        </div>
+      </CardBody>
+    </Card>
+  )
+}
+
+function MultiObjectivePspCard({
+  label,
+  summary,
+  emphasis = false,
+}: {
+  label: string
+  summary: { psp: string; authRate: number; costBps: number | null }
+  emphasis?: boolean
+}) {
+  const borderTone = emphasis
+    ? 'border-cyan-300 bg-white dark:border-cyan-700 dark:bg-[#0d141a]'
+    : 'border-slate-200 bg-white dark:border-[#1c1c24] dark:bg-[#0d0d13]'
+  return (
+    <div className={`rounded-xl border px-3 py-2 ${borderTone}`}>
+      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+        {label}
+      </p>
+      <p className="mt-1 font-mono text-sm font-semibold text-slate-900 dark:text-white">
+        {summary.psp}
+      </p>
+      <div className="mt-1.5 flex gap-3 text-xs text-slate-600 dark:text-slate-300">
+        <span>
+          <span className="text-slate-400">auth</span>{' '}
+          <span className="font-mono">{(summary.authRate * 100).toFixed(2)}%</span>
+        </span>
+        <span>
+          <span className="text-slate-400">cost</span>{' '}
+          <span className="font-mono">
+            {summary.costBps != null ? `${summary.costBps.toFixed(2)} bps` : '—'}
+          </span>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -1,11 +1,10 @@
-import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { useDeferredValue, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { RuleEvaluationPanel } from './RuleEvaluationPanel'
 import { ErrorInfoFields, ErrorInfoState, GsmOptionRow, DEFAULT_ERROR_INFO } from './ErrorInfoFields'
 import { PenaltyClassificationGuide } from './PenaltyClassificationGuide'
 import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
 import { BarChart, Bar, LineChart, Line, ComposedChart, Area, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, ReferenceLine, ReferenceArea } from 'recharts'
-import { Tooltip as UiTooltip } from '../ui/Tooltip'
 import { Button } from '../ui/Button'
 import { Badge } from '../ui/Badge'
 import { Card, CardBody, CardHeader, SurfaceLabel } from '../ui/Card'
@@ -16,13 +15,13 @@ import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
 import { useAuthStore } from '../../store/authStore'
 import { apiPost, fetcher } from '../../lib/api'
 import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
-import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, RoutingEventType, UpdateScoreResponse } from '../../types/api'
+import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, RoutingEvent, RoutingEventType, UpdateScoreResponse } from '../../types/api'
 import { ROUTING_APPROACH_COLORS } from '../../lib/constants'
 import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
 import { describeRoutingEvent, useRoutingEvents } from '../../hooks/useRoutingEvents'
 import { FEATURE_FLAGS } from '../../lib/featureFlags'
-import { Play, RefreshCw, ChevronDown, ChevronUp, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings, ArrowRightLeft, Target, TrendingDown } from 'lucide-react'
+import { Play, RefreshCw, ChevronDown, ChevronUp, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings, ArrowRightLeft, Target, TrendingDown, Flag } from 'lucide-react'
 
 // UI-local algorithm tokens for the simulation dropdown. Maps to the backend
 // /decide-gateway request as follows:
@@ -868,13 +867,129 @@ export function DecisionSimulatorPage() {
   // the Events panel to the current run instead of the merchant's whole last hour.
   const [simulationStartedAtMs, setSimulationStartedAtMs] = useState<number | null>(null)
   // Live routing-event stream (leader flips, auth-band crossings), filtered to the run.
-  const routingEvents = useRoutingEvents('1h')
+  // Poll tightly while a run is producing events so the Autopilot feed keeps up;
+  // relax back to the idle cadence once it finishes.
+  const routingEvents = useRoutingEvents('1h', isSimulating ? 1_000 : 15_000)
   const sessionRoutingEvents = useMemo(() => {
     if (simulationStartedAtMs == null) return []
     const sinceMs = simulationStartedAtMs - EVENTS_RUN_START_MARGIN_MS
     return routingEvents.events.filter((event) => event.bucket_ms >= sinceMs)
   }, [routingEvents.events, simulationStartedAtMs])
+  // Keep the run's feed append-only. The backend re-detects every event from
+  // ClickHouse on each poll, and the trailing (still-filling) 1s bucket can make a
+  // just-emitted event flicker out on the next scan — so replacing the list each
+  // poll makes recent rows visibly vanish. Instead we merge each snapshot into a
+  // stable, ID-keyed accumulator (event IDs are deterministic), so once a row
+  // appears it stays for the run. Reset whenever a new run starts/clears.
+  const [accumulatedEvents, setAccumulatedEvents] = useState<RoutingEvent[]>([])
+  const accumulatedEventIdsRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    accumulatedEventIdsRef.current = new Set()
+    setAccumulatedEvents([])
+  }, [simulationStartedAtMs])
+  useEffect(() => {
+    const unseen = sessionRoutingEvents.filter((e) => !accumulatedEventIdsRef.current.has(e.id))
+    if (unseen.length === 0) return
+    unseen.forEach((e) => accumulatedEventIdsRef.current.add(e.id))
+    setAccumulatedEvents((prev) =>
+      prev
+        .concat(unseen)
+        .sort((a, b) => b.bucket_ms - a.bucket_ms || b.id.localeCompare(a.id))
+        .slice(0, 200),
+    )
+  }, [sessionRoutingEvents])
+  // Briefly highlight freshly-arrived Autopilot actions so a new leader change /
+  // band crossing catches the eye, then fades back. We diff incoming event IDs
+  // against the ones already seen; the very first batch is baselined silently so
+  // an existing backlog doesn't all flash at once on mount.
+  const [highlightedEventIds, setHighlightedEventIds] = useState<Set<string>>(new Set())
+  const seenEventIdsRef = useRef<Set<string>>(new Set())
+  const baselinedEventsRef = useRef(false)
+  const highlightTimersRef = useRef<number[]>([])
+  useEffect(() => {
+    const ids = accumulatedEvents.map((e) => e.id)
+    if (!baselinedEventsRef.current) {
+      ids.forEach((id) => seenEventIdsRef.current.add(id))
+      baselinedEventsRef.current = true
+      return
+    }
+    const fresh = ids.filter((id) => !seenEventIdsRef.current.has(id))
+    if (fresh.length === 0) return
+    fresh.forEach((id) => seenEventIdsRef.current.add(id))
+    setHighlightedEventIds((prev) => {
+      const next = new Set(prev)
+      fresh.forEach((id) => next.add(id))
+      return next
+    })
+    const timer = window.setTimeout(() => {
+      setHighlightedEventIds((prev) => {
+        const next = new Set(prev)
+        fresh.forEach((id) => next.delete(id))
+        return next
+      })
+    }, 12000)
+    highlightTimersRef.current.push(timer)
+  }, [accumulatedEvents])
+  useEffect(() => () => { highlightTimersRef.current.forEach((t) => window.clearTimeout(t)) }, [])
+  // Near-tied gateways produce storms of two kinds: a score parked on the auth-band
+  // edge re-crosses it on every wobble (enter/exit), and two leaders trading the #1
+  // spot fire a leader_changed on every swap. Collapse each consecutive run into a
+  // single "contesting" row that reports the net current state + how many times it
+  // flipped, so the feed stays readable instead of scrolling identical lines.
+  type FeedItem =
+    | { kind: 'single'; event: RoutingEvent }
+    | { kind: 'flap'; gateway: string; crossings: number; latest: RoutingEvent; inBand: boolean }
+    | { kind: 'leaderFlap'; gateways: string[]; crossings: number; latest: RoutingEvent }
+  const collapsedRoutingEvents = useMemo<FeedItem[]>(() => {
+    const isBand = (t: RoutingEventType) =>
+      t === 'gateway_entered_auth_band' || t === 'gateway_exited_auth_band'
+    const list = accumulatedEvents.slice(0, 50)
+    const items: FeedItem[] = []
+    let i = 0
+    while (i < list.length) {
+      const ev = list[i]
+      if (isBand(ev.event_type)) {
+        // list is newest-first; gather the adjacent run for this gateway.
+        let j = i
+        while (j < list.length && isBand(list[j].event_type) && list[j].gateway === ev.gateway) j++
+        const crossings = j - i
+        if (crossings > 1) {
+          items.push({
+            kind: 'flap',
+            gateway: ev.gateway,
+            crossings,
+            latest: ev,
+            inBand: ev.event_type === 'gateway_entered_auth_band',
+          })
+        } else {
+          items.push({ kind: 'single', event: ev })
+        }
+        i = j
+      } else if (ev.event_type === 'leader_changed') {
+        // Gather the adjacent run of lead swaps (any direction).
+        let j = i
+        while (j < list.length && list[j].event_type === 'leader_changed') j++
+        const crossings = j - i
+        if (crossings > 1) {
+          const gateways = Array.from(new Set(list.slice(i, j).map((e) => e.gateway))).sort()
+          items.push({ kind: 'leaderFlap', gateways, crossings, latest: ev })
+        } else {
+          items.push({ kind: 'single', event: ev })
+        }
+        i = j
+      } else {
+        items.push({ kind: 'single', event: ev })
+        i++
+      }
+    }
+    return items
+  }, [accumulatedEvents])
   const [showPenaltyGuide, setShowPenaltyGuide] = useState(false)
+  // SR / volume chart window: focus on the most recent N transactions (auto-follows
+  // the live stream) or 'all' for the full-session view. Both charts share this so
+  // their x-axes stay aligned.
+  const [chartWindow, setChartWindow] = useState<number | 'all'>(100)
+  const CHART_WINDOW_OPTIONS: (number | 'all')[] = [100, 500, 'all']
 
   const routingKeyNames = useMemo(
     () => Object.keys(routingKeysConfig).sort(),
@@ -1516,6 +1631,10 @@ export function DecisionSimulatorPage() {
     const MAX_CONSECUTIVE_ERRORS = 3
     let consecutiveErrors = 0
     let lastUIUpdate = 0
+    // Refreshing the events feed on every 150ms UI tick fires overlapping fetches
+    // whose out-of-order responses make rows flicker; ~1s keeps it fresh without
+    // the storm (the SWR poll runs at 1s too).
+    let lastEventsRefresh = 0
 
     const isMultiObjective = form.ranking_algorithm === 'SR_MULTI_OBJECTIVE'
 
@@ -1628,6 +1747,12 @@ export function DecisionSimulatorPage() {
             markExplorerRunDataUpdated()
             lastUIUpdate = now
           }
+          // Pull fresh Autopilot events at most ~once/sec (throttled apart from the
+          // UI tick) so the feed stays current without a fetch storm.
+          if (now - lastEventsRefresh > 1000 || i === total - 1) {
+            routingEvents.refresh()
+            lastEventsRefresh = now
+          }
         } catch (e: unknown) {
           consecutiveErrors++
           if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
@@ -1641,6 +1766,8 @@ export function DecisionSimulatorPage() {
     } finally {
       setSimulationResults([...results])
       setIsSimulating(false)
+      // Final flush: events from the last txns can land just after the loop ends.
+      routingEvents.refresh()
     }
   }
 
@@ -1785,10 +1912,6 @@ export function DecisionSimulatorPage() {
 
   const totalSimulationPayments = parseInt(simulationConfig.totalPayments) || 0
   const completedSimulationCount = simulationResults.length
-  const simulationProgressPercentage =
-    totalSimulationPayments > 0
-      ? Math.round((completedSimulationCount / totalSimulationPayments) * 100)
-      : 0
   const hasSimulationActivity = isSimulating || completedSimulationCount > 0
 
   const eligibleGatewaysParsed = useMemo(
@@ -1831,19 +1954,6 @@ export function DecisionSimulatorPage() {
     return acc
   }, {} as Record<string, { total: number; success: number; failure: number }>), [deferredSimulationResults])
 
-  // Latest SR score the routing engine assigned to each gateway (gatewayPriorityMap),
-  // i.e. the "real" success rate plotted in the trend chart — not the observed success/total ratio.
-  const gatewaySrScores = useMemo(() => {
-    const scores: Record<string, number> = {}
-    for (const r of deferredSimulationResults) {
-      if (r.routingApproach?.includes('HEDGING') || !r.gatewayPriorityMap) continue
-      for (const [gw, score] of Object.entries(r.gatewayPriorityMap)) {
-        if (score !== undefined && score !== null) scores[gw] = Math.round((score as number) * 100)
-      }
-    }
-    return scores
-  }, [deferredSimulationResults])
-
   // Live cost-optimisation tolerance band (pp) — the most recent value the router reported
   // for this run, falling back to the configured default when no decision carried one.
   const costRoutingTolerancePp = useMemo(() => {
@@ -1854,32 +1964,53 @@ export function DecisionSimulatorPage() {
     return DEFAULT_COST_ROUTING_TOLERANCE
   }, [deferredSimulationResults])
 
-  // Single forward pass: carry the last seen non-hedging score for each gateway forward,
-  // sampling every `step` results. O(n) vs the previous O(n × MAX_PTS) backward search.
+  // Per-gateway engine SR-score trend. Each line plots the routing engine's
+  // priority score for that gateway (gateway_priority_map), i.e. the same value
+  // shown in the Transaction Log "SR Score" column — not the realized outcome
+  // rate. This is the score the engine actually routes on, so the Top-PSP line
+  // and the cost-eligible band below reflect the real Auth-vs-Cost decisions.
+  // A normal SR decision emits a full map of every eligible gateway's score;
+  // hedging decisions emit only an exploratory {decidedGateway: 1.0} entry, so
+  // we skip those to avoid 100% spikes and carry forward each gateway's last
+  // real score instead.
   const gatewaySparklines = useMemo(() => {
     const results = deferredSimulationResults
-    const empty = { series: {} as Record<string, number[]>, paymentNums: [] as number[], yMin: 0, yMax: 100 }
+    const empty = { series: {} as Record<string, (number | null)[]>, paymentNums: [] as number[], yMin: 0, yMax: 100 }
     if (results.length < 2) return empty
 
-    const MAX_PTS = 200
-    const step = Math.max(1, Math.floor(results.length / MAX_PTS))
+    const TARGET_POINTS = 80
+    // Focus on the last `chartWindow` transactions (or the whole run). Bucketing
+    // across just the window — not the full session — gives recent events more
+    // resolution rather than cropping a coarse 80-point view of everything.
+    const windowStart = chartWindow === 'all' ? 0 : Math.max(0, results.length - chartWindow)
+    const windowLen = results.length - windowStart
+    const bucketSize = Math.max(1, Math.ceil(windowLen / TARGET_POINTS))
     const gateways = Object.keys(gatewayStats)
-    const lastScore: Record<string, number> = {}
-    const series: Record<string, number[]> = {}
+    const lastScore: Record<string, number> = {}  // engine score (0–100), carried forward
+    const series: Record<string, (number | null)[]> = {}
     gateways.forEach(gw => { series[gw] = [] })
     const paymentNums: number[] = []
 
     for (let i = 0; i < results.length; i++) {
       const r = results[i]
-      if (!r.routingApproach?.includes('HEDGING') && r.gatewayPriorityMap) {
+      const pm = r.gatewayPriorityMap
+      // Refresh every gateway's score from the decision's priority map, skipping
+      // hedging (single-entry exploratory map at 1.0) so the band stays meaningful.
+      if (pm && !r.routingApproach?.includes('HEDGING')) {
         for (const gw of gateways) {
-          const score = r.gatewayPriorityMap[gw]
-          if (score !== undefined && score !== null) lastScore[gw] = Math.round(score * 100)
+          const s = pm[gw]
+          if (typeof s === 'number') lastScore[gw] = Math.round(s * 100)
         }
       }
-      if (i % step === 0 || i === results.length - 1) {
+      // Transactions before the window only seed the carried-forward score so the
+      // left edge opens at the correct value; they aren't plotted.
+      if (i < windowStart) continue
+      const posInWindow = i - windowStart
+      // Sample every gateway's current engine score at the bucket boundary. A gateway
+      // with no score yet records null (skipped by the chart) rather than a 0 dip.
+      if ((posInWindow + 1) % bucketSize === 0 || i === results.length - 1) {
         paymentNums.push(i + 1)
-        for (const gw of gateways) series[gw].push(lastScore[gw] ?? 0)
+        for (const gw of gateways) series[gw].push(lastScore[gw] ?? null)
       }
     }
 
@@ -1887,7 +2018,7 @@ export function DecisionSimulatorPage() {
     let obsMin = 100, obsMax = 0
     for (const gw of gateways) {
       for (const v of series[gw]) {
-        if (v > 0) { if (v < obsMin) obsMin = v; if (v > obsMax) obsMax = v }
+        if (v != null && v > 0) { if (v < obsMin) obsMin = v; if (v > obsMax) obsMax = v }
       }
     }
     if (obsMin > obsMax) { obsMin = 0; obsMax = 100 }
@@ -1895,18 +2026,53 @@ export function DecisionSimulatorPage() {
     const yMax = Math.min(100, obsMax + 2)
 
     return { series, paymentNums, yMin, yMax }
-  }, [deferredSimulationResults, gatewayStats])
+  }, [deferredSimulationResults, gatewayStats, chartWindow])
+
+  // Rolling routing-share trend, paired with the SR chart on the same x-axis.
+  // For each bucket it reports the share of the last ≤WINDOW transactions that
+  // went to each gateway, normalized to sum to 100% per point. Drawn as a 100%
+  // stacked area so the split is always full height — you read the live traffic
+  // mix directly and watch a connector's band grow or shrink as routing shifts.
+  const gatewayVolumeTrend = useMemo(() => {
+    const results = deferredSimulationResults
+    const gateways = Object.keys(gatewayStats)
+    const empty = { data: [] as Record<string, number>[], gateways, windowSize: 1 }
+    if (results.length < 2) return empty
+
+    const ROLLING_WINDOW = 50
+    const TARGET_POINTS = 80
+    // Match the SR chart's window so both x-axes stay aligned.
+    const windowStart = chartWindow === 'all' ? 0 : Math.max(0, results.length - chartWindow)
+    const windowLen = results.length - windowStart
+    const bucketSize = Math.max(1, Math.ceil(windowLen / TARGET_POINTS))
+    const recent: string[] = []  // decided gateway of the last ≤WINDOW transactions
+    const data: Record<string, number>[] = []
+
+    for (let i = 0; i < results.length; i++) {
+      // Keep rolling the share window across all history so the left edge of the
+      // visible window still has full ≤ROLLING_WINDOW lookback, but only emit
+      // points inside the window.
+      recent.push(results[i].decidedGateway)
+      if (recent.length > ROLLING_WINDOW) recent.shift()
+      if (i < windowStart) continue
+      const posInWindow = i - windowStart
+      if ((posInWindow + 1) % bucketSize === 0 || i === results.length - 1) {
+        const counts: Record<string, number> = {}
+        for (const gw of recent) counts[gw] = (counts[gw] ?? 0) + 1
+        const total = recent.length || 1
+        const row: Record<string, number> = { step: i + 1 }
+        for (const gw of gateways) row[gw] = Math.round(((counts[gw] ?? 0) / total) * 1000) / 10
+        data.push(row)
+      }
+    }
+    return { data, gateways, windowSize: ROLLING_WINDOW }
+  }, [deferredSimulationResults, gatewayStats, chartWindow])
 
   const hedgingHits = useMemo(
     () => deferredSimulationResults.filter(r => r.routingApproach?.includes('HEDGING')).length,
     [deferredSimulationResults],
   )
 
-  const smartRetryStats = useMemo(() => {
-    const triggered = deferredSimulationResults.filter(r => r.retryGateway !== undefined).length
-    const recovered = deferredSimulationResults.filter(r => r.retryStatus === 'CHARGED').length
-    return { triggered, recovered }
-  }, [deferredSimulationResults])
 
   const totalCostSaved = useMemo(() => {
     let value = 0
@@ -2100,6 +2266,11 @@ export function DecisionSimulatorPage() {
       setSimulationConfig(defaults.simulationConfig)
       setGatewaySimConfigs({})
       setSimulationResults(defaults.simulationResults)
+      // Abort any in-flight run and drop the run-start timestamp so the
+      // Autopilot Actions feed (scoped to simulationStartedAtMs) clears back
+      // to its empty state instead of replaying the previous run's events.
+      simulationAbortRef.current = true
+      setSimulationStartedAtMs(null)
       setIsSimulating(false)
     } else if (activeTab === 'rule') {
       setRuleResetSignal(n => n + 1)
@@ -2171,7 +2342,7 @@ export function DecisionSimulatorPage() {
       )}
 
       {activeTab === 'batch' && (
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)] lg:items-stretch">
           <div className="flex flex-wrap items-end gap-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 dark:border-[#222226] dark:bg-[#0b0b10]">
             {[
               { key: 'stripe', label: 'Stripe success rate' },
@@ -2197,8 +2368,13 @@ export function DecisionSimulatorPage() {
                     max={100}
                     value={rate}
                     onChange={e => setGwSuccessRate(key, Number(e.target.value))}
-                    className="h-1 w-full cursor-pointer"
-                    style={{ accentColor: color }}
+                    className="mt-1 h-1.5 w-full cursor-pointer appearance-none rounded-full outline-none
+                      [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:bg-[color:var(--thumb)] [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:transition-transform [&::-webkit-slider-thumb]:hover:scale-110 [&::-webkit-slider-thumb]:active:scale-95
+                      [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:border-solid [&::-moz-range-thumb]:bg-[color:var(--thumb)] [&::-moz-range-thumb]:shadow"
+                    style={{
+                      '--thumb': color,
+                      background: `linear-gradient(to right, ${color} ${rate}%, rgba(148,163,184,0.45) ${rate}%)`,
+                    } as CSSProperties}
                   />
                 </div>
               )
@@ -2208,7 +2384,7 @@ export function DecisionSimulatorPage() {
               onClick={isSimulating ? () => { simulationAbortRef.current = true } : runSimulation}
               disabled={!effectiveMerchantId || routingConfigUnavailable}
               variant={isSimulating ? 'secondary' : 'primary'}
-              className="self-end"
+              className="self-end lg:ml-auto"
             >
               {isSimulating ? <><X size={14} /> Stop</> : <><Play size={14} className="fill-current" /> Run simulation</>}
             </Button>
@@ -2216,13 +2392,13 @@ export function DecisionSimulatorPage() {
 
           <div className="flex flex-1 flex-wrap items-end justify-around gap-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 dark:border-[#222226] dark:bg-[#0b0b10]">
             <div className="flex flex-col gap-1.5">
-              <SurfaceLabel>Total auth won</SurfaceLabel>
+              <SurfaceLabel>Total SR decisions</SurfaceLabel>
               <p className="py-1.5 text-lg font-semibold leading-snug tabular-nums text-sky-600 dark:text-sky-400">
                 {multiObjectiveStats.authWon.toLocaleString()}
               </p>
             </div>
             <div className="flex flex-col gap-1.5">
-              <SurfaceLabel>Total cost won</SurfaceLabel>
+              <SurfaceLabel>Total Cost overrides</SurfaceLabel>
               <p className="py-1.5 text-lg font-semibold leading-snug tabular-nums text-violet-600 dark:text-violet-400">
                 {multiObjectiveStats.costWon.toLocaleString()}
               </p>
@@ -2240,104 +2416,22 @@ export function DecisionSimulatorPage() {
       <div className={activeTab === 'volume'
         ? 'grid grid-cols-1 gap-5 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]'
         : activeTab === 'batch'
-          ? 'grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)]'
+          ? 'grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)] lg:items-stretch lg:h-[calc(100vh-220px)] lg:min-h-[560px] lg:max-h-[760px]'
           : 'grid grid-cols-1 gap-6 lg:grid-cols-2'
       }
         style={activeTab === 'rule' ? { display: 'none' } : undefined}
       >
-        <div className={`flex flex-col gap-6 min-w-0 ${activeTab === 'batch' ? '' : 'self-start'}`}>
+        <div className={`flex flex-col gap-6 min-w-0 ${activeTab === 'batch' ? 'lg:min-h-0' : 'self-start'}`}>
         {activeTab === 'batch' && (
                 <Card className="flex-1">
-                  <CardHeader className="!py-3">
-                    <div className="flex items-center justify-between gap-3">
-                      <h3 className="text-sm font-medium text-slate-800 dark:text-white">Gateway Selection Summary</h3>
-                      <div className="flex items-center gap-1.5">
-                        {totalSimulationPayments > 0 && (() => {
-                          const r = 6
-                          const circ = 2 * Math.PI * r
-                          const offset = circ * (1 - simulationProgressPercentage / 100)
-                          return (
-                            <svg width="16" height="16" viewBox="0 0 16 16" className="-rotate-90">
-                              <circle cx="8" cy="8" r={r} fill="none" strokeWidth="2" className="stroke-slate-200 dark:stroke-slate-700" />
-                              <circle
-                                cx="8" cy="8" r={r} fill="none" strokeWidth="2" strokeLinecap="round"
-                                strokeDasharray={circ} strokeDashoffset={offset}
-                                className="stroke-brand-500 transition-[stroke-dashoffset] duration-300"
-                              />
-                            </svg>
-                          )
-                        })()}
-                        <span className="text-[11px] text-slate-500 dark:text-slate-400">
-                          {completedSimulationCount} / {totalSimulationPayments || 0}
-                        </span>
-                        {completedSimulationCount > 0 && (
-                          <>
-                            <span className="text-slate-300 dark:text-slate-600">·</span>
-                            {hedgingHits > 0 ? (
-                              <span className="text-[11px] font-medium text-brand-600 dark:text-sky-400">
-                                {Math.round((hedgingHits / completedSimulationCount) * 100)}% hedged
-                              </span>
-                            ) : (
-                              <UiTooltip text="Enable ENABLE_EXPLORE_AND_EXPLOIT_ON_SRV3_{PMT} or ENABLE_MERCHANT_ON_VOLUME_DISTRIBUTION_FEATURE_SR_V3 in Redis">
-                                <span className="text-[11px] text-amber-500 dark:text-amber-400 cursor-help">0 hedged</span>
-                              </UiTooltip>
-                            )}
-                            {smartRetryEnabled && smartRetryStats.triggered > 0 && (
-                              <>
-                                <span className="text-slate-300 dark:text-slate-600">·</span>
-                                <UiTooltip text={`${smartRetryStats.triggered} retries triggered · ${smartRetryStats.recovered} recovered`}>
-                                  <span className="text-[11px] font-medium text-orange-500 dark:text-orange-400 cursor-help">
-                                    {smartRetryStats.triggered} retried · {smartRetryStats.recovered} recovered
-                                  </span>
-                                </UiTooltip>
-                              </>
-                            )}
-                            {totalCostSaved.value > 0 && totalCostSaved.currency && (
-                              <>
-                                <span className="text-slate-300 dark:text-slate-600">·</span>
-                                <span className="text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
-                                  saved {formatCurrencyValue(totalCostSaved.value, totalCostSaved.currency)}
-                                </span>
-                              </>
-                            )}
-                          </>
-                        )}
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardBody className="!pt-3 flex flex-1 flex-col">
+                  <CardBody className="!pt-4 flex flex-1 flex-col">
                     {sortedGatewayStats.length > 0 ? (() => {
-                      const totalRouted = totalRoutedPayments
                       const sortedGateways = sortedGatewayStats
                       const hasAnySpark = sortedGateways.some(([gw]) => (gatewaySparklines.series[gw]?.length ?? 0) >= 2)
                       return (
                         <div className="flex flex-1 flex-col gap-4">
-                          {/* per-gateway stat rows */}
-                          <div className="space-y-2">
-                            {sortedGateways.map(([gateway, stats]) => {
-                              const share = totalRouted > 0 ? Math.round((stats.total / totalRouted) * 100) : 0
-                              const observedSr = stats.total > 0 ? Math.round((stats.success / stats.total) * 100) : 0
-                              const srPct = gatewaySrScores[gateway] ?? observedSr
-                              const gwColor = gatewayColorMap[gateway] ?? GW_PALETTE[0]
-                              return (
-                                <div key={gateway} className="space-y-1">
-                                  <div className="flex items-center justify-end gap-1.5">
-                                    <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: gwColor }} />
-                                    <span className="text-xs font-semibold text-slate-700 dark:text-slate-200 truncate shrink-0 w-14 text-left">{gateway}</span>
-                                    <span className={`font-bold tabular-nums text-[11px] w-14 text-right ${srPct >= 80 ? 'text-emerald-600 dark:text-emerald-400' : srPct >= 50 ? 'text-amber-500' : 'text-red-500'}`}>{srPct}% SR</span>
-                                    <span className="text-slate-300 dark:text-slate-600 text-[11px]">·</span>
-                                    <span className="text-slate-400 dark:text-slate-500 tabular-nums text-[11px] w-16 text-right">{share}% routed</span>
-                                    <span className="text-slate-300 dark:text-slate-600 text-[11px]">·</span>
-                                    <span className="tabular-nums text-slate-500 dark:text-slate-400 text-[11px] w-12 text-right">
-                                      <span className="text-emerald-600 dark:text-emerald-400">{stats.success}</span>
-                                      <span className="text-slate-300 dark:text-slate-600 mx-0.5">/</span>
-                                      <span className="text-red-400">{stats.failure}</span>
-                                    </span>
-                                  </div>
-                                </div>
-                              )
-                            })}
-                          </div>
+                          {/* per-gateway stat rows moved to the Gateway Selection Summary
+                              card in the right column (enlarged, above Autopilot Actions). */}
                           {/* combined multi-line SR trend chart */}
                           {hasAnySpark && (() => {
                             const { series, paymentNums } = gatewaySparklines
@@ -2367,12 +2461,51 @@ export function DecisionSimulatorPage() {
                               }
                               return row
                             })
-                            const bandLabel = `Dynamic Threshold (Top PSP − ${bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp)`
+                            // Zoom the Y-axis to the data band instead of a fixed 0–100%.
+                            // SR lines and the threshold typically sit in the upper range, so
+                            // anchoring the floor just below the lowest plotted value removes the
+                            // dead space under ~75% and makes the contended region legible.
+                            const yValues: number[] = []
+                            chartData.forEach((row) => {
+                              sortedGateways.forEach(([gw]) => { if (row[gw] != null) yValues.push(row[gw]) })
+                              if (row.threshold != null) yValues.push(row.threshold)
+                            })
+                            const dataMin = yValues.length ? Math.min(...yValues) : 0
+                            const yMin = Math.max(0, Math.floor((dataMin - 5) / 5) * 5)
+                            const bandLabel = `SR threshold for cost override`
                             return (
                               <div className="w-full flex-1 min-h-[320px] flex flex-col">
+                                <div className="mb-2 flex items-start justify-between gap-3">
+                                  <div>
+                                    <h4 className="text-sm font-medium text-slate-800 dark:text-white">Success Rate Trend</h4>
+                                    <p className="text-[13px] text-slate-400 dark:text-slate-500">Engine routing score per connector, with the cost-eligible band below the leader</p>
+                                  </div>
+                                  <div className="flex items-center gap-2 shrink-0">
+                                    <span className="text-[11px] text-slate-400 dark:text-slate-500">Window</span>
+                                    <div className="inline-flex rounded-md border border-slate-200 dark:border-[#1f1f29] p-0.5">
+                                      {CHART_WINDOW_OPTIONS.map((opt) => {
+                                        const active = chartWindow === opt
+                                        return (
+                                          <button
+                                            key={String(opt)}
+                                            type="button"
+                                            onClick={() => setChartWindow(opt)}
+                                            className={`px-2.5 py-1 text-[11px] font-medium rounded transition-colors ${
+                                              active
+                                                ? 'bg-brand-500 text-white'
+                                                : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'
+                                            }`}
+                                          >
+                                            {opt === 'all' ? 'All' : `Last ${opt}`}
+                                          </button>
+                                        )
+                                      })}
+                                    </div>
+                                  </div>
+                                </div>
                                 <div className="min-h-0 flex-1">
                                 <ResponsiveContainer width="100%" height="100%">
-                                  <ComposedChart data={chartData} margin={{ top: 16, right: 8, bottom: 28, left: 0 }}>
+                                  <ComposedChart data={chartData} margin={{ top: 16, right: 8, bottom: 8, left: 0 }}>
                                     <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:opacity-20" vertical={false} />
                                     <Area dataKey="threshold" stackId="elig" stroke="none" fill="transparent" isAnimationActive={false} legendType="none" activeDot={false} connectNulls />
                                     <Area dataKey="eligibleSpan" stackId="elig" stroke="none" fill="#10b981" fillOpacity={0.08} isAnimationActive={false} legendType="none" activeDot={false} connectNulls />
@@ -2382,10 +2515,10 @@ export function DecisionSimulatorPage() {
                                       tickLine={false}
                                       axisLine={{ stroke: '#e2e8f0' }}
                                       minTickGap={28}
-                                      label={{ value: 'Number of Transactions', position: 'insideBottom', offset: -12, fontSize: 11, fill: '#94a3b8' }}
                                     />
                                     <YAxis
-                                      domain={[0, 100]}
+                                      domain={[yMin, 100]}
+                                      allowDataOverflow
                                       tick={{ fontSize: 11, fill: '#94a3b8' }}
                                       tickLine={false}
                                       axisLine={{ stroke: '#e2e8f0' }}
@@ -2476,6 +2609,107 @@ export function DecisionSimulatorPage() {
                               </div>
                             )
                           })()}
+                          {/* routing-share trend — traffic split across connectors */}
+                          {gatewayVolumeTrend.data.length >= 2 && (() => {
+                            const { data, gateways } = gatewayVolumeTrend
+                            const latest = data[data.length - 1] ?? {}
+                            const colorFor = (gw: string, idx: number) => gatewayColorMap[gw] ?? GW_PALETTE[idx % GW_PALETTE.length]
+                            const latestSplit = gateways
+                              .map((gw, idx) => ({ gw, share: latest[gw] ?? 0, color: colorFor(gw, idx) }))
+                              .sort((a, b) => b.share - a.share)
+                            // Each connector is its own line at its real share (they sum to
+                            // 100%, but are not stacked) so a hand-off shows as the two lines
+                            // crossing. Paint the taller area first so the smaller one's line
+                            // stays visible on top.
+                            const drawOrder = gateways
+                              .map((gw, idx) => ({ gw, idx, share: latest[gw] ?? 0 }))
+                              .sort((a, b) => b.share - a.share)
+                            return (
+                              <div className="w-full border-t border-slate-100 pt-4 dark:border-[#1a1a22]">
+                                <div className="mb-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+                                  <div>
+                                    <h4 className="text-sm font-medium text-slate-800 dark:text-white">Routing Distribution</h4>
+                                  </div>
+                                  <div className="flex flex-wrap items-center gap-1.5">
+                                    {latestSplit.map(({ gw, share, color }) => (
+                                      <span
+                                        key={gw}
+                                        className="inline-flex items-center gap-1.5 rounded-full bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-600 ring-1 ring-inset ring-slate-200/70 dark:bg-[#12121a] dark:text-slate-300 dark:ring-[#22222c]"
+                                      >
+                                        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: color }} />
+                                        {gw}
+                                        <span className="tabular-nums font-semibold text-slate-900 dark:text-white">{Math.round(share)}%</span>
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                                <div className="h-[200px] w-full">
+                                  <ResponsiveContainer width="100%" height="100%">
+                                    <ComposedChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: 0 }}>
+                                      <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:opacity-20" vertical={false} />
+                                      <XAxis
+                                        dataKey="step"
+                                        tick={{ fontSize: 11, fill: '#94a3b8' }}
+                                        tickLine={false}
+                                        axisLine={{ stroke: '#e2e8f0' }}
+                                        minTickGap={28}
+                                      />
+                                      <YAxis
+                                        domain={[0, 100]}
+                                        ticks={[0, 25, 50, 75, 100]}
+                                        tick={{ fontSize: 11, fill: '#94a3b8' }}
+                                        tickLine={false}
+                                        axisLine={{ stroke: '#e2e8f0' }}
+                                        width={44}
+                                        tickFormatter={(v: number) => `${v}%`}
+                                      />
+                                      <Tooltip
+                                        cursor={{ stroke: '#cbd5e1', strokeWidth: 1 }}
+                                        content={(props) => {
+                                          const { active, payload } = props as unknown as { active?: boolean; payload?: Array<{ payload?: Record<string, number> }> }
+                                          if (!active || !payload || !payload.length) return null
+                                          const row = payload[0].payload
+                                          if (!row) return null
+                                          const rows = gateways
+                                            .map((gw, idx) => ({ gw, share: row[gw] ?? 0, color: colorFor(gw, idx) }))
+                                            .sort((a, b) => b.share - a.share)
+                                          return (
+                                            <div style={{ ...CHART_TOOLTIP_STYLE, padding: '10px 12px', fontSize: 12, lineHeight: 1.5, minWidth: 170 }}>
+                                              <p style={{ ...CHART_TOOLTIP_LABEL_STYLE, margin: '0 0 6px' }}>Payment {row.step}</p>
+                                              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                                                {rows.map(({ gw, share, color }) => (
+                                                  <div key={gw} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                                                    <span style={{ width: 8, height: 8, borderRadius: 2, backgroundColor: color, flexShrink: 0 }} />
+                                                    <span style={{ color, fontWeight: 600 }}>{gw}</span>
+                                                    <span style={{ marginLeft: 'auto', fontVariantNumeric: 'tabular-nums' }}>{share.toFixed(1)}%</span>
+                                                  </div>
+                                                ))}
+                                              </div>
+                                            </div>
+                                          )
+                                        }}
+                                      />
+                                      {drawOrder.map(({ gw, idx }) => (
+                                        <Area
+                                          key={gw}
+                                          type="monotone"
+                                          dataKey={gw}
+                                          name={gw}
+                                          stroke={colorFor(gw, idx)}
+                                          fill={colorFor(gw, idx)}
+                                          fillOpacity={0.18}
+                                          strokeWidth={2.5}
+                                          isAnimationActive={false}
+                                          legendType="none"
+                                          activeDot={{ r: 3.5, strokeWidth: 0 }}
+                                        />
+                                      ))}
+                                    </ComposedChart>
+                                  </ResponsiveContainer>
+                                </div>
+                              </div>
+                            )
+                          })()}
                         </div>
                       )
                     })() : (() => {
@@ -2509,7 +2743,7 @@ export function DecisionSimulatorPage() {
                           </div>
                           <div className="w-full flex-1 min-h-[300px]">
                             <ResponsiveContainer width="100%" height="100%">
-                              <LineChart data={chartData} margin={{ top: 16, right: 8, bottom: 20, left: 0 }}>
+                              <LineChart data={chartData} margin={{ top: 16, right: 8, bottom: 8, left: 0 }}>
                                 <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:opacity-20" vertical={false} />
                                 <XAxis
                                   dataKey="step"
@@ -2517,7 +2751,6 @@ export function DecisionSimulatorPage() {
                                   tickLine={false}
                                   axisLine={{ stroke: '#e2e8f0' }}
                                   minTickGap={28}
-                                  label={{ value: 'Number of Transactions', position: 'insideBottom', offset: -12, fontSize: 11, fill: '#94a3b8' }}
                                 />
                                 <YAxis
                                   domain={[0, 100]}
@@ -2979,7 +3212,7 @@ export function DecisionSimulatorPage() {
         )}
         </div>
 
-        <div className="min-w-0 flex flex-col gap-4">
+        <div className={`min-w-0 flex flex-col gap-4 ${activeTab === 'batch' ? 'lg:min-h-0' : ''}`}>
           {activeTab === 'debit' ? (
             debitResult ? (
               <>
@@ -3332,18 +3565,65 @@ export function DecisionSimulatorPage() {
             )
           ) : activeTab === 'batch' ? (
             <>
-              {/* Events — routing events from the active simulation run only. */}
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between gap-3">
+              {/* Run summary — per-gateway stats lifted above the feed and enlarged.
+                  The run progress / hedged / saved line stays on the chart card to
+                  avoid duplicating it here. */}
+              {hasSimulationActivity && (
+                <Card className="lg:shrink-0">
+                  <CardHeader className="flex flex-row items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-medium text-slate-800 dark:text-white">Gateway Selection Summary</h3>
+                      <p className="text-[13px] text-slate-400 dark:text-slate-500 mt-0.5">Overall success rate &amp; routed share across the run</p>
+                    </div>
+                    <span className="text-[13px] tabular-nums flex items-center gap-1.5 shrink-0">
+                      <span className="text-slate-400">{completedSimulationCount} / {totalSimulationPayments || 0}</span>
+                      {completedSimulationCount > 0 && hedgingHits > 0 && (
+                        <>
+                          <span className="text-slate-300 dark:text-slate-600">·</span>
+                          <span className="font-medium text-brand-600 dark:text-sky-400">
+                            {Math.round((hedgingHits / completedSimulationCount) * 100)}% hedged
+                          </span>
+                        </>
+                      )}
+                    </span>
+                  </CardHeader>
+                  <CardBody className="space-y-3">
+                    {sortedGatewayStats.map(([gateway, stats]) => {
+                      const share = totalRoutedPayments > 0 ? Math.round((stats.total / totalRoutedPayments) * 100) : 0
+                      const srPct = stats.total > 0 ? Math.round((stats.success / stats.total) * 100) : 0
+                      const gwColor = gatewayColorMap[gateway] ?? GW_PALETTE[0]
+                      return (
+                        <div key={gateway} className="flex items-center gap-2.5">
+                          <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: gwColor }} />
+                          <span className="text-sm font-semibold text-slate-800 dark:text-slate-100 w-20 truncate">{gateway}</span>
+                          <span className={`text-lg font-bold tabular-nums leading-none ${srPct >= 80 ? 'text-emerald-600 dark:text-emerald-400' : srPct >= 50 ? 'text-amber-500' : 'text-red-500'}`}>{srPct}%</span>
+                          <span className="text-[11px] text-slate-400 dark:text-slate-500">overall SR</span>
+                          <span className="ml-auto flex items-center gap-2 text-xs tabular-nums text-slate-500 dark:text-slate-400">
+                            <span>{share}% of traffic</span>
+                            <span className="text-slate-300 dark:text-slate-600">·</span>
+                            <span>
+                              <span className="text-emerald-600 dark:text-emerald-400">{stats.success}</span>
+                              <span className="text-slate-300 dark:text-slate-600 mx-0.5">/</span>
+                              <span className="text-red-400">{stats.failure}</span>
+                            </span>
+                          </span>
+                        </div>
+                      )
+                    })}
+                  </CardBody>
+                </Card>
+              )}
+              {/* Autopilot Actions — fills the column now the transaction log moved full-width below. */}
+              <Card className="lg:flex-1 lg:min-h-0 lg:flex lg:flex-col">
+                <CardHeader className="flex flex-row items-center justify-between gap-3 lg:shrink-0">
                   <span className="flex items-center gap-2.5">
-                    <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.18)]" />
                     <h3 className="text-sm font-medium text-slate-800 dark:text-white">Autopilot Actions</h3>
                   </span>
-                  {sessionRoutingEvents.length > 0 && (
-                    <span className="text-xs text-slate-400 tabular-nums">{sessionRoutingEvents.length} actions</span>
+                  {accumulatedEvents.length > 0 && (
+                    <span className="text-xs text-slate-400 tabular-nums">{accumulatedEvents.length} actions</span>
                   )}
                 </CardHeader>
-                <CardBody className="p-0">
+                <CardBody className="p-0 lg:flex-1 lg:min-h-0 lg:flex lg:flex-col">
                   {simulationStartedAtMs == null ? (
                     <div className="py-12 text-center">
                       <p className="text-sm text-slate-500 dark:text-slate-400">No events yet</p>
@@ -3358,126 +3638,100 @@ export function DecisionSimulatorPage() {
                         The analytics pipeline (Kafka → ClickHouse) is offline for this environment.
                       </p>
                     </div>
-                  ) : sessionRoutingEvents.length === 0 ? (
-                    <div className="py-12 text-center">
-                      <p className="text-sm text-slate-500 dark:text-slate-400">Waiting for events…</p>
-                      <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
-                        No leader changes or auth-band crossings for this run yet.
-                      </p>
-                    </div>
                   ) : (
-                    <div className="max-h-[360px] overflow-y-auto divide-y divide-slate-100 dark:divide-[#1a1a22]">
-                      {sessionRoutingEvents.slice(0, 50).map((event) => {
+                    <div className="max-h-[240px] overflow-y-auto lg:max-h-none lg:flex-1 lg:min-h-0 divide-y divide-slate-100 dark:divide-[#1a1a22]">
+                      {collapsedRoutingEvents.map((item) => {
+                        if (item.kind === 'leaderFlap') {
+                          const isFresh = highlightedEventIds.has(item.latest.id)
+                          return (
+                            <div
+                              key={item.latest.id}
+                              className={`flex items-start gap-2.5 px-4 py-2.5 transition-colors duration-1000 ${isFresh ? 'bg-emerald-200 dark:bg-emerald-500/25' : 'bg-transparent'}`}
+                            >
+                              <div className="mt-0.5 shrink-0">
+                                <ArrowRightLeft size={16} className="text-sky-500" />
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <p className="text-[15px] text-slate-700 dark:text-slate-200">
+                                  {item.gateways.join(' & ')} competing closely on success
+                                  <span className="ml-1.5 rounded-full bg-sky-100 px-1.5 py-0.5 text-[11px] font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-300">×{item.crossings}</span>
+                                </p>
+                                <p className="mt-0.5 text-[13px] text-slate-600 dark:text-slate-400">
+                                  now routing to {item.latest.gateway} · {formatSimEventTime(item.latest.bucket_ms)}
+                                </p>
+                              </div>
+                            </div>
+                          )
+                        }
+                        if (item.kind === 'flap') {
+                          const isFresh = highlightedEventIds.has(item.latest.id)
+                          return (
+                            <div
+                              key={item.latest.id}
+                              className={`flex items-start gap-2.5 px-4 py-2.5 transition-colors duration-1000 ${isFresh ? 'bg-emerald-200 dark:bg-emerald-500/25' : 'bg-transparent'}`}
+                            >
+                              <div className="mt-0.5 shrink-0">
+                                <RefreshCw size={16} className="text-amber-500" />
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <p className="text-[15px] text-slate-700 dark:text-slate-200">
+                                  {item.gateway} fluctuating at the cost-savings cutoff
+                                  <span className="ml-1.5 rounded-full bg-amber-100 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">×{item.crossings}</span>
+                                </p>
+                                <p className="mt-0.5 text-[13px] text-slate-600 dark:text-slate-400">
+                                  now {item.inBand ? 'routed to save cost' : 'using top performer only'} · {formatSimEventTime(item.latest.bucket_ms)}
+                                </p>
+                              </div>
+                            </div>
+                          )
+                        }
+                        const event = item.event
                         const meta = SIM_EVENT_META[event.event_type]
                         const Icon = meta?.icon ?? ArrowRightLeft
+                        const isFresh = highlightedEventIds.has(event.id)
                         return (
-                          <div key={event.id} className="flex items-start gap-2.5 px-4 py-2.5">
+                          <div
+                            key={event.id}
+                            className={`flex items-start gap-2.5 px-4 py-2.5 transition-colors duration-1000 ${isFresh ? 'bg-emerald-200 dark:bg-emerald-500/25' : 'bg-transparent'}`}
+                          >
                             <div className="mt-0.5 shrink-0">
-                              <Icon size={14} className={meta?.iconClass ?? 'text-slate-400'} />
+                              <Icon size={16} className={meta?.iconClass ?? 'text-slate-400'} />
                             </div>
                             <div className="min-w-0 flex-1">
-                              <p className="text-[13px] text-slate-700 dark:text-slate-200">{describeRoutingEvent(event)}</p>
-                              <p className="mt-0.5 text-[11px] text-slate-400">{formatSimEventTime(event.bucket_ms)}</p>
+                              <p className="text-[15px] text-slate-700 dark:text-slate-200">{describeRoutingEvent(event)}</p>
+                              <p className="mt-0.5 text-[13px] text-slate-600 dark:text-slate-400">{formatSimEventTime(event.bucket_ms)}</p>
                             </div>
                           </div>
                         )
                       })}
+                      {/* Default first event — the start of tracking. It's the oldest
+                          entry, so it sits at the bottom of the newest-first feed. */}
+                      <div className="flex items-start gap-2.5 px-4 py-2.5 bg-gradient-to-r from-sky-50 via-transparent to-violet-50 dark:from-sky-500/10 dark:to-violet-500/10">
+                        <div className="mt-0.5 shrink-0">
+                          <Flag size={16} className="text-violet-500" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-[15px] text-slate-700 dark:text-slate-200">
+                            Started tracking{' '}
+                            <span className="font-semibold text-emerald-600 dark:text-emerald-400">SR</span>{' '}and{' '}
+                            <span className="font-semibold text-violet-600 dark:text-violet-400">Cost</span>{' '}for{' '}
+                            {eligibleGatewaysParsed.map((gw, i) => (
+                              <span key={gw}>
+                                <span className="font-semibold capitalize" style={{ color: gatewayColorMap[gw] ?? GW_PALETTE[0] }}>{gw}</span>
+                                {i < eligibleGatewaysParsed.length - 1 ? ', ' : ''}
+                              </span>
+                            ))}{' '}at CARD, CARD SCHEME, CARD_TYPE, CARD_PROGRAM, AMOUNT combinations
+                          </p>
+                          {simulationStartedAtMs != null && (
+                            <p className="mt-0.5 text-[13px] text-slate-600 dark:text-slate-400">{formatSimEventTime(simulationStartedAtMs)}</p>
+                          )}
+                        </div>
+                      </div>
                     </div>
                   )}
                 </CardBody>
               </Card>
-              {hasSimulationActivity ? (
-              <>
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between gap-3">
-                    <h3 className="text-sm font-medium text-slate-800 dark:text-white">Transaction Log</h3>
-                    {deferredSimulationResults.length > 0 && (
-                      <span className="text-xs text-slate-400 tabular-nums">{deferredSimulationResults.length} transactions</span>
-                    )}
-                  </CardHeader>
-                  <CardBody className="p-0">
-
-                    {deferredSimulationResults.length > 0 ? (
-                      <div ref={txLogRef} className="max-h-[480px] overflow-y-auto overflow-x-hidden">
-                        <table className="w-full text-sm">
-                          <thead className="bg-slate-50 dark:bg-[#0a0a0f] text-[11px] text-slate-400 dark:text-slate-500 sticky top-0 border-b border-slate-100 dark:border-[#1c1c24]">
-                            <tr>
-                              <th className="text-left px-2 py-2 w-8">#</th>
-                              <th className="text-left px-2 py-2">Amount</th>
-                              <th className="text-left px-2 py-2 whitespace-nowrap">Gateway</th>
-                              <th className="text-left px-2 py-2">Routing</th>
-                              <th className="text-left px-2 py-2">Outcome</th>
-                              <th className="text-right px-2 py-2 whitespace-nowrap">Cost Savings</th>
-                              {smartRetryEnabled && <th className="text-left px-2 py-2 whitespace-nowrap">Retry Gateway</th>}
-                              {smartRetryEnabled && <th className="text-left px-2 py-2">Retry Outcome</th>}
-                            </tr>
-                          </thead>
-                          <tbody className="divide-y divide-slate-100 dark:divide-[#1a1a22]">
-                            {deferredSimulationResults.map((res, idx) => {
-                              const absIdx = idx
-                              return (
-                              <tr
-                                key={res.paymentId}
-                                className="group cursor-pointer hover:bg-slate-50 dark:hover:bg-[#0d0d14] transition-colors"
-                                onClick={() => openAuditModal(res.paymentId)}
-                              >
-                                <td className="px-2 py-2 text-[11px] text-slate-400 tabular-nums">{absIdx + 1}</td>
-                                <td className="px-2 py-2 whitespace-nowrap">
-                                  <span className="block font-mono text-xs text-slate-700 dark:text-slate-300 tabular-nums group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
-                                    {formatCurrencyValue(res.amount, res.currency)}
-                                  </span>
-                                </td>
-                                <td className="px-2 py-2 text-xs font-medium text-slate-600 dark:text-slate-300 whitespace-nowrap">{res.decidedGateway}</td>
-                                <td className="px-2 py-2">
-                                  {res.routingApproach?.includes('HEDGING') ? (
-                                    <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-900/20 dark:text-amber-300 dark:ring-amber-800">Hedging</span>
-                                  ) : res.routingApproach === 'SR_SELECTION_MULTI_OBJECTIVE' ? (
-                                    <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-300 dark:ring-emerald-800">Cost Based</span>
-                                  ) : res.routingApproach === 'SR_SELECTION_V3_ROUTING' ? (
-                                    <span className="inline-flex items-center rounded-full bg-brand-50 px-2 py-0.5 text-[11px] font-medium text-brand-700 ring-1 ring-inset ring-brand-200 dark:bg-brand-900/20 dark:text-brand-300 dark:ring-brand-800">Auth Based</span>
-                                  ) : (
-                                    <span className="text-[11px] text-slate-400">{res.routingApproach ?? '—'}</span>
-                                  )}
-                                </td>
-                                <td className="px-2 py-2">
-                                  <span className={`text-xs font-semibold ${res.status === 'CHARGED' ? 'text-emerald-600 dark:text-emerald-400' : res.status === 'PENDING_VBV' ? 'text-amber-600 dark:text-amber-400' : 'text-red-500 dark:text-red-400'}`}>{res.status}</span>
-                                </td>
-                                <td className="px-2 py-2 text-right whitespace-nowrap">
-                                  {res.costWon && res.costSavedBps != null && res.costSavedBps > 0 && res.status === 'CHARGED' ? (
-                                    <span className="font-mono text-xs text-emerald-700 dark:text-emerald-400 tabular-nums">
-                                      {formatSavingsCurrency(res.costSavedBps, res.amount, res.currency)}
-                                    </span>
-                                  ) : null}
-                                </td>
-                                {smartRetryEnabled && (
-                                  <td className="px-2 py-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
-                                    {res.retryGateway ?? '—'}
-                                  </td>
-                                )}
-                                {smartRetryEnabled && (
-                                  <td className="px-2 py-2">
-                                    {res.retryStatus ? (
-                                      <Badge variant={res.retryStatus === 'CHARGED' ? 'green' : res.retryStatus === 'PENDING_VBV' ? 'orange' : 'red'}>
-                                        {res.retryStatus}
-                                      </Badge>
-                                    ) : <span className="text-xs text-slate-400">—</span>}
-                                  </td>
-                                )}
-                              </tr>
-                            )})}
-                          </tbody>
-                        </table>
-                      </div>
-                    ) : (
-                      <div className="flex items-center gap-3 px-4 py-6 text-sm text-slate-500">
-                        <Spinner size={16} />
-                        Waiting for the first simulated payment result…
-                      </div>
-                    )}
-                  </CardBody>
-                </Card>
-              </>
-            ) : (
+              {!hasSimulationActivity && (
               <div className="space-y-3">
                 <button
                   type="button"
@@ -3683,6 +3937,108 @@ export function DecisionSimulatorPage() {
           )}
         </div>
       </div>
+
+      {/* Transaction Log — full-width table at the page bottom. */}
+      {activeTab === 'batch' && hasSimulationActivity && (
+        <Card className="mt-6">
+          <CardHeader className="flex flex-row items-center justify-between gap-3">
+            <h3 className="text-sm font-medium text-slate-800 dark:text-white">Transaction Log</h3>
+            {deferredSimulationResults.length > 0 && (
+              <span className="text-xs text-slate-400 tabular-nums">{deferredSimulationResults.length} transactions</span>
+            )}
+          </CardHeader>
+          <CardBody className="p-0">
+            {deferredSimulationResults.length > 0 ? (
+              <div ref={txLogRef} className="max-h-[560px] overflow-y-auto overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-slate-50 dark:bg-[#0a0a0f] text-[11px] text-slate-400 dark:text-slate-500 sticky top-0 border-b border-slate-100 dark:border-[#1c1c24]">
+                    <tr>
+                      <th className="text-left px-3 py-2 w-8">#</th>
+                      <th className="text-left px-3 py-2">Amount</th>
+                      <th className="text-left px-3 py-2 whitespace-nowrap">Gateway</th>
+                      <th className="text-right px-3 py-2 whitespace-nowrap">SR Score</th>
+                      <th className="text-left px-3 py-2">Routing</th>
+                      <th className="text-left px-3 py-2">Outcome</th>
+                      <th className="text-right px-3 py-2 whitespace-nowrap">Cost Savings</th>
+                      {smartRetryEnabled && <th className="text-left px-3 py-2 whitespace-nowrap">Retry Gateway</th>}
+                      {smartRetryEnabled && <th className="text-left px-3 py-2">Retry Outcome</th>}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-[#1a1a22]">
+                    {deferredSimulationResults.map((res, idx) => (
+                      <tr
+                        key={res.paymentId}
+                        className="group cursor-pointer hover:bg-slate-50 dark:hover:bg-[#0d0d14] transition-colors"
+                        onClick={() => openAuditModal(res.paymentId)}
+                      >
+                        <td className="px-3 py-2 text-[11px] text-slate-400 tabular-nums">{idx + 1}</td>
+                        <td className="px-3 py-2 whitespace-nowrap">
+                          <span className="block font-mono text-xs text-slate-700 dark:text-slate-300 tabular-nums group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
+                            {formatCurrencyValue(res.amount, res.currency)}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-xs font-medium text-slate-600 dark:text-slate-300 whitespace-nowrap">{res.decidedGateway}</td>
+                        <td className="px-3 py-2 text-right whitespace-nowrap">
+                          {(() => {
+                            const srScore = res.gatewayPriorityMap?.[res.decidedGateway]
+                            return typeof srScore === 'number' ? (
+                              <span className="font-mono text-xs text-slate-600 dark:text-slate-300 tabular-nums">
+                                {(srScore * 100).toFixed(1)}%
+                              </span>
+                            ) : (
+                              <span className="text-[11px] text-slate-400">—</span>
+                            )
+                          })()}
+                        </td>
+                        <td className="px-3 py-2">
+                          {res.routingApproach?.includes('HEDGING') ? (
+                            <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-900/20 dark:text-amber-300 dark:ring-amber-800">Hedging</span>
+                          ) : res.routingApproach === 'SR_SELECTION_MULTI_OBJECTIVE' ? (
+                            <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-300 dark:ring-emerald-800">Cost Based</span>
+                          ) : res.routingApproach === 'SR_SELECTION_V3_ROUTING' ? (
+                            <span className="inline-flex items-center rounded-full bg-brand-50 px-2 py-0.5 text-[11px] font-medium text-brand-700 ring-1 ring-inset ring-brand-200 dark:bg-brand-900/20 dark:text-brand-300 dark:ring-brand-800">Auth Based</span>
+                          ) : (
+                            <span className="text-[11px] text-slate-400">{res.routingApproach ?? '—'}</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span className={`text-xs font-semibold ${res.status === 'CHARGED' ? 'text-emerald-600 dark:text-emerald-400' : res.status === 'PENDING_VBV' ? 'text-amber-600 dark:text-amber-400' : 'text-red-500 dark:text-red-400'}`}>{res.status}</span>
+                        </td>
+                        <td className="px-3 py-2 text-right whitespace-nowrap">
+                          {res.costWon && res.costSavedBps != null && res.costSavedBps > 0 && res.status === 'CHARGED' ? (
+                            <span className="font-mono text-xs text-emerald-700 dark:text-emerald-400 tabular-nums">
+                              {formatSavingsCurrency(res.costSavedBps, res.amount, res.currency)}
+                            </span>
+                          ) : null}
+                        </td>
+                        {smartRetryEnabled && (
+                          <td className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                            {res.retryGateway ?? '—'}
+                          </td>
+                        )}
+                        {smartRetryEnabled && (
+                          <td className="px-3 py-2">
+                            {res.retryStatus ? (
+                              <Badge variant={res.retryStatus === 'CHARGED' ? 'green' : res.retryStatus === 'PENDING_VBV' ? 'orange' : 'red'}>
+                                {res.retryStatus}
+                              </Badge>
+                            ) : <span className="text-xs text-slate-400">—</span>}
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="flex items-center gap-3 px-4 py-6 text-sm text-slate-500">
+                <Spinner size={16} />
+                Waiting for the first simulated payment result…
+              </div>
+            )}
+          </CardBody>
+        </Card>
+      )}
 
       {setupPrompt && (
         <div className="fixed bottom-0 left-0 right-0 top-[76px] z-[140] flex items-center justify-center p-4">

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -4,7 +4,7 @@ import { ErrorInfoFields, ErrorInfoState, GsmOptionRow, DEFAULT_ERROR_INFO } fro
 import { PenaltyClassificationGuide } from './PenaltyClassificationGuide'
 import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
-import { BarChart, Bar, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, ReferenceLine, ReferenceArea } from 'recharts'
+import { BarChart, Bar, LineChart, Line, ComposedChart, Area, CartesianGrid, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, Cell, ReferenceLine, ReferenceArea } from 'recharts'
 import { Tooltip as UiTooltip } from '../ui/Tooltip'
 import { Button } from '../ui/Button'
 import { Badge } from '../ui/Badge'
@@ -16,12 +16,13 @@ import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
 import { useAuthStore } from '../../store/authStore'
 import { apiPost, fetcher } from '../../lib/api'
 import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
-import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, UpdateScoreResponse } from '../../types/api'
+import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, RoutingEventType, UpdateScoreResponse } from '../../types/api'
 import { ROUTING_APPROACH_COLORS } from '../../lib/constants'
 import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
+import { describeRoutingEvent, useRoutingEvents } from '../../hooks/useRoutingEvents'
 import { FEATURE_FLAGS } from '../../lib/featureFlags'
-import { Play, RefreshCw, ChevronDown, ChevronUp, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings } from 'lucide-react'
+import { Play, RefreshCw, ChevronDown, ChevronUp, Code, Plus, Trash2, PieChart as PieChartIcon, X, Network, Settings, ArrowRightLeft, Target, TrendingDown } from 'lucide-react'
 
 // UI-local algorithm tokens for the simulation dropdown. Maps to the backend
 // /decide-gateway request as follows:
@@ -165,6 +166,23 @@ function approachColor(approach: string): string {
 
 const COLORS = ['#0069ED', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16']
 const GW_PALETTE = ['#3b82f6', '#8b5cf6', '#f97316', '#ec4899', '#14b8a6']
+
+// Routing events bucket at second granularity and the analytics pipeline lags a
+// little, so allow a small margin before the run-start when scoping events to a run.
+const EVENTS_RUN_START_MARGIN_MS = 3000
+
+// Icon/colour per routing-event type for the simulator's Events panel. Events come
+// from the /analytics/routing-events feed: leader flips and auth-band entries/exits
+// as gateway success-rate scores shift during a run.
+const SIM_EVENT_META: Record<RoutingEventType, { icon: React.ElementType; iconClass: string }> = {
+  leader_changed: { icon: ArrowRightLeft, iconClass: 'text-sky-500' },
+  gateway_entered_auth_band: { icon: Target, iconClass: 'text-emerald-500' },
+  gateway_exited_auth_band: { icon: TrendingDown, iconClass: 'text-amber-500' },
+}
+
+function formatSimEventTime(ms: number) {
+  return new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
 
 type VolumePaymentEntry = {
   paymentId: string
@@ -847,6 +865,16 @@ export function DecisionSimulatorPage() {
   const [previewInspectorTab, setPreviewInspectorTab] = useState<AuditInspectorTab>('summary')
   const [previewTraceLabel, setPreviewTraceLabel] = useState('Rule Evaluation Decision')
   const deferredSimulationResults = useDeferredValue(simulationResults)
+  // Timestamp (ms) the active batch run started; null until the user runs one. Scopes
+  // the Events panel to the current run instead of the merchant's whole last hour.
+  const [simulationStartedAtMs, setSimulationStartedAtMs] = useState<number | null>(null)
+  // Live routing-event stream (leader flips, auth-band crossings), filtered to the run.
+  const routingEvents = useRoutingEvents('1h')
+  const sessionRoutingEvents = useMemo(() => {
+    if (simulationStartedAtMs == null) return []
+    const sinceMs = simulationStartedAtMs - EVENTS_RUN_START_MARGIN_MS
+    return routingEvents.events.filter((event) => event.bucket_ms >= sinceMs)
+  }, [routingEvents.events, simulationStartedAtMs])
   const [showPenaltyGuide, setShowPenaltyGuide] = useState(false)
 
   const routingKeyNames = useMemo(
@@ -1029,6 +1057,7 @@ export function DecisionSimulatorPage() {
     setVolumeEvaluationLog(defaults.volumeEvaluationLog)
     setVolumeProgress(defaults.volumeProgress)
     setSimulationResults(defaults.simulationResults)
+    setSimulationStartedAtMs(null)
     setResponseOpen(defaults.responseOpen)
     setDebitResponseOpen(defaults.debitResponseOpen)
     setVolumeResponseOpen(defaults.volumeResponseOpen)
@@ -1073,6 +1102,7 @@ export function DecisionSimulatorPage() {
     setVolumeEvaluationLog(nextState.volumeEvaluationLog)
     setVolumeProgress(nextState.volumeProgress)
     setSimulationResults(nextState.simulationResults)
+    setSimulationStartedAtMs(null)
     setResponseOpen(nextState.responseOpen)
     setDebitResponseOpen(nextState.debitResponseOpen)
     setVolumeResponseOpen(nextState.volumeResponseOpen)
@@ -1476,6 +1506,7 @@ export function DecisionSimulatorPage() {
     if (total <= 0) return setError('Total Payments must be greater than 0')
 
     setIsSimulating(true)
+    setSimulationStartedAtMs(Date.now())
     setError(null)
     setSetupPrompt(null)
     setSimulationResults([])
@@ -2282,48 +2313,40 @@ export function DecisionSimulatorPage() {
                           {/* combined multi-line SR trend chart */}
                           {hasAnySpark && (() => {
                             const { series, paymentNums } = gatewaySparklines
+                            // Cost-based routing is eligible for any PSP whose SR sits within the
+                            // auth-rate tolerance band of the *leading* PSP's SR. The leader moves
+                            // every transaction, so the threshold is computed per point as
+                            // topPspSr − band and drawn as a dynamic dashed line: wherever a PSP's
+                            // line crosses it you can see exactly when it entered or exited the band.
+                            const bandPp = costRoutingTolerancePp * 100
                             const chartData = paymentNums.map((n, i) => {
                               const row: Record<string, number> = { step: n }
+                              let topAtPoint: number | null = null
                               sortedGateways.forEach(([gw]) => {
                                 const v = series[gw]?.[i]
-                                if (v != null) row[gw] = v
+                                if (v != null) {
+                                  row[gw] = v
+                                  if (topAtPoint == null || v > topAtPoint) topAtPoint = v
+                                }
                               })
+                              if (topAtPoint != null) {
+                                const threshold = Math.max(0, topAtPoint - bandPp)
+                                row.topPspSr = topAtPoint
+                                row.threshold = threshold
+                                // Span from the threshold up to 100%, stacked over a transparent base,
+                                // so the shaded eligible area rises and falls with the band.
+                                row.eligibleSpan = Math.max(0, 100 - threshold)
+                              }
                               return row
                             })
-                            // Cost-based routing is eligible for gateways whose SR sits within the
-                            // auth-rate tolerance band of the best gateway's SR — shade that band as
-                            // the eligible area, with a dotted line at its lower threshold. The band
-                            // width comes from the live cost-optimisation tolerance, stored as a
-                            // fraction (e.g. 0.2 = 20 percentage points) so scale it to the 0–100 SR axis.
-                            const srScores = sortedGateways
-                              .map(([gw]) => gatewaySrScores[gw])
-                              .filter((v): v is number => v != null)
-                            const bestSr = srScores.length ? Math.max(...srScores) : null
-                            const bandPp = costRoutingTolerancePp * 100
-                            const costBandThreshold = bestSr != null ? Math.max(0, bestSr - bandPp) : null
+                            const bandLabel = `Dynamic Threshold (Top PSP − ${bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp)`
                             return (
                               <div className="w-full flex-1 min-h-[300px]">
                                 <ResponsiveContainer width="100%" height="100%">
-                                  <LineChart data={chartData} margin={{ top: 16, right: 8, bottom: 20, left: 0 }}>
+                                  <ComposedChart data={chartData} margin={{ top: 16, right: 8, bottom: 24, left: 0 }}>
                                     <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:opacity-20" vertical={false} />
-                                    {costBandThreshold != null && (
-                                      <ReferenceArea
-                                        y1={costBandThreshold}
-                                        y2={100}
-                                        fill="#10b981"
-                                        fillOpacity={0.08}
-                                        ifOverflow="extendDomain"
-                                      />
-                                    )}
-                                    {costBandThreshold != null && (
-                                      <ReferenceLine
-                                        y={costBandThreshold}
-                                        stroke="#10b981"
-                                        strokeDasharray="4 4"
-                                        strokeWidth={1.5}
-                                        label={{ value: `Cost-based eligible ≥ ${costBandThreshold.toFixed(costBandThreshold % 1 ? 1 : 0)}% (${bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp band)`, position: 'insideTopLeft', fontSize: 10, fill: '#059669' }}
-                                      />
-                                    )}
+                                    <Area dataKey="threshold" stackId="elig" stroke="none" fill="transparent" isAnimationActive={false} legendType="none" connectNulls />
+                                    <Area dataKey="eligibleSpan" stackId="elig" stroke="none" fill="#10b981" fillOpacity={0.08} isAnimationActive={false} legendType="none" connectNulls />
                                     <XAxis
                                       dataKey="step"
                                       tick={{ fontSize: 11, fill: '#94a3b8' }}
@@ -2341,12 +2364,34 @@ export function DecisionSimulatorPage() {
                                       tickFormatter={(v: number) => `${v}%`}
                                     />
                                     <Tooltip
-                                      contentStyle={CHART_TOOLTIP_STYLE}
-                                      labelStyle={CHART_TOOLTIP_LABEL_STYLE}
-                                      itemStyle={CHART_TOOLTIP_ITEM_STYLE}
-                                      formatter={(value: number, name: string) => [`${value}%`, name]}
-                                      labelFormatter={(l) => `Payment ${l}`}
+                                      content={(props) => {
+                                        const { active, payload } = props as unknown as { active?: boolean; payload?: Array<{ payload?: Record<string, number> }> }
+                                        if (!active || !payload || !payload.length) return null
+                                        const row = payload[0].payload
+                                        if (!row) return null
+                                        return (
+                                          <div style={CHART_TOOLTIP_STYLE}>
+                                            <p style={CHART_TOOLTIP_LABEL_STYLE}>Payment {row.step}</p>
+                                            {sortedGateways.map(([gw]) => (
+                                              row[gw] == null ? null : (
+                                                <p key={gw} style={{ ...CHART_TOOLTIP_ITEM_STYLE, color: gatewayColorMap[gw] ?? GW_PALETTE[0] }}>
+                                                  {gw}: {row[gw].toFixed(1)}%
+                                                </p>
+                                              )
+                                            ))}
+                                            {row.threshold != null && (
+                                              <div style={{ marginTop: 6, paddingTop: 6, borderTop: '1px solid rgba(148,163,184,0.25)' }}>
+                                                <p style={CHART_TOOLTIP_ITEM_STYLE}><strong>Top PSP SR:</strong> {row.topPspSr?.toFixed(1)}%</p>
+                                                <p style={CHART_TOOLTIP_ITEM_STYLE}><strong>Configured Band:</strong> −{bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp</p>
+                                                <p style={CHART_TOOLTIP_ITEM_STYLE}><strong>Cost-Eligible Threshold:</strong> {row.threshold.toFixed(1)}%</p>
+                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, opacity: 0.7, fontSize: 10 }}>This threshold changes at every x-axis point.</p>
+                                              </div>
+                                            )}
+                                          </div>
+                                        )
+                                      }}
                                     />
+                                    <Legend wrapperStyle={{ fontSize: 11, paddingTop: 4 }} />
                                     {sortedGateways.map(([gw]) => (
                                       <Line
                                         key={gw}
@@ -2360,7 +2405,18 @@ export function DecisionSimulatorPage() {
                                         connectNulls
                                       />
                                     ))}
-                                  </LineChart>
+                                    <Line
+                                      type="natural"
+                                      dataKey="threshold"
+                                      name={bandLabel}
+                                      stroke="#10b981"
+                                      strokeDasharray="5 4"
+                                      strokeWidth={1.75}
+                                      dot={false}
+                                      isAnimationActive={false}
+                                      connectNulls
+                                    />
+                                  </ComposedChart>
                                 </ResponsiveContainer>
                               </div>
                             )
@@ -3248,17 +3304,58 @@ export function DecisionSimulatorPage() {
             )
           ) : activeTab === 'batch' ? (
             <>
-              {/* Events — backend stream not wired yet, shows empty state */}
+              {/* Events — routing events from the active simulation run only. */}
               <Card>
-                <CardHeader className="flex flex-row items-center gap-2.5">
-                  <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.18)]" />
-                  <h3 className="text-sm font-medium text-slate-800 dark:text-white">Events</h3>
+                <CardHeader className="flex flex-row items-center justify-between gap-3">
+                  <span className="flex items-center gap-2.5">
+                    <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.18)]" />
+                    <h3 className="text-sm font-medium text-slate-800 dark:text-white">Events</h3>
+                  </span>
+                  {sessionRoutingEvents.length > 0 && (
+                    <span className="text-xs text-slate-400 tabular-nums">{sessionRoutingEvents.length} events</span>
+                  )}
                 </CardHeader>
-                <CardBody className="py-12 text-center">
-                  <p className="text-sm text-slate-500 dark:text-slate-400">No events yet</p>
-                  <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
-                    Event stream will appear here once the backend is available.
-                  </p>
+                <CardBody className="p-0">
+                  {simulationStartedAtMs == null ? (
+                    <div className="py-12 text-center">
+                      <p className="text-sm text-slate-500 dark:text-slate-400">No events yet</p>
+                      <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                        Start a simulation — leader changes and auth-band crossings appear here as gateway scores shift.
+                      </p>
+                    </div>
+                  ) : routingEvents.isUnavailable ? (
+                    <div className="py-12 text-center">
+                      <p className="text-sm text-slate-500 dark:text-slate-400">Events unavailable</p>
+                      <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                        The analytics pipeline (Kafka → ClickHouse) is offline for this environment.
+                      </p>
+                    </div>
+                  ) : sessionRoutingEvents.length === 0 ? (
+                    <div className="py-12 text-center">
+                      <p className="text-sm text-slate-500 dark:text-slate-400">Waiting for events…</p>
+                      <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                        No leader changes or auth-band crossings for this run yet.
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="max-h-[360px] overflow-y-auto divide-y divide-slate-100 dark:divide-[#1a1a22]">
+                      {sessionRoutingEvents.slice(0, 50).map((event) => {
+                        const meta = SIM_EVENT_META[event.event_type]
+                        const Icon = meta?.icon ?? ArrowRightLeft
+                        return (
+                          <div key={event.id} className="flex items-start gap-2.5 px-4 py-2.5">
+                            <div className="mt-0.5 shrink-0">
+                              <Icon size={14} className={meta?.iconClass ?? 'text-slate-400'} />
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <p className="text-[13px] text-slate-700 dark:text-slate-200">{describeRoutingEvent(event)}</p>
+                              <p className="mt-0.5 text-[11px] text-slate-400">{formatSimEventTime(event.bucket_ms)}</p>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
                 </CardBody>
               </Card>
               {hasSimulationActivity ? (

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -4,7 +4,7 @@ import { ErrorInfoFields, ErrorInfoState, GsmOptionRow, DEFAULT_ERROR_INFO } fro
 import { PenaltyClassificationGuide } from './PenaltyClassificationGuide'
 import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
-import { BarChart, Bar, LineChart, Line, ComposedChart, Area, CartesianGrid, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, Cell, ReferenceLine, ReferenceArea } from 'recharts'
+import { BarChart, Bar, LineChart, Line, ComposedChart, Area, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, ReferenceLine, ReferenceArea } from 'recharts'
 import { Tooltip as UiTooltip } from '../ui/Tooltip'
 import { Button } from '../ui/Button'
 import { Badge } from '../ui/Badge'
@@ -2341,12 +2341,13 @@ export function DecisionSimulatorPage() {
                             })
                             const bandLabel = `Dynamic Threshold (Top PSP − ${bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp)`
                             return (
-                              <div className="w-full flex-1 min-h-[300px]">
+                              <div className="w-full flex-1 min-h-[320px] flex flex-col">
+                                <div className="min-h-0 flex-1">
                                 <ResponsiveContainer width="100%" height="100%">
-                                  <ComposedChart data={chartData} margin={{ top: 16, right: 8, bottom: 24, left: 0 }}>
+                                  <ComposedChart data={chartData} margin={{ top: 16, right: 8, bottom: 28, left: 0 }}>
                                     <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:opacity-20" vertical={false} />
-                                    <Area dataKey="threshold" stackId="elig" stroke="none" fill="transparent" isAnimationActive={false} legendType="none" connectNulls />
-                                    <Area dataKey="eligibleSpan" stackId="elig" stroke="none" fill="#10b981" fillOpacity={0.08} isAnimationActive={false} legendType="none" connectNulls />
+                                    <Area dataKey="threshold" stackId="elig" stroke="none" fill="transparent" isAnimationActive={false} legendType="none" activeDot={false} connectNulls />
+                                    <Area dataKey="eligibleSpan" stackId="elig" stroke="none" fill="#10b981" fillOpacity={0.08} isAnimationActive={false} legendType="none" activeDot={false} connectNulls />
                                     <XAxis
                                       dataKey="step"
                                       tick={{ fontSize: 11, fill: '#94a3b8' }}
@@ -2370,28 +2371,27 @@ export function DecisionSimulatorPage() {
                                         const row = payload[0].payload
                                         if (!row) return null
                                         return (
-                                          <div style={CHART_TOOLTIP_STYLE}>
-                                            <p style={CHART_TOOLTIP_LABEL_STYLE}>Payment {row.step}</p>
+                                          <div style={{ ...CHART_TOOLTIP_STYLE, padding: '10px 12px', fontSize: 12, lineHeight: 1.5 }}>
+                                            <p style={{ ...CHART_TOOLTIP_LABEL_STYLE, margin: '0 0 6px' }}>Payment {row.step}</p>
                                             {sortedGateways.map(([gw]) => (
                                               row[gw] == null ? null : (
-                                                <p key={gw} style={{ ...CHART_TOOLTIP_ITEM_STYLE, color: gatewayColorMap[gw] ?? GW_PALETTE[0] }}>
+                                                <p key={gw} style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '2px 0', color: gatewayColorMap[gw] ?? GW_PALETTE[0] }}>
                                                   {gw}: {row[gw].toFixed(1)}%
                                                 </p>
                                               )
                                             ))}
                                             {row.threshold != null && (
-                                              <div style={{ marginTop: 6, paddingTop: 6, borderTop: '1px solid rgba(148,163,184,0.25)' }}>
-                                                <p style={CHART_TOOLTIP_ITEM_STYLE}><strong>Top PSP SR:</strong> {row.topPspSr?.toFixed(1)}%</p>
-                                                <p style={CHART_TOOLTIP_ITEM_STYLE}><strong>Configured Band:</strong> −{bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp</p>
-                                                <p style={CHART_TOOLTIP_ITEM_STYLE}><strong>Cost-Eligible Threshold:</strong> {row.threshold.toFixed(1)}%</p>
-                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, opacity: 0.7, fontSize: 10 }}>This threshold changes at every x-axis point.</p>
+                                              <div style={{ marginTop: 8, paddingTop: 8, borderTop: '1px solid rgba(148,163,184,0.25)' }}>
+                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '3px 0' }}><strong>Top PSP SR:</strong> {row.topPspSr?.toFixed(1)}%</p>
+                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '3px 0' }}><strong>Configured Band:</strong> −{bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp</p>
+                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '3px 0' }}><strong>Cost-Eligible Threshold:</strong> {row.threshold.toFixed(1)}%</p>
+                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '6px 0 0', opacity: 0.7, fontSize: 10 }}>This threshold changes at every x-axis point.</p>
                                               </div>
                                             )}
                                           </div>
                                         )
                                       }}
                                     />
-                                    <Legend wrapperStyle={{ fontSize: 11, paddingTop: 4 }} />
                                     {sortedGateways.map(([gw]) => (
                                       <Line
                                         key={gw}
@@ -2401,6 +2401,7 @@ export function DecisionSimulatorPage() {
                                         stroke={gatewayColorMap[gw] ?? GW_PALETTE[0]}
                                         strokeWidth={2.5}
                                         dot={false}
+                                        activeDot={false}
                                         isAnimationActive={false}
                                         connectNulls
                                       />
@@ -2413,11 +2414,25 @@ export function DecisionSimulatorPage() {
                                       strokeDasharray="5 4"
                                       strokeWidth={1.75}
                                       dot={false}
+                                      activeDot={false}
                                       isAnimationActive={false}
                                       connectNulls
                                     />
                                   </ComposedChart>
                                 </ResponsiveContainer>
+                                </div>
+                                <div className="mt-3 flex flex-wrap items-center justify-center gap-x-5 gap-y-1.5 text-[11px] text-slate-500 dark:text-slate-400">
+                                  {sortedGateways.map(([gw]) => (
+                                    <span key={gw} className="inline-flex items-center gap-1.5">
+                                      <span className="h-2 w-2 rounded-full" style={{ backgroundColor: gatewayColorMap[gw] ?? GW_PALETTE[0] }} />
+                                      {gw}
+                                    </span>
+                                  ))}
+                                  <span className="inline-flex items-center gap-1.5">
+                                    <span className="inline-block w-4 border-t-2 border-dashed" style={{ borderColor: '#10b981' }} />
+                                    {bandLabel}
+                                  </span>
+                                </div>
                               </div>
                             )
                           })()}

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -116,6 +116,7 @@ function formatCurrencyValue(value: number, currency: string): string {
     return new Intl.NumberFormat(undefined, {
       style: 'currency',
       currency,
+      currencyDisplay: 'narrowSymbol',
       maximumFractionDigits: 2,
     }).format(value)
   } catch {

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -281,7 +281,7 @@ function cloneConnectors(connectors: GatewayConnector[]) {
   return connectors.map((connector) => ({ ...connector }))
 }
 
-function normalizeDebitCardType(value: unknown): DebitRoutingFormState['card_type'] {
+function normalizeDebitCardCategory(value: unknown): DebitRoutingFormState['card_type'] {
   return `${value || ''}`.toLowerCase() === 'credit' ? 'credit' : 'debit'
 }
 
@@ -373,7 +373,7 @@ function loadExplorerState(scopeKey: string): ExplorerPersistedState {
       debitForm: {
         ...defaults.debitForm,
         ...(parsed.debitForm || {}),
-        card_type: normalizeDebitCardType(parsed.debitForm?.card_type),
+        card_type: normalizeDebitCardCategory(parsed.debitForm?.card_type),
       },
       ruleParams: parsed.ruleParams?.length ? cloneRuleParams(parsed.ruleParams) : defaults.ruleParams,
       fallbackConnectors: parsed.fallbackConnectors?.length ? cloneConnectors(parsed.fallbackConnectors) : defaults.fallbackConnectors,
@@ -1444,7 +1444,7 @@ export function DecisionSimulatorPage() {
         regulated_name: debitForm.is_regulated && debitForm.regulated_name.trim()
           ? debitForm.regulated_name.trim()
           : null,
-        card_type: normalizeDebitCardType(debitForm.card_type),
+        card_type: normalizeDebitCardCategory(debitForm.card_type),
       },
     })
   }

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -2136,7 +2136,7 @@ export function DecisionSimulatorPage() {
         <div>
           <SurfaceLabel>Simulation console</SurfaceLabel>
           <div className="mt-2 flex flex-wrap items-center gap-3">
-            <h1 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">Decision Explorer</h1>
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">Decision Simulator</h1>
             <Badge variant="blue">{effectiveMerchantId || 'No merchant'}</Badge>
           </div>
         </div>
@@ -2370,22 +2370,34 @@ export function DecisionSimulatorPage() {
                                         if (!active || !payload || !payload.length) return null
                                         const row = payload[0].payload
                                         if (!row) return null
+                                        const hasBand = row.threshold != null
                                         return (
-                                          <div style={{ ...CHART_TOOLTIP_STYLE, padding: '10px 12px', fontSize: 12, lineHeight: 1.5 }}>
+                                          <div style={{ ...CHART_TOOLTIP_STYLE, padding: '10px 12px', fontSize: 12, lineHeight: 1.5, minWidth: 190 }}>
                                             <p style={{ ...CHART_TOOLTIP_LABEL_STYLE, margin: '0 0 6px' }}>Payment {row.step}</p>
-                                            {sortedGateways.map(([gw]) => (
-                                              row[gw] == null ? null : (
-                                                <p key={gw} style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '2px 0', color: gatewayColorMap[gw] ?? GW_PALETTE[0] }}>
-                                                  {gw}: {row[gw].toFixed(1)}%
-                                                </p>
-                                              )
-                                            ))}
-                                            {row.threshold != null && (
-                                              <div style={{ marginTop: 8, paddingTop: 8, borderTop: '1px solid rgba(148,163,184,0.25)' }}>
-                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '3px 0' }}><strong>Top PSP SR:</strong> {row.topPspSr?.toFixed(1)}%</p>
-                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '3px 0' }}><strong>Configured Band:</strong> −{bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp</p>
-                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '3px 0' }}><strong>Cost-Eligible Threshold:</strong> {row.threshold.toFixed(1)}%</p>
-                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: '6px 0 0', opacity: 0.7, fontSize: 10 }}>This threshold changes at every x-axis point.</p>
+                                            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                                              {sortedGateways.map(([gw]) => {
+                                                if (row[gw] == null) return null
+                                                const gwColor = gatewayColorMap[gw] ?? GW_PALETTE[0]
+                                                const isTop = hasBand && row.topPspSr != null && row[gw] === row.topPspSr
+                                                return (
+                                                  <div key={gw} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                                                    <span style={{ width: 8, height: 8, borderRadius: 999, backgroundColor: gwColor, flexShrink: 0 }} />
+                                                    <span style={{ color: gwColor, fontWeight: 600 }}>{gw}</span>
+                                                    <span style={{ marginLeft: 'auto', fontVariantNumeric: 'tabular-nums' }}>{row[gw].toFixed(1)}%</span>
+                                                    {hasBand && (
+                                                      <span style={{ fontSize: 10, fontWeight: 600, width: 34, textAlign: 'right', color: '#10b981' }}>
+                                                        {isTop ? '★ Top' : ''}
+                                                      </span>
+                                                    )}
+                                                  </div>
+                                                )
+                                              })}
+                                            </div>
+                                            {hasBand && (
+                                              <div style={{ marginTop: 8, paddingTop: 8, borderTop: '1px solid rgba(148,163,184,0.25)', display: 'flex', flexDirection: 'column', gap: 3 }}>
+                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: 0, display: 'flex', justifyContent: 'space-between', gap: 12 }}><span>Top PSP SR</span><strong>{row.topPspSr?.toFixed(1)}%</strong></p>
+                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: 0, display: 'flex', justifyContent: 'space-between', gap: 12 }}><span>Configured Band</span><strong>{bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp</strong></p>
+                                                <p style={{ ...CHART_TOOLTIP_ITEM_STYLE, margin: 0, display: 'flex', justifyContent: 'space-between', gap: 12, color: '#10b981' }}><span>Cost-Eligible ≥</span><strong>{row.threshold.toFixed(1)}%</strong></p>
                                               </div>
                                             )}
                                           </div>
@@ -2445,15 +2457,10 @@ export function DecisionSimulatorPage() {
                       const previewGateways = eligibleGatewaysParsed
                       if (previewGateways.length === 0) return null
                       const previewScores = previewGateways.map(gw => ({ gw, sr: getGwSuccessRate(gw) }))
-                      const bestSr = previewScores.reduce((m, g) => Math.max(m, g.sr), 0)
-                      const bandPp = DEFAULT_COST_ROUTING_TOLERANCE * 100
-                      const costBandThreshold = Math.max(0, bestSr - bandPp)
                       const target = totalSimulationPayments || Number(SIMULATION_TOTAL_PAYMENTS)
-                      const chartData = [1, target].map(step => {
-                        const row: Record<string, number> = { step }
-                        previewScores.forEach(({ gw, sr }) => { row[gw] = sr })
-                        return row
-                      })
+                      // Empty plot area until a simulation runs — only the axis range
+                      // is seeded so the chart frame renders without any band or lines.
+                      const chartData = [{ step: 1 }, { step: target }]
                       return (
                         <div className="flex flex-1 flex-col gap-4">
                           <div className="space-y-2">
@@ -2476,14 +2483,6 @@ export function DecisionSimulatorPage() {
                             <ResponsiveContainer width="100%" height="100%">
                               <LineChart data={chartData} margin={{ top: 16, right: 8, bottom: 20, left: 0 }}>
                                 <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:opacity-20" vertical={false} />
-                                <ReferenceArea y1={costBandThreshold} y2={100} fill="#10b981" fillOpacity={0.08} ifOverflow="extendDomain" />
-                                <ReferenceLine
-                                  y={costBandThreshold}
-                                  stroke="#10b981"
-                                  strokeDasharray="4 4"
-                                  strokeWidth={1.5}
-                                  label={{ value: `Cost-based eligible ≥ ${costBandThreshold.toFixed(costBandThreshold % 1 ? 1 : 0)}% (${bandPp.toFixed(bandPp % 1 ? 1 : 0)}pp band)`, position: 'insideTopLeft', fontSize: 10, fill: '#059669' }}
-                                />
                                 <XAxis
                                   dataKey="step"
                                   tick={{ fontSize: 11, fill: '#94a3b8' }}
@@ -2500,20 +2499,6 @@ export function DecisionSimulatorPage() {
                                   width={44}
                                   tickFormatter={(v: number) => `${v}%`}
                                 />
-                                {previewScores.map(({ gw }) => (
-                                  <Line
-                                    key={gw}
-                                    type="monotone"
-                                    dataKey={gw}
-                                    name={gw}
-                                    stroke={gatewayColorMap[gw] ?? GW_PALETTE[0]}
-                                    strokeWidth={2.5}
-                                    strokeDasharray="5 4"
-                                    dot={false}
-                                    isAnimationActive={false}
-                                    connectNulls
-                                  />
-                                ))}
                               </LineChart>
                             </ResponsiveContainer>
                           </div>
@@ -3324,10 +3309,10 @@ export function DecisionSimulatorPage() {
                 <CardHeader className="flex flex-row items-center justify-between gap-3">
                   <span className="flex items-center gap-2.5">
                     <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.18)]" />
-                    <h3 className="text-sm font-medium text-slate-800 dark:text-white">Events</h3>
+                    <h3 className="text-sm font-medium text-slate-800 dark:text-white">Autopilot Actions</h3>
                   </span>
                   {sessionRoutingEvents.length > 0 && (
-                    <span className="text-xs text-slate-400 tabular-nums">{sessionRoutingEvents.length} events</span>
+                    <span className="text-xs text-slate-400 tabular-nums">{sessionRoutingEvents.length} actions</span>
                   )}
                 </CardHeader>
                 <CardBody className="p-0">

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -105,6 +105,7 @@ interface SimulationResult {
   retryStatus?: 'CHARGED' | 'FAILURE' | 'PENDING_VBV'
   costSavedBps?: number | null
   costWon?: boolean
+  authWon?: boolean
   tolerancePp?: number | null
   amount: number
   currency: string
@@ -221,9 +222,6 @@ const DEFAULT_DEBIT_FORM: DebitRoutingFormState = {
 // Auth-rate simulation runs a fixed batch — no user input; it starts on Run
 // and stops at this many transactions.
 const SIMULATION_TOTAL_PAYMENTS = '5000'
-
-// Static annotation shown beside the simulation controls (read-only note).
-const EXPERIMENT_NOTE = 'Stripe degraded · Testing cost-based fallback to Adyen'
 
 // Default auth-rate tolerance band below the best gateway's SR within which gateways are
 // SR-equivalent and become eligible for cost-based routing. Stored as a fraction
@@ -1615,6 +1613,7 @@ export function DecisionSimulatorPage() {
             retryStatus,
             costSavedBps: mo?.costSavedBps ?? null,
             costWon: mo?.outcome === 'COST_WON',
+            authWon: mo?.outcome === 'AUTH_WON',
             tolerancePp: mo?.tolerancePp ?? null,
             amount,
             currency: form.currency,
@@ -1920,6 +1919,18 @@ export function DecisionSimulatorPage() {
     return { value, currency }
   }, [deferredSimulationResults])
 
+  // Multi-objective outcome counts: how often the auth objective vs the cost
+  // objective won the routing decision across the run.
+  const multiObjectiveStats = useMemo(() => {
+    let authWon = 0
+    let costWon = 0
+    for (const r of deferredSimulationResults) {
+      if (r.authWon) authWon++
+      if (r.costWon) costWon++
+    }
+    return { authWon, costWon }
+  }, [deferredSimulationResults])
+
   const debitNetworkRows = debitResult?.debit_routing_output?.co_badged_card_networks_info || []
   const volumeColorIndex = useMemo(
     () => new Map(volumeDistribution.map((item, index) => [item.name, index] as const)),
@@ -2159,53 +2170,69 @@ export function DecisionSimulatorPage() {
       )}
 
       {activeTab === 'batch' && (
-        <div className="flex flex-wrap items-end gap-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 dark:border-[#222226] dark:bg-[#0b0b10]">
-          {[
-            { key: 'stripe', label: 'Stripe success rate' },
-            { key: 'adyen', label: 'Adyen success rate' },
-          ].map(({ key, label }) => {
-            const color = gatewayColorMap[key] ?? GW_PALETTE[0]
-            const rate = getGwSuccessRate(key)
-            return (
-              <div key={key} className="flex w-[190px] flex-col gap-1.5">
-                <div className="flex items-center gap-1.5">
-                  <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: color }} />
-                  <SurfaceLabel>{label}</SurfaceLabel>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
+          <div className="flex flex-wrap items-end gap-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 dark:border-[#222226] dark:bg-[#0b0b10]">
+            {[
+              { key: 'stripe', label: 'Stripe success rate' },
+              { key: 'adyen', label: 'Adyen success rate' },
+            ].map(({ key, label }) => {
+              const color = gatewayColorMap[key] ?? GW_PALETTE[0]
+              const rate = getGwSuccessRate(key)
+              return (
+                <div key={key} className="flex w-[190px] flex-col gap-1.5">
+                  <div className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: color }} />
+                    <SurfaceLabel>{label}</SurfaceLabel>
+                  </div>
+                  <input
+                    type="text"
+                    value={`${rate}%`}
+                    onChange={e => setGwSuccessRate(key, Math.max(0, Math.min(100, parseInt(e.target.value.replace(/\D/g, ''), 10) || 0)))}
+                    className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm font-semibold text-slate-800 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0d0d13] dark:text-slate-100"
+                  />
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    value={rate}
+                    onChange={e => setGwSuccessRate(key, Number(e.target.value))}
+                    className="h-1 w-full cursor-pointer"
+                    style={{ accentColor: color }}
+                  />
                 </div>
-                <input
-                  type="text"
-                  value={`${rate}%`}
-                  onChange={e => setGwSuccessRate(key, Math.max(0, Math.min(100, parseInt(e.target.value.replace(/\D/g, ''), 10) || 0)))}
-                  className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm font-semibold text-slate-800 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0d0d13] dark:text-slate-100"
-                />
-                <input
-                  type="range"
-                  min={0}
-                  max={100}
-                  value={rate}
-                  onChange={e => setGwSuccessRate(key, Number(e.target.value))}
-                  className="h-1 w-full cursor-pointer"
-                  style={{ accentColor: color }}
-                />
-              </div>
-            )
-          })}
+              )
+            })}
 
-          <div className="flex min-w-[240px] flex-1 flex-col gap-1.5">
-            <SurfaceLabel>Experiment variables</SurfaceLabel>
-            <p className="py-1.5 text-sm leading-snug text-slate-700 dark:text-slate-200">
-              {EXPERIMENT_NOTE}
-            </p>
+            <Button
+              onClick={isSimulating ? () => { simulationAbortRef.current = true } : runSimulation}
+              disabled={!effectiveMerchantId || routingConfigUnavailable}
+              variant={isSimulating ? 'secondary' : 'primary'}
+              className="self-end"
+            >
+              {isSimulating ? <><X size={14} /> Stop</> : <><Play size={14} className="fill-current" /> Run simulation</>}
+            </Button>
           </div>
 
-          <Button
-            onClick={isSimulating ? () => { simulationAbortRef.current = true } : runSimulation}
-            disabled={!effectiveMerchantId || routingConfigUnavailable}
-            variant={isSimulating ? 'secondary' : 'primary'}
-            className="ml-auto self-end"
-          >
-            {isSimulating ? <><X size={14} /> Stop</> : <><Play size={14} className="fill-current" /> Run simulation</>}
-          </Button>
+          <div className="flex flex-1 flex-wrap items-end justify-around gap-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 dark:border-[#222226] dark:bg-[#0b0b10]">
+            <div className="flex flex-col gap-1.5">
+              <SurfaceLabel>Total auth won</SurfaceLabel>
+              <p className="py-1.5 text-lg font-semibold leading-snug tabular-nums text-sky-600 dark:text-sky-400">
+                {multiObjectiveStats.authWon.toLocaleString()}
+              </p>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <SurfaceLabel>Total cost won</SurfaceLabel>
+              <p className="py-1.5 text-lg font-semibold leading-snug tabular-nums text-violet-600 dark:text-violet-400">
+                {multiObjectiveStats.costWon.toLocaleString()}
+              </p>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <SurfaceLabel>Total cost saved</SurfaceLabel>
+              <p className="py-1.5 text-lg font-semibold leading-snug tabular-nums text-emerald-600 dark:text-emerald-400">
+                {formatCurrencyValue(totalCostSaved.value, totalCostSaved.currency || form.currency || 'USD')}
+              </p>
+            </div>
+          </div>
         </div>
       )}
 

--- a/website/src/components/pages/RoutingEventsPage.tsx
+++ b/website/src/components/pages/RoutingEventsPage.tsx
@@ -1,0 +1,177 @@
+import { useMemo, useState } from 'react'
+import { ArrowRightLeft, BellRing, Target, TrendingDown } from 'lucide-react'
+import { describeRoutingEvent, useRoutingEvents } from '../../hooks/useRoutingEvents'
+import { AnalyticsRangeValue, RoutingEvent, RoutingEventType } from '../../types/api'
+import { Badge } from '../ui/Badge'
+import { Card, CardBody, CardHeader } from '../ui/Card'
+import { Spinner } from '../ui/Spinner'
+
+const PRESET_OPTIONS: { value: AnalyticsRangeValue; label: string }[] = [
+  { value: '1h', label: 'Last 1 hour' },
+  { value: '12h', label: 'Last 12 hours' },
+  { value: '1d', label: 'Last 1 day' },
+  { value: '1w', label: 'Last 1 week' },
+]
+
+const EVENT_TYPE_META: Record<
+  RoutingEventType,
+  { label: string; badge: 'blue' | 'green' | 'orange'; icon: React.ElementType }
+> = {
+  leader_changed: { label: 'Leader change', badge: 'blue', icon: ArrowRightLeft },
+  gateway_entered_auth_band: { label: 'Entered auth band', badge: 'green', icon: Target },
+  gateway_exited_auth_band: { label: 'Exited auth band', badge: 'orange', icon: TrendingDown },
+}
+
+const ALL_EVENT_TYPES = Object.keys(EVENT_TYPE_META) as RoutingEventType[]
+
+function formatEventDateTime(bucketMs: number) {
+  return new Date(bucketMs).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function eventDimension(event: RoutingEvent) {
+  return [event.payment_method_type, event.payment_method].filter(Boolean).join(' / ') || 'all'
+}
+
+export function RoutingEventsPage() {
+  const [range, setRange] = useState<AnalyticsRangeValue>('12h')
+  const [activeTypes, setActiveTypes] = useState<Set<RoutingEventType>>(new Set(ALL_EVENT_TYPES))
+  const { events, isLoading, isUnavailable, markAllSeen, unseenCount } = useRoutingEvents(range)
+
+  const visibleEvents = useMemo(
+    () => events.filter((event) => activeTypes.has(event.event_type)),
+    [events, activeTypes],
+  )
+
+  function toggleType(type: RoutingEventType) {
+    setActiveTypes((previous) => {
+      const next = new Set(previous)
+      if (next.has(type)) {
+        next.delete(type)
+      } else {
+        next.add(type)
+      }
+      return next
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Routing events</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-[#8d96aa]">
+            Live changes in success-rate based routing — leader flips and gateways entering or exiting the auth band.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {unseenCount > 0 && (
+            <button
+              onClick={markAllSeen}
+              className="text-[13px] font-medium text-brand-600 hover:underline"
+            >
+              Mark all read ({unseenCount})
+            </button>
+          )}
+          <select
+            value={range}
+            onChange={(event) => setRange(event.target.value as AnalyticsRangeValue)}
+            className="h-9 rounded-lg border border-[#e6e6ee] bg-white px-3 text-[13px] font-medium text-slate-700 dark:border-[#1a1a24] dark:bg-[#121218] dark:text-slate-300"
+          >
+            {PRESET_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {ALL_EVENT_TYPES.map((type) => {
+          const meta = EVENT_TYPE_META[type]
+          const active = activeTypes.has(type)
+          return (
+            <button
+              key={type}
+              onClick={() => toggleType(type)}
+              className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${
+                active
+                  ? 'border-brand-600/40 bg-brand-50 text-brand-700 dark:border-sky-400/40 dark:bg-sky-400/10 dark:text-sky-200'
+                  : 'border-[#e6e6ee] bg-white text-slate-500 hover:bg-slate-50 dark:border-[#1a1a24] dark:bg-[#121218] dark:text-slate-400 dark:hover:bg-[#18181f]'
+              }`}
+            >
+              <meta.icon size={13} />
+              {meta.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-slate-900 dark:text-white">
+              {visibleEvents.length} event{visibleEvents.length === 1 ? '' : 's'}
+            </p>
+            <p className="text-[12px] text-slate-400">Refreshes every 30 seconds</p>
+          </div>
+        </CardHeader>
+        <CardBody className="p-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-16">
+              <Spinner />
+            </div>
+          ) : isUnavailable ? (
+            <div className="px-6 py-14 text-center">
+              <BellRing size={28} className="mx-auto text-slate-300 dark:text-slate-600" />
+              <p className="mt-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+                Routing events are unavailable
+              </p>
+              <p className="mt-1 text-[13px] text-slate-400">
+                The analytics pipeline (Kafka → ClickHouse) is offline or disabled for this environment.
+              </p>
+            </div>
+          ) : visibleEvents.length === 0 ? (
+            <div className="px-6 py-14 text-center">
+              <BellRing size={28} className="mx-auto text-slate-300 dark:text-slate-600" />
+              <p className="mt-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+                No routing events in this window
+              </p>
+              <p className="mt-1 text-[13px] text-slate-400">
+                Events appear once success-rate feedback flows through update-gateway-score and gateway
+                scores start shifting.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-slate-100 dark:divide-[#1a1f2a]">
+              {visibleEvents.map((event) => {
+                const meta = EVENT_TYPE_META[event.event_type]
+                return (
+                  <li key={event.id} className="flex items-start gap-4 px-6 py-4">
+                    <div className="mt-0.5 shrink-0">
+                      <Badge variant={meta.badge}>{meta.label}</Badge>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm text-slate-800 dark:text-slate-200">
+                        {describeRoutingEvent(event)}
+                      </p>
+                      <p className="mt-0.5 text-[12px] text-slate-400">
+                        {formatEventDateTime(event.bucket_ms)} · dimension {eventDimension(event)}
+                        {event.transaction_count != null && ` · ${event.transaction_count} txns in SR window`}
+                      </p>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </CardBody>
+      </Card>
+    </div>
+  )
+}

--- a/website/src/components/pages/RoutingHubPage.tsx
+++ b/website/src/components/pages/RoutingHubPage.tsx
@@ -377,6 +377,9 @@ export function RoutingHubPage() {
                   {srData.defaultHedgingPercent != null && (
                     <SRRow label="Hedging" value={`${srData.defaultHedgingPercent}%`} />
                   )}
+                  {srData.defaultTolerancePp != null && (
+                    <SRRow label="Tolerance band" value={`${srData.defaultTolerancePp} pp`} />
+                  )}
                   {srData.defaultLatencyThreshold != null && (
                     <SRRow label="Latency threshold" value={`${srData.defaultLatencyThreshold} ms`} />
                   )}

--- a/website/src/components/pages/SRRoutingPage.tsx
+++ b/website/src/components/pages/SRRoutingPage.tsx
@@ -43,6 +43,10 @@ const srFormSchema = z.object({
     (v) => (v === '' || v === null ? null : Number(v)),
     z.number().nullable()
   ),
+  defaultTolerancePp: z.preprocess(
+    (v) => (v === '' || v === null ? null : Number(v)),
+    z.number().min(0).max(100).nullable()
+  ),
   subLevelInputConfig: z.array(subLevelSchema),
 })
 
@@ -58,6 +62,7 @@ interface SRConfigResponse {
       defaultSuccessRate: number | null
       defaultLatencyThreshold: number | null
       defaultHedgingPercent: number | null
+      defaultTolerancePp: number | null
       subLevelInputConfig: {
         paymentMethodType: string
         paymentMethod: string
@@ -102,6 +107,10 @@ function CurrentConfigDetails({ config }: { config: SRConfigResponse['config'] }
           <div>
             <span className="text-slate-500">Feedback Latency Window:</span>
             <p className="font-medium">{config.data.defaultLatencyThreshold ?? 'Not set'} s</p>
+          </div>
+          <div>
+            <span className="text-slate-500">Tolerance band (pp):</span>
+            <p className="font-medium">{config.data.defaultTolerancePp ?? 'Not set (0.5)'}</p>
           </div>
         </div>
       </div>
@@ -150,7 +159,7 @@ function CurrentConfigDetails({ config }: { config: SRConfigResponse['config'] }
   )
 }
 
-type SRTab = 'scoring' | 'elimination' | 'flags'
+type SRTab = 'scoring' | 'elimination' | 'cost' | 'flags'
 
 export function SRRoutingPage() {
   const { merchantId } = useMerchantStore()
@@ -184,6 +193,7 @@ export function SRRoutingPage() {
       defaultSuccessRate: 0.5,
       defaultLatencyThreshold: null,
       defaultHedgingPercent: null,
+      defaultTolerancePp: null,
       subLevelInputConfig: [],
     },
   })
@@ -198,6 +208,7 @@ export function SRRoutingPage() {
         defaultSuccessRate: d.defaultSuccessRate ?? 0.5,
         defaultLatencyThreshold: d.defaultLatencyThreshold ?? null,
         defaultHedgingPercent: d.defaultHedgingPercent ?? null,
+        defaultTolerancePp: d.defaultTolerancePp ?? null,
         subLevelInputConfig: subLevelRows,
       })
       setShowSubLevelOverrides(subLevelRows.length > 0)
@@ -244,6 +255,7 @@ export function SRRoutingPage() {
             defaultSuccessRate: data.defaultSuccessRate,
             defaultLatencyThreshold: data.defaultLatencyThreshold,
             defaultHedgingPercent: data.defaultHedgingPercent,
+            defaultTolerancePp: data.defaultTolerancePp,
             subLevelInputConfig: data.subLevelInputConfig.length > 0
               ? data.subLevelInputConfig
               : null,
@@ -290,7 +302,7 @@ export function SRRoutingPage() {
       {/* Page header */}
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Auth-Rate Based Routing</h1>
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Multi Objective Routing</h1>
           <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
             Dynamic gateway scoring based on real-time success rates.
           </p>
@@ -337,6 +349,7 @@ export function SRRoutingPage() {
         <nav className="-mb-px flex gap-1">
           <button type="button" className={tabClass('scoring')} onClick={() => setActiveTab('scoring')}>Scoring</button>
           <button type="button" className={tabClass('elimination')} onClick={() => setActiveTab('elimination')}>Elimination</button>
+          <button type="button" className={tabClass('cost')} onClick={() => setActiveTab('cost')}>Cost Based Routing</button>
           <button type="button" className={tabClass('flags')} onClick={() => setActiveTab('flags')}>Feature Flags</button>
         </nav>
       </div>
@@ -466,6 +479,43 @@ export function SRRoutingPage() {
           {/* ── Elimination tab ── */}
           {activeTab === 'elimination' && <EliminationConfig merchantId={merchantId} />}
 
+          {/* ── Cost Based Routing tab ── */}
+          {activeTab === 'cost' && (
+            <form onSubmit={handleSubmit(onSave)} className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Cost Based Routing</h2>
+                  <p className="text-xs text-slate-500 mt-0.5">Tunes how aggressively the router prefers the cheaper PSP within the auth-rate tolerance band.</p>
+                </CardHeader>
+                <CardBody className="grid gap-6 md:grid-cols-3">
+                  <label className="space-y-1.5">
+                    <span className="text-xs font-medium text-slate-600 dark:text-slate-300">Cost Optimisation Override Configuration (pp)</span>
+                    <input
+                      type="number" step="0.01"
+                      {...register('defaultTolerancePp')}
+                      placeholder="0.5"
+                      className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    />
+                    {errors.defaultTolerancePp && <p className="text-xs text-red-500">{errors.defaultTolerancePp.message}</p>}
+                    <p className="text-[11px] text-slate-400 leading-relaxed">
+                      Auth-rate band in percentage points used by multi-objective routing. Within this window, the cheaper PSP wins. Leave blank for the default (0.5 pp).
+                    </p>
+                  </label>
+                </CardBody>
+              </Card>
+
+              <ErrorMessage error={saveError} />
+              {saveSuccess && (
+                <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-4 py-3 text-sm text-emerald-400">
+                  Configuration saved.
+                </div>
+              )}
+              <Button type="submit" disabled={saving || !merchantId}>
+                {saving ? <><Spinner size={14} /> Saving…</> : 'Save Cost Config'}
+              </Button>
+            </form>
+          )}
+
           {/* ── Feature Flags tab ── */}
           {activeTab === 'flags' && <SRFeatureFlags merchantId={merchantId} />}
         </>
@@ -492,6 +542,12 @@ const SR_FEATURES: { feature: KnownFeature; title: string; description: string }
     title: 'A/B test on real payments',
     description:
       'Routes live production traffic through the active A/B test algorithm. When enabled, each payment is deterministically assigned to a control or variant arm based on its payment ID. Disable at any time to fall back to standard SR routing with no impact on in-flight payments.',
+  },
+  {
+    feature: 'multi-objective-routing',
+    title: 'Multi-objective routing',
+    description:
+      'Within the auth-tolerance band, picks the cheaper PSP using cost data from Hypersense. Active only when Explore-exploit on SRv3 is disabled — when both are on, hedging wins to keep the bandit\'s exploration signal clean. routing_approach shows SR_SELECTION_MULTI_OBJECTIVE when this path is taken.',
   },
 ]
 

--- a/website/src/components/pages/SRRoutingPage.tsx
+++ b/website/src/components/pages/SRRoutingPage.tsx
@@ -349,7 +349,7 @@ export function SRRoutingPage() {
         <nav className="-mb-px flex gap-1">
           <button type="button" className={tabClass('scoring')} onClick={() => setActiveTab('scoring')}>Scoring</button>
           <button type="button" className={tabClass('elimination')} onClick={() => setActiveTab('elimination')}>Elimination</button>
-          <button type="button" className={tabClass('cost')} onClick={() => setActiveTab('cost')}>Cost Based Routing</button>
+          <button type="button" className={tabClass('cost')} onClick={() => setActiveTab('cost')}>Cost Based</button>
           <button type="button" className={tabClass('flags')} onClick={() => setActiveTab('flags')}>Feature Flags</button>
         </nav>
       </div>
@@ -484,12 +484,12 @@ export function SRRoutingPage() {
             <form onSubmit={handleSubmit(onSave)} className="space-y-6">
               <Card>
                 <CardHeader>
-                  <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Cost Based Routing</h2>
+                  <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Cost Based Config</h2>
                   <p className="text-xs text-slate-500 mt-0.5">Tunes how aggressively the router prefers the cheaper PSP within the auth-rate tolerance band.</p>
                 </CardHeader>
                 <CardBody className="grid gap-6 md:grid-cols-3">
                   <label className="space-y-1.5">
-                    <span className="text-xs font-medium text-slate-600 dark:text-slate-300">Cost Optimisation Override Configuration (pp)</span>
+                    <span className="text-xs font-medium text-slate-600 dark:text-slate-300">Cost Optimisation Override Configuration</span>
                     <input
                       type="number" step="0.01"
                       {...register('defaultTolerancePp')}
@@ -498,7 +498,7 @@ export function SRRoutingPage() {
                     />
                     {errors.defaultTolerancePp && <p className="text-xs text-red-500">{errors.defaultTolerancePp.message}</p>}
                     <p className="text-[11px] text-slate-400 leading-relaxed">
-                      Auth-rate band in percentage points used by multi-objective routing. Within this window, the cheaper PSP wins. Leave blank for the default (0.5 pp).
+                      Auth-rate band used by multi-objective routing. Within this window, the cheaper PSP wins. Leave blank for the default (0.5).
                     </p>
                   </label>
                 </CardBody>
@@ -747,7 +747,7 @@ function EliminationConfig({ merchantId }: { merchantId: string | null }) {
 
       <Card>
         <CardHeader>
-          <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Elimination Config</h2>
+          <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Elimination Configs</h2>
           <p className="text-xs text-slate-500 mt-0.5">
             Gateways whose SR score drops below the threshold are removed from routing entirely.
           </p>

--- a/website/src/components/pages/SRRoutingPage.tsx
+++ b/website/src/components/pages/SRRoutingPage.tsx
@@ -109,8 +109,8 @@ function CurrentConfigDetails({ config }: { config: SRConfigResponse['config'] }
             <p className="font-medium">{config.data.defaultLatencyThreshold ?? 'Not set'} s</p>
           </div>
           <div>
-            <span className="text-slate-500">Tolerance band (pp):</span>
-            <p className="font-medium">{config.data.defaultTolerancePp ?? 'Not set (0.5)'}</p>
+            <span className="text-slate-500">Tolerance band:</span>
+            <p className="font-medium">{config.data.defaultTolerancePp != null ? `${config.data.defaultTolerancePp * 100}%` : 'Not set (50%)'}</p>
           </div>
         </div>
       </div>
@@ -208,7 +208,8 @@ export function SRRoutingPage() {
         defaultSuccessRate: d.defaultSuccessRate ?? 0.5,
         defaultLatencyThreshold: d.defaultLatencyThreshold ?? null,
         defaultHedgingPercent: d.defaultHedgingPercent ?? null,
-        defaultTolerancePp: d.defaultTolerancePp ?? null,
+        // Stored as a fraction in the backend (e.g. 0.1) but shown as a percentage in the UI (10).
+        defaultTolerancePp: d.defaultTolerancePp != null ? d.defaultTolerancePp * 100 : null,
         subLevelInputConfig: subLevelRows,
       })
       setShowSubLevelOverrides(subLevelRows.length > 0)
@@ -255,7 +256,8 @@ export function SRRoutingPage() {
             defaultSuccessRate: data.defaultSuccessRate,
             defaultLatencyThreshold: data.defaultLatencyThreshold,
             defaultHedgingPercent: data.defaultHedgingPercent,
-            defaultTolerancePp: data.defaultTolerancePp,
+            // UI holds a percentage (e.g. 10); persist back as a fraction (0.1).
+            defaultTolerancePp: data.defaultTolerancePp != null ? data.defaultTolerancePp / 100 : null,
             subLevelInputConfig: data.subLevelInputConfig.length > 0
               ? data.subLevelInputConfig
               : null,
@@ -484,21 +486,23 @@ export function SRRoutingPage() {
             <form onSubmit={handleSubmit(onSave)} className="space-y-6">
               <Card>
                 <CardHeader>
-                  <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Cost Based Config</h2>
-                  <p className="text-xs text-slate-500 mt-0.5">Tunes how aggressively the router prefers the cheaper PSP within the auth-rate tolerance band.</p>
+                  <h2 className="text-base font-semibold text-slate-800 dark:text-white">Cost Based Config</h2>
                 </CardHeader>
-                <CardBody className="grid gap-6 md:grid-cols-3">
-                  <label className="space-y-1.5">
-                    <span className="text-xs font-medium text-slate-600 dark:text-slate-300">Cost Optimisation Override Configuration</span>
-                    <input
-                      type="number" step="0.01"
-                      {...register('defaultTolerancePp')}
-                      placeholder="0.5"
-                      className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-1 focus:ring-brand-500"
-                    />
-                    {errors.defaultTolerancePp && <p className="text-xs text-red-500">{errors.defaultTolerancePp.message}</p>}
-                    <p className="text-[11px] text-slate-400 leading-relaxed">
-                      Auth-rate band used by multi-objective routing. Within this window, the cheaper PSP wins. Leave blank for the default (0.5).
+                <CardBody>
+                  <label className="space-y-1.5 block">
+                    <span className="block text-sm font-medium text-slate-600 dark:text-slate-300 whitespace-nowrap">Auth Tolerance Band for Cost Optimisation</span>
+                    <div className="relative max-w-xs">
+                      <input
+                        type="number" step="1"
+                        {...register('defaultTolerancePp')}
+                        placeholder="50"
+                        className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-3 py-2 pr-8 w-full text-base focus:outline-none focus:ring-1 focus:ring-brand-500"
+                      />
+                      <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-base text-slate-400">%</span>
+                    </div>
+                    {errors.defaultTolerancePp && <p className="text-sm text-red-500">{errors.defaultTolerancePp.message}</p>}
+                    <p className="text-xs text-slate-400 leading-relaxed">
+                      Auth-tolerance band window within which the cheaper PSP wins
                     </p>
                   </label>
                 </CardBody>
@@ -547,7 +551,7 @@ const SR_FEATURES: { feature: KnownFeature; title: string; description: string }
     feature: 'multi-objective-routing',
     title: 'Multi-objective routing',
     description:
-      'Within the auth-tolerance band, picks the cheaper PSP using cost data from Hypersense. Active only when Explore-exploit on SRv3 is disabled — when both are on, hedging wins to keep the bandit\'s exploration signal clean. routing_approach shows SR_SELECTION_MULTI_OBJECTIVE when this path is taken.',
+      'Within the auth-tolerance band, picks the cheaper PSP using cost data from PSP. Active only when Explore-exploit on SRv3 is disabled — when both are on, hedging wins to keep the bandit\'s exploration signal clean. routing_approach shows SR_SELECTION_MULTI_OBJECTIVE when this path is taken.',
   },
 ]
 

--- a/website/src/hooks/useMerchantFeatures.ts
+++ b/website/src/hooks/useMerchantFeatures.ts
@@ -2,7 +2,11 @@ import useSWR from 'swr'
 import { apiPost, fetcher } from '../lib/api'
 import { MerchantFeaturesResponse } from '../types/api'
 
-export type KnownFeature = 'gsm-scoring-filter' | 'explore-exploit-srv3' | 'ab-test-real-payments'
+export type KnownFeature =
+  | 'gsm-scoring-filter'
+  | 'explore-exploit-srv3'
+  | 'ab-test-real-payments'
+  | 'multi-objective-routing'
 
 export function useMerchantFeatures(merchantId?: string) {
   const path = merchantId ? `/merchant-account/${merchantId}/features` : null

--- a/website/src/hooks/useRoutingEvents.ts
+++ b/website/src/hooks/useRoutingEvents.ts
@@ -4,7 +4,7 @@ import { fetcher } from '../lib/api'
 import { useAuthStore } from '../store/authStore'
 import { AnalyticsRangeValue, RoutingEvent, RoutingEventsResponse } from '../types/api'
 
-const POLL_INTERVAL_MS = 30_000
+const POLL_INTERVAL_MS = 15_000
 const SEEN_STORAGE_PREFIX = 'routing_events_seen'
 const MAX_SEEN_IDS = 500
 

--- a/website/src/hooks/useRoutingEvents.ts
+++ b/website/src/hooks/useRoutingEvents.ts
@@ -75,26 +75,13 @@ export function useRoutingEvents(range: AnalyticsRangeValue = '12h') {
   }
 }
 
-// SR scores are success rates on a 0..1 scale; show them as percentages.
-function formatScore(value: number | null): string {
-  if (value == null) return '–'
-  return `${(value * 100).toFixed(1)}%`
-}
-
 export function describeRoutingEvent(event: RoutingEvent): string {
-  const dimension = [event.payment_method_type, event.payment_method]
-    .filter(Boolean)
-    .join('/')
-  const scope = dimension ? ` for ${dimension}` : ''
-  const score = formatScore(event.score)
-  const previousScore = formatScore(event.previous_score)
-
   switch (event.event_type) {
     case 'leader_changed':
-      return `${event.gateway} overtook ${event.previous_gateway ?? 'previous leader'}${scope} — success rate ${score} vs ${previousScore}`
+      return `switching psp to ${event.gateway}`
     case 'gateway_entered_auth_band':
-      return `${event.gateway} entered the auth band of ${event.previous_gateway ?? 'the leader'}${scope} — success rate ${score} vs leader ${previousScore}`
+      return `${event.gateway} entered auth band`
     case 'gateway_exited_auth_band':
-      return `${event.gateway} dropped out of the auth band of ${event.previous_gateway ?? 'the leader'}${scope} — success rate ${score} vs leader ${previousScore}`
+      return `${event.gateway} exited auth band`
   }
 }

--- a/website/src/hooks/useRoutingEvents.ts
+++ b/website/src/hooks/useRoutingEvents.ts
@@ -35,15 +35,21 @@ function persistSeenIds(merchantId: string, ids: Set<string>) {
   }
 }
 
-export function useRoutingEvents(range: AnalyticsRangeValue = '12h') {
+export function useRoutingEvents(
+  range: AnalyticsRangeValue = '12h',
+  // Override the poll cadence — e.g. tighten it while a simulation is actively
+  // producing events so the Autopilot feed keeps up instead of lagging by a
+  // full poll interval. Falls back to the idle default.
+  refreshInterval: number = POLL_INTERVAL_MS,
+) {
   const merchantId = useAuthStore((state) => state.user?.merchantId) ?? ''
   // Short windows get second-granularity detection (catches crossings inside a
   // burst); longer windows use minute buckets to keep the scan bounded.
   const bucket = range === '15m' || range === '1h' ? '1s' : '1m'
-  const { data, error, isLoading } = useSWR<RoutingEventsResponse>(
+  const { data, error, isLoading, mutate } = useSWR<RoutingEventsResponse>(
     merchantId ? `/analytics/routing-events?range=${range}&bucket=${bucket}` : null,
     fetcher,
-    { refreshInterval: POLL_INTERVAL_MS, revalidateOnFocus: false },
+    { refreshInterval, revalidateOnFocus: false },
   )
 
   const [seenIds, setSeenIds] = useState<Set<string>>(() => loadSeenIds(merchantId))
@@ -65,11 +71,18 @@ export function useRoutingEvents(range: AnalyticsRangeValue = '12h') {
     })
   }, [events, merchantId])
 
+  // Force an immediate re-fetch (bypassing the poll timer) — used to pull fresh
+  // events the moment a simulation batch lands.
+  const refresh = useCallback(() => {
+    void mutate()
+  }, [mutate])
+
   return {
     events,
     unseenEvents,
     unseenCount: unseenEvents.length,
     markAllSeen,
+    refresh,
     isLoading,
     isUnavailable: Boolean(error),
   }
@@ -80,8 +93,10 @@ export function describeRoutingEvent(event: RoutingEvent): string {
     case 'leader_changed':
       return `switching psp to ${event.gateway}`
     case 'gateway_entered_auth_band':
-      return `${event.gateway} entered auth band`
+      // Score is now within tolerance of the top PSP, so the engine can route to
+      // it for cost savings despite a slightly lower success rate.
+      return `${event.gateway} now good enough on success — routing it to save cost`
     case 'gateway_exited_auth_band':
-      return `${event.gateway} exited auth band`
+      return `${event.gateway} slipped on success — not eligible for cost override anymore`
   }
 }

--- a/website/src/hooks/useRoutingEvents.ts
+++ b/website/src/hooks/useRoutingEvents.ts
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useState } from 'react'
+import {
+  ReactNode,
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import useSWR from 'swr'
 import { fetcher } from '../lib/api'
 import { useAuthStore } from '../store/authStore'
@@ -7,6 +16,23 @@ import { AnalyticsRangeValue, RoutingEvent, RoutingEventsResponse } from '../typ
 const POLL_INTERVAL_MS = 15_000
 const SEEN_STORAGE_PREFIX = 'routing_events_seen'
 const MAX_SEEN_IDS = 500
+
+// The always-on live feed. One poll at this range is shared by every
+// always-mounted consumer (the notification bell) and the simulator, so they no
+// longer issue overlapping requests. Wider, user-driven windows (the events page
+// browsing history) are a genuinely different query and open their own.
+const LIVE_RANGE: AnalyticsRangeValue = '1h'
+
+// Short windows get second-granularity detection (catches crossings inside a
+// burst); longer windows use minute buckets to keep the scan bounded.
+function bucketForRange(range: AnalyticsRangeValue): string {
+  return range === '15m' || range === '1h' ? '1s' : '1m'
+}
+
+function routingEventsKey(merchantId: string, range: AnalyticsRangeValue): string | null {
+  if (!merchantId) return null
+  return `/analytics/routing-events?range=${range}&bucket=${bucketForRange(range)}`
+}
 
 function seenStorageKey(merchantId: string) {
   return `${SEEN_STORAGE_PREFIX}:${merchantId}`
@@ -35,21 +61,31 @@ function persistSeenIds(merchantId: string, ids: Set<string>) {
   }
 }
 
-export function useRoutingEvents(
-  range: AnalyticsRangeValue = '12h',
-  // Override the poll cadence — e.g. tighten it while a simulation is actively
-  // producing events so the Autopilot feed keeps up instead of lagging by a
-  // full poll interval. Falls back to the idle default.
-  refreshInterval: number = POLL_INTERVAL_MS,
-) {
+interface RoutingEventsContextValue {
+  liveEvents: RoutingEvent[]
+  isLoading: boolean
+  isUnavailable: boolean
+  isSeen: (id: string) => boolean
+  markSeen: (events: RoutingEvent[]) => void
+  refresh: () => void
+  // Let a single consumer (the simulator) tighten the shared poll while it is
+  // actively producing events; pass null to release back to the idle default.
+  requestPollInterval: (intervalMs: number | null) => void
+}
+
+const RoutingEventsContext = createContext<RoutingEventsContextValue | null>(null)
+
+// Owns the one live-feed poll and the merchant-scoped seen-state. Mount once,
+// above the notification bell and the routed pages, so every consumer of
+// `useRoutingEvents` shares a single network poll and one consistent seen-set.
+export function RoutingEventsProvider({ children }: { children: ReactNode }) {
   const merchantId = useAuthStore((state) => state.user?.merchantId) ?? ''
-  // Short windows get second-granularity detection (catches crossings inside a
-  // burst); longer windows use minute buckets to keep the scan bounded.
-  const bucket = range === '15m' || range === '1h' ? '1s' : '1m'
+  const [pollIntervalMs, setPollIntervalMs] = useState(POLL_INTERVAL_MS)
+
   const { data, error, isLoading, mutate } = useSWR<RoutingEventsResponse>(
-    merchantId ? `/analytics/routing-events?range=${range}&bucket=${bucket}` : null,
+    routingEventsKey(merchantId, LIVE_RANGE),
     fetcher,
-    { refreshInterval, revalidateOnFocus: false },
+    { refreshInterval: pollIntervalMs, revalidateOnFocus: false },
   )
 
   const [seenIds, setSeenIds] = useState<Set<string>>(() => loadSeenIds(merchantId))
@@ -58,24 +94,116 @@ export function useRoutingEvents(
     setSeenIds(loadSeenIds(merchantId))
   }, [merchantId])
 
-  // Degrade silently when analytics is unavailable (e.g. ClickHouse disabled).
-  const events: RoutingEvent[] = error ? [] : data?.events ?? []
-  const unseenEvents = events.filter((event) => !seenIds.has(event.id))
+  const isSeen = useCallback((id: string) => seenIds.has(id), [seenIds])
 
-  const markAllSeen = useCallback(() => {
-    setSeenIds((previous) => {
-      const next = new Set(previous)
-      for (const event of events) next.add(event.id)
-      persistSeenIds(merchantId, next)
-      return next
-    })
-  }, [events, merchantId])
+  const markSeen = useCallback(
+    (events: RoutingEvent[]) => {
+      setSeenIds((previous) => {
+        const next = new Set(previous)
+        for (const event of events) next.add(event.id)
+        persistSeenIds(merchantId, next)
+        return next
+      })
+    },
+    [merchantId],
+  )
 
   // Force an immediate re-fetch (bypassing the poll timer) — used to pull fresh
   // events the moment a simulation batch lands.
   const refresh = useCallback(() => {
     void mutate()
   }, [mutate])
+
+  const requestPollInterval = useCallback((intervalMs: number | null) => {
+    setPollIntervalMs(intervalMs ?? POLL_INTERVAL_MS)
+  }, [])
+
+  // Degrade silently when analytics is unavailable (e.g. ClickHouse disabled).
+  const liveEvents = useMemo<RoutingEvent[]>(() => (error ? [] : data?.events ?? []), [error, data])
+
+  const value = useMemo<RoutingEventsContextValue>(
+    () => ({
+      liveEvents,
+      isLoading,
+      isUnavailable: Boolean(error),
+      isSeen,
+      markSeen,
+      refresh,
+      requestPollInterval,
+    }),
+    [liveEvents, isLoading, error, isSeen, markSeen, refresh, requestPollInterval],
+  )
+
+  return createElement(RoutingEventsContext.Provider, { value }, children)
+}
+
+function useRoutingEventsContext(): RoutingEventsContextValue {
+  const context = useContext(RoutingEventsContext)
+  if (!context) {
+    throw new Error('useRoutingEvents must be used within a <RoutingEventsProvider>')
+  }
+  return context
+}
+
+export function useRoutingEvents(
+  range: AnalyticsRangeValue = LIVE_RANGE,
+  // Override the shared poll cadence — e.g. tighten it while a simulation is
+  // actively producing events so the Autopilot feed keeps up. Omit to use the
+  // idle default. Only honored for the live feed (the bell + simulator share it).
+  refreshInterval?: number,
+) {
+  const merchantId = useAuthStore((state) => state.user?.merchantId) ?? ''
+  const {
+    liveEvents,
+    isLoading: liveLoading,
+    isUnavailable: liveUnavailable,
+    isSeen,
+    markSeen,
+    refresh: refreshLive,
+    requestPollInterval,
+  } = useRoutingEventsContext()
+
+  const isLive = range === LIVE_RANGE
+
+  // Live consumers share the provider's single poll; a caller that passes an
+  // explicit cadence retunes it, then releases on unmount/stop so the bell's
+  // idle 15s cadence is restored.
+  useEffect(() => {
+    if (!isLive || refreshInterval === undefined) return
+    requestPollInterval(refreshInterval)
+    return () => requestPollInterval(null)
+  }, [isLive, refreshInterval, requestPollInterval])
+
+  // Wider, user-driven windows (the events page) open their own subscription;
+  // the live feed already covers LIVE_RANGE for the bell + simulator.
+  const { data, error, isLoading: rangeLoading, mutate } = useSWR<RoutingEventsResponse>(
+    isLive ? null : routingEventsKey(merchantId, range),
+    fetcher,
+    { refreshInterval: refreshInterval ?? POLL_INTERVAL_MS, revalidateOnFocus: false },
+  )
+
+  const events = isLive ? liveEvents : error ? [] : data?.events ?? []
+  const isLoading = isLive ? liveLoading : rangeLoading
+  const isUnavailable = isLive ? liveUnavailable : Boolean(error)
+
+  const unseenEvents = useMemo(
+    () => events.filter((event) => !isSeen(event.id)),
+    [events, isSeen],
+  )
+
+  // "Mark all read" applies to whatever this consumer is showing, but writes to
+  // the shared seen-state so the badge clears everywhere at once.
+  const markAllSeen = useCallback(() => {
+    markSeen(events)
+  }, [events, markSeen])
+
+  const refresh = useCallback(() => {
+    if (isLive) {
+      refreshLive()
+    } else {
+      void mutate()
+    }
+  }, [isLive, refreshLive, mutate])
 
   return {
     events,
@@ -84,7 +212,7 @@ export function useRoutingEvents(
     markAllSeen,
     refresh,
     isLoading,
-    isUnavailable: Boolean(error),
+    isUnavailable,
   }
 }
 

--- a/website/src/hooks/useRoutingEvents.ts
+++ b/website/src/hooks/useRoutingEvents.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from 'react'
+import useSWR from 'swr'
+import { fetcher } from '../lib/api'
+import { useAuthStore } from '../store/authStore'
+import { AnalyticsRangeValue, RoutingEvent, RoutingEventsResponse } from '../types/api'
+
+const POLL_INTERVAL_MS = 30_000
+const SEEN_STORAGE_PREFIX = 'routing_events_seen'
+const MAX_SEEN_IDS = 500
+
+function seenStorageKey(merchantId: string) {
+  return `${SEEN_STORAGE_PREFIX}:${merchantId}`
+}
+
+function loadSeenIds(merchantId: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(seenStorageKey(merchantId))
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw)
+    return new Set(Array.isArray(parsed) ? parsed.filter((id) => typeof id === 'string') : [])
+  } catch {
+    return new Set()
+  }
+}
+
+function persistSeenIds(merchantId: string, ids: Set<string>) {
+  try {
+    // Event IDs are stable across polls; cap stored history so it never grows unbounded.
+    localStorage.setItem(
+      seenStorageKey(merchantId),
+      JSON.stringify(Array.from(ids).slice(-MAX_SEEN_IDS)),
+    )
+  } catch {
+    // localStorage unavailable (private mode/quota): unseen state just resets per session.
+  }
+}
+
+export function useRoutingEvents(range: AnalyticsRangeValue = '12h') {
+  const merchantId = useAuthStore((state) => state.user?.merchantId) ?? ''
+  // Short windows get second-granularity detection (catches crossings inside a
+  // burst); longer windows use minute buckets to keep the scan bounded.
+  const bucket = range === '15m' || range === '1h' ? '1s' : '1m'
+  const { data, error, isLoading } = useSWR<RoutingEventsResponse>(
+    merchantId ? `/analytics/routing-events?range=${range}&bucket=${bucket}` : null,
+    fetcher,
+    { refreshInterval: POLL_INTERVAL_MS, revalidateOnFocus: false },
+  )
+
+  const [seenIds, setSeenIds] = useState<Set<string>>(() => loadSeenIds(merchantId))
+
+  useEffect(() => {
+    setSeenIds(loadSeenIds(merchantId))
+  }, [merchantId])
+
+  // Degrade silently when analytics is unavailable (e.g. ClickHouse disabled).
+  const events: RoutingEvent[] = error ? [] : data?.events ?? []
+  const unseenEvents = events.filter((event) => !seenIds.has(event.id))
+
+  const markAllSeen = useCallback(() => {
+    setSeenIds((previous) => {
+      const next = new Set(previous)
+      for (const event of events) next.add(event.id)
+      persistSeenIds(merchantId, next)
+      return next
+    })
+  }, [events, merchantId])
+
+  return {
+    events,
+    unseenEvents,
+    unseenCount: unseenEvents.length,
+    markAllSeen,
+    isLoading,
+    isUnavailable: Boolean(error),
+  }
+}
+
+// SR scores are success rates on a 0..1 scale; show them as percentages.
+function formatScore(value: number | null): string {
+  if (value == null) return '–'
+  return `${(value * 100).toFixed(1)}%`
+}
+
+export function describeRoutingEvent(event: RoutingEvent): string {
+  const dimension = [event.payment_method_type, event.payment_method]
+    .filter(Boolean)
+    .join('/')
+  const scope = dimension ? ` for ${dimension}` : ''
+  const score = formatScore(event.score)
+  const previousScore = formatScore(event.previous_score)
+
+  switch (event.event_type) {
+    case 'leader_changed':
+      return `${event.gateway} overtook ${event.previous_gateway ?? 'previous leader'}${scope} — success rate ${score} vs ${previousScore}`
+    case 'gateway_entered_auth_band':
+      return `${event.gateway} entered the auth band of ${event.previous_gateway ?? 'the leader'}${scope} — success rate ${score} vs leader ${previousScore}`
+    case 'gateway_exited_auth_band':
+      return `${event.gateway} dropped out of the auth band of ${event.previous_gateway ?? 'the leader'}${scope} — success rate ${score} vs leader ${previousScore}`
+  }
+}

--- a/website/src/lib/api.ts
+++ b/website/src/lib/api.ts
@@ -108,7 +108,7 @@ export async function apiFetch<T>(
   const body = options?.body ? JSON.parse(options.body as string) : undefined
   const requestPath = resolveApiPath(path)
 
-  logRequest(method, requestPath, body)
+  // logRequest(method, requestPath, body)
 
   try {
     const token = tokenRef.get()
@@ -135,7 +135,7 @@ export async function apiFetch<T>(
       responseBody = responseText
     }
 
-    logResponse(requestPath, res.status, res.statusText, responseBody)
+    // logResponse(requestPath, res.status, res.statusText, responseBody)
 
     // Only clear session when the JWT itself is confirmed invalid/expired.
     // A generic 401 (e.g. missing API key on a protected route) must NOT wipe the session.

--- a/website/src/lib/api.ts
+++ b/website/src/lib/api.ts
@@ -16,27 +16,27 @@ function resolveApiPath(path: string) {
   return `${API_BASE_PATH}${normalizedPath}`
 }
 
-function logRequest(method: string, path: string, body?: unknown) {
-  if (!DEBUG_API) return
-  console.log('\n' + '='.repeat(80))
-  console.log(`[API REQUEST] ${new Date().toISOString()}`)
-  console.log(`Method: ${method}`)
-  console.log(`Path: ${path}`)
-  if (body !== undefined) {
-    console.log('Body:', JSON.stringify(body, null, 2))
-  }
-  console.log('='.repeat(80))
-}
+// function logRequest(method: string, path: string, body?: unknown) {
+//   if (!DEBUG_API) return
+//   console.log('\n' + '='.repeat(80))
+//   console.log(`[API REQUEST] ${new Date().toISOString()}`)
+//   console.log(`Method: ${method}`)
+//   console.log(`Path: ${path}`)
+//   if (body !== undefined) {
+//     console.log('Body:', JSON.stringify(body, null, 2))
+//   }
+//   console.log('='.repeat(80))
+// }
 
-function logResponse(path: string, status: number, statusText: string, body: string) {
-  if (!DEBUG_API) return
-  console.log('\n' + '-'.repeat(80))
-  console.log(`[API RESPONSE] ${new Date().toISOString()}`)
-  console.log(`Path: ${path}`)
-  console.log(`Status: ${status} ${statusText}`)
-  console.log('Response Body:', body)
-  console.log('-'.repeat(80) + '\n')
-}
+// function logResponse(path: string, status: number, statusText: string, body: string) {
+//   if (!DEBUG_API) return
+//   console.log('\n' + '-'.repeat(80))
+//   console.log(`[API RESPONSE] ${new Date().toISOString()}`)
+//   console.log(`Path: ${path}`)
+//   console.log(`Status: ${status} ${statusText}`)
+//   console.log('Response Body:', body)
+//   console.log('-'.repeat(80) + '\n')
+// }
 
 function logError(path: string, error: unknown) {
   if (!DEBUG_API) return
@@ -104,8 +104,6 @@ export async function apiFetch<T>(
   path: string,
   options?: RequestInit
 ): Promise<T> {
-  const method = options?.method || 'GET'
-  const body = options?.body ? JSON.parse(options.body as string) : undefined
   const requestPath = resolveApiPath(path)
 
   // logRequest(method, requestPath, body)
@@ -126,14 +124,14 @@ export async function apiFetch<T>(
     })
 
     const responseText = await res.text()
-    let responseBody: string
+    // let responseBody: string
 
-    try {
-      const json = JSON.parse(responseText)
-      responseBody = JSON.stringify(json, null, 2)
-    } catch {
-      responseBody = responseText
-    }
+    // try {
+    //   const json = JSON.parse(responseText)
+    //   responseBody = JSON.stringify(json, null, 2)
+    // } catch {
+    //   responseBody = responseText
+    // }
 
     // logResponse(requestPath, res.status, res.statusText, responseBody)
 

--- a/website/src/lib/chartStyles.ts
+++ b/website/src/lib/chartStyles.ts
@@ -6,6 +6,7 @@ export const CHART_TOOLTIP_STYLE: CSSProperties = {
   borderRadius: '14px',
   color: 'var(--chart-tooltip-text)',
   boxShadow: 'var(--chart-tooltip-shadow)',
+  padding: '10px 12px',
 }
 
 export const CHART_TOOLTIP_LABEL_STYLE: CSSProperties = {

--- a/website/src/lib/constants.ts
+++ b/website/src/lib/constants.ts
@@ -59,6 +59,7 @@ export type RoutingKey = keyof typeof STATIC_ROUTING_KEYS
 
 export const ROUTING_APPROACH_COLORS: Record<string, string> = {
   SR_SELECTION_V3_ROUTING: 'bg-blue-100 text-blue-800',
+  SR_SELECTION_MULTI_OBJECTIVE: 'bg-cyan-100 text-cyan-800',
   PRIORITY_LOGIC: 'bg-purple-100 text-purple-800',
   NTW_BASED_ROUTING: 'bg-green-100 text-green-800',
   SR_SELECTION_V3_ROUTING_WITH_HEDGING: 'bg-orange-100 text-orange-800',

--- a/website/src/types/api.ts
+++ b/website/src/types/api.ts
@@ -532,6 +532,32 @@ export interface UpdateScoreResponse {
   gsm_info: GsmInfo | null
 }
 
+export type RoutingEventType =
+  | 'leader_changed'
+  | 'gateway_entered_auth_band'
+  | 'gateway_exited_auth_band'
+
+export interface RoutingEvent {
+  id: string
+  event_type: RoutingEventType
+  merchant_id: string
+  payment_method_type: string | null
+  payment_method: string | null
+  bucket_ms: number
+  gateway: string
+  previous_gateway: string | null
+  score: number | null
+  previous_score: number | null
+  transaction_count: number | null
+}
+
+export interface RoutingEventsResponse {
+  merchant_id: string
+  range: AnalyticsRangeValue
+  events: RoutingEvent[]
+  generated_at_ms: number
+}
+
 export interface PaymentAuditResponse {
   merchant_id: string
   range: AnalyticsRangeValue

--- a/website/src/types/api.ts
+++ b/website/src/types/api.ts
@@ -11,7 +11,26 @@ export interface DecideGatewayResponse {
   reset_approach: string
   is_scheduled_outage: boolean
   debit_routing_output?: DebitRoutingOutput | null
+  multi_objective_info?: MultiObjectiveInfo | null
   latency: number | null
+}
+
+export type MultiObjectiveOutcome = 'COST_WON' | 'AUTH_WON'
+
+export interface PspSummary {
+  psp: string
+  authRate: number
+  costBps: number | null
+}
+
+export interface MultiObjectiveInfo {
+  outcome: MultiObjectiveOutcome
+  reason: string
+  tolerancePp: number
+  srHead: PspSummary | null
+  chosen: PspSummary | null
+  costSavedBps: number | null
+  qualifiedCount: number
 }
 
 export type RoutingAlgorithmName =
@@ -186,6 +205,7 @@ export interface SRConfigData {
   defaultLowerResetFactor: number | null
   defaultUpperResetFactor: number | null
   defaultGatewayExtraScore: number | null
+  defaultTolerancePp: number | null
   subLevelInputConfig: SubLevelConfig[] | null
 }
 
@@ -365,6 +385,31 @@ export interface AnalyticsRoutingStatsResponse {
   top_rules: AnalyticsRuleHit[]
   sr_trend: GatewayScoreSeriesPoint[]
   available_filters: RoutingFilterOptions
+}
+
+export interface AnalyticsAvailableCurrency {
+  currency: string
+  decision_count: number
+}
+
+export interface AnalyticsCostSavingsTrendPoint {
+  bucket_ms: number
+  saved_value: number
+}
+
+export interface AnalyticsCostSavingsTotals {
+  saved_value: number
+  cost_won_count: number
+  total_decisions: number
+}
+
+export interface AnalyticsCostSavingsResponse {
+  merchant_id: string
+  range: AnalyticsRangeValue
+  currency: string | null
+  available_currencies: AnalyticsAvailableCurrency[]
+  trend: AnalyticsCostSavingsTrendPoint[]
+  totals: AnalyticsCostSavingsTotals
 }
 
 export interface RoutingFilterOptions {


### PR DESCRIPTION
Added support for multi-objective routing simulation by considering pre-seeded payment account reports from Adyen and Stripe for cost estimation. Changes include the addition of cost savings analytics endpoints, improvements to ClickHouse table creation and ingestion latency, and better developer experience for local Postgres setups.

**Analytics Features**

* Added cost savings analytics: new Rust modules (`cost_savings.rs`) and supporting models provide endpoints and logic for tracking cost savings trends, available currencies, and aggregate totals. These are integrated into the ClickHouse analytics store and exposed via new API endpoints.
* Added score bucket series endpoint for routing events analytics, supporting time-bucketed score aggregation per gateway. 

**ClickHouse Ingestion and Schema**

* Changed all ClickHouse `CREATE TABLE` statements to use `IF NOT EXISTS`, making table creation idempotent and preventing errors on repeated runs. 
* Reduced Kafka ingestion flush interval to 250ms (from 7.5s default) for near real-time analytics updates, both in shell scripts and Helm chart config. 

**Developer Experience and Configuration**

* Added default `POSTGRES_PASSWORD` for local development in `oneclick.sh` and improved seeding of required global service configuration rows in Postgres, ensuring decider features work out-of-the-box. 
* Added `[hypersense]` config section in `development.toml` for new cost observability integration.