### PR TITLE
fix(analytics): fix analytics and overview bugs

### DIFF
--- a/cypress/e2e/ui/analytics-page.cy.js
+++ b/cypress/e2e/ui/analytics-page.cy.js
@@ -78,7 +78,7 @@ describe('Analytics UI', () => {
       .parents('div.space-y-8')
       .first()
       .within(() => {
-        cy.contains('button', /^Auth-rate based$/).should('be.visible')
+        cy.contains('button', /^Multi-objective$/).should('be.visible')
         cy.contains('button', /^Rule based \/ Volume based$/).should('be.visible')
       })
 
@@ -95,7 +95,7 @@ describe('Analytics UI', () => {
     cy.wait('@overviewRefresh')
     cy.wait('@routingRefresh')
     // Wait for the view to settle and API data to load
-    cy.contains('button', /^Auth-rate based$/).should('have.class', 'bg-white')
+    cy.contains('button', /^Multi-objective$/).should('have.class', 'bg-white')
 
     // Wait for analytics data to load (looking for endpoint hit cards)
     cy.contains('Decide Gateway').should('be.visible')
@@ -107,8 +107,6 @@ describe('Analytics UI', () => {
       .within(() => {
         cy.contains('button', /^Rule based \/ Volume based$/).scrollIntoView().click({ force: true })
       })
-    cy.contains(
-      'Routing decisions from /routing/evaluate, kept separate from auth-rate transaction routing and gateway scoring.',
-    ).should('exist')
+    cy.contains('Latest decisions from').should('exist')
   })
 })

--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -71,7 +71,7 @@ type RoutingFilters = {
 
 type AnalyticsView = 'transactions' | 'rule_based'
 const ANALYTICS_VIEW_LABELS: Record<AnalyticsView, string> = {
-  transactions: 'Auth-rate based',
+  transactions: 'Multi-objective',
   rule_based: 'Rule based / Volume based',
 }
 
@@ -182,7 +182,7 @@ const CARD_INFO: Record<'hits' | 'share' | 'alignment' | 'sr' | 'preview_hits' |
   },
   preview_share: {
     title: 'Rule-based gateway selection mix',
-    purpose: 'Use this to see which connectors lead selected rule decisions, separate from auth-rate transaction decisions.',
+    purpose: 'Use this to see which connectors lead selected rule decisions, separate from multi-objective transaction decisions.',
     calculation: 'Returned decision traces are grouped by latest selected connector and displayed as share of selected rule decisions.',
     source: 'Reads rule decision activity through `/analytics/preview-trace`.',
   },
@@ -1843,7 +1843,7 @@ export function AnalyticsPage() {
                         {formatCurrencyValue(costSavings.data.totals.saved_value, costSavings.data.currency)}
                       </p>
                       <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                        {formatNumber(costSavings.data.totals.cost_won_count, 0)} of {formatNumber(costSavings.data.totals.total_decisions, 0)} decisions
+                        {formatNumber(costSavings.data.totals.cost_won_count, 0)} of {formatNumber(costSavings.data.totals.total_decisions, 0)} cost decisions
                       </p>
                     </>
                   ) : (

--- a/website/src/components/pages/OverviewPage.tsx
+++ b/website/src/components/pages/OverviewPage.tsx
@@ -22,6 +22,7 @@ import {
 import { Badge } from '../ui/Badge'
 import { Card as GlassCard, SurfaceLabel } from '../ui/Card'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
+import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
 
 const OVERVIEW_RANGE_OPTIONS: {
   value: AnalyticsRange
@@ -154,6 +155,7 @@ export function OverviewPage() {
     { shouldRetryOnError: false },
   )
   const debitRoutingFlag = useDebitRoutingFlag(effectiveMerchantId)
+  const merchantFeatures = useMerchantFeatures(effectiveMerchantId || undefined)
 
   const analyticsOverviewUrl = `/analytics/overview?range=${range}`
   const analyticsRoutingUrl = `/analytics/routing-stats?range=${range}`
@@ -217,11 +219,21 @@ export function OverviewPage() {
   const topGateway = gatewayUsage[0]?.gateway || analyticsOverview.data?.top_scores?.[0]?.gateway
   const selectedWindow =
     OVERVIEW_RANGE_OPTIONS.find((option) => option.value === range) || OVERVIEW_RANGE_OPTIONS[1]
-  const hasAuthRateConfig = Boolean(srConfig?.config?.data)
+  // Multi-objective is set up when either the merchant saved a manual successRate
+  // config on /routing/sr (a merchant-specific /rule/get response — the same
+  // condition that page uses) or turned on Autopilot mode there (the `autopilot`
+  // merchant feature flag). A global default config alone counts as neither.
+  const hasMultiObjectiveConfig = Boolean(
+    srConfig?.config?.type === 'successRate' &&
+      srConfig.config.data &&
+      srConfig.merchant_id === effectiveMerchantId,
+  )
+  const autopilotEnabled = merchantFeatures.isEnabled('autopilot')
+  const multiObjectiveReady = hasMultiObjectiveConfig || autopilotEnabled
   const hasDebitRouting = debitRoutingFlag.isEnabled
   const configuredBasics = [
     Boolean(activeRouting),
-    hasAuthRateConfig,
+    multiObjectiveReady,
     hasRuleBasedRouting,
     hasDebitRouting,
   ].filter(Boolean).length
@@ -236,9 +248,13 @@ export function OverviewPage() {
       href: '../routing',
     },
     {
-      label: 'Auth-rate config',
-      description: hasAuthRateConfig ? 'Configured' : 'Not configured',
-      state: hasAuthRateConfig ? 'Configured' : 'Not set',
+      label: 'Multi-objective config',
+      description: autopilotEnabled
+        ? 'Autopilot mode enabled'
+        : hasMultiObjectiveConfig
+          ? 'Configured'
+          : 'Not configured',
+      state: autopilotEnabled ? 'Auto-pilot' : hasMultiObjectiveConfig ? 'Configured' : 'Not set',
       icon: TrendingUp,
       required: true,
       href: '../routing/sr',
@@ -453,22 +469,26 @@ export function OverviewPage() {
               {/* Checklist */}
               <div className="mt-4 divide-y divide-slate-100 dark:divide-[#1e2535]">
                 {setupItems.map((item) => {
+                  const readyState =
+                    item.state === 'Live' ||
+                    item.state === 'Configured' ||
+                    item.state === 'Enabled' ||
+                    item.state === 'Auto-pilot'
                   const iconColor =
                     item.state === 'Issue'
                       ? 'text-red-500'
-                      : item.state === 'Live' || item.state === 'Configured' || item.state === 'Enabled'
+                      : readyState
                         ? 'text-emerald-500'
                         : 'text-slate-400 dark:text-[#5a6a82]'
-                  const badgeVariant =
-                    item.state === 'Live' || item.state === 'Configured' || item.state === 'Enabled'
-                      ? 'green'
-                      : item.state === 'Issue'
-                        ? 'red'
-                        : item.state === 'Checking'
-                          ? 'gray'
-                          : item.required
-                            ? 'orange'
-                            : 'gray'
+                  const badgeVariant = readyState
+                    ? 'green'
+                    : item.state === 'Issue'
+                      ? 'red'
+                      : item.state === 'Checking'
+                        ? 'gray'
+                        : item.required
+                          ? 'orange'
+                          : 'gray'
                   const inner = (
                     <>
                       <div className="flex items-center gap-3 min-w-0">

--- a/website/src/components/pages/PaymentAuditPage.tsx
+++ b/website/src/components/pages/PaymentAuditPage.tsx
@@ -46,7 +46,7 @@ type AuditFilters = {
 type InspectorTab = (typeof INSPECTOR_TABS)[number]
 type AuditMode = 'transactions' | 'rule_based' | 'debit_routing'
 const AUDIT_MODE_LABELS: Record<AuditMode, string> = {
-  transactions: 'Auth-rate based',
+  transactions: 'Multi-objective',
   rule_based: 'Rule based / Volume based',
   debit_routing: 'Debit routing',
 }
@@ -648,7 +648,7 @@ export function PaymentAuditPage() {
   const content = mode === 'rule_based'
     ? {
         title: 'Decision Audit',
-        description: 'Inspect rule decisions from /routing/evaluate without mixing them into auth-rate transaction outcomes.',
+        description: 'Inspect rule decisions from /routing/evaluate without mixing them into multi-objective transaction outcomes.',
         merchantPrompt: 'Audit data follows your signed-in merchant account.',
         searchTitle: 'Search Rule Decision Trail',
         searchDescription: 'Use decision payment IDs or request IDs when you have them. Gateway, status, and error code help narrow rule decision activity quickly.',

--- a/website/src/components/pages/RoutingHubPage.tsx
+++ b/website/src/components/pages/RoutingHubPage.tsx
@@ -20,9 +20,10 @@ import { useAuthStore } from '../../store/authStore'
 import { apiPost, fetcher } from '../../lib/api'
 import { AnalyticsOverviewResponse, RoutingAlgorithm, RuleConfig, SRConfigData } from '../../types/api'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
+import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
 
 type StrategyId = 'auth-rate' | 'rules' | 'volume' | 'debit' | 'ab-test'
-type StrategyState = 'configured' | 'enabled' | 'not_set'
+type StrategyState = 'configured' | 'enabled' | 'autopilot' | 'not_set'
 
 interface StrategyRow {
   id: StrategyId
@@ -36,7 +37,7 @@ interface StrategyRow {
 }
 
 const strategyLabels: Record<StrategyId, string> = {
-  'auth-rate': 'Auth-Rate Configuration',
+  'auth-rate': 'Multi-Objective Configuration',
   rules: 'Rule-Based Routing',
   volume: 'Volume Split Routing',
   debit: 'Debit Routing',
@@ -55,12 +56,19 @@ function isRuleBasedAlgorithmType(type: string) {
   return type === 'advanced' || type === 'priority' || type === 'single'
 }
 
+function strategyStateLabel(state: StrategyState) {
+  if (state === 'configured') return 'Configured'
+  if (state === 'autopilot') return 'Auto-pilot'
+  return 'Enabled'
+}
+
 export function RoutingHubPage() {
   const { mutate: mutateCache } = useSWRConfig()
   const selectedMerchantId = useMerchantStore((state) => state.merchantId)
   const authMerchantId = useAuthStore((state) => state.user?.merchantId || '')
   const merchantId = selectedMerchantId || authMerchantId
   const debitRoutingFlag = useDebitRoutingFlag(merchantId)
+  const merchantFeatures = useMerchantFeatures(merchantId || undefined)
   const [deactivatingStrategy, setDeactivatingStrategy] = useState<StrategyId | null>(null)
   const [pendingDeactivateStrategy, setPendingDeactivateStrategy] = useState<StrategyId | null>(null)
   const [actionMessage, setActionMessage] = useState<string | null>(null)
@@ -84,12 +92,15 @@ export function RoutingHubPage() {
 
   const activeAlgorithm = activeAlgorithms?.[0]
   const srData = ((srConfig as any)?.config?.data ?? srConfig?.data) as SRConfigData | undefined
-  const hasAuthRateConfig = Boolean(srData)
+  // Manual config saved on /routing/sr and Autopilot mode (the `autopilot` merchant
+  // feature flag toggled there) are both valid multi-objective setups.
+  const hasMultiObjectiveConfig = Boolean(srData)
+  const autopilotOn = merchantFeatures.isEnabled('autopilot')
   const hasRuleBasedRouting = (activeAlgorithms || []).some((a) => isRuleBasedAlgorithmType(algorithmType(a)))
   const hasVolumeSplit = (activeAlgorithms || []).some((a) => algorithmType(a) === 'volume_split')
   const hasDebitRouting = debitRoutingFlag.isEnabled
   const hasAbTest = (activeAlgorithms || []).some((a) => algorithmType(a) === 'ab_test')
-  const loading = activeLoading || srLoading || debitRoutingFlag.isLoading
+  const loading = activeLoading || srLoading || debitRoutingFlag.isLoading || merchantFeatures.isLoading
   const activeRuleAlgorithm = (activeAlgorithms || []).find((a) => isRuleBasedAlgorithmType(algorithmType(a)))
   const activeVolumeAlgorithm = (activeAlgorithms || []).find((a) => algorithmType(a) === 'volume_split')
 
@@ -105,8 +116,18 @@ export function RoutingHubPage() {
     setActionError(null)
     try {
       if (strategyId === 'auth-rate') {
-        await apiPost('/rule/delete', { merchant_id: merchantId, algorithm: 'successRate' })
-        await mutateSrConfig(undefined, { revalidate: false })
+        if (hasMultiObjectiveConfig) {
+          await apiPost('/rule/delete', { merchant_id: merchantId, algorithm: 'successRate' })
+          await mutateSrConfig(undefined, { revalidate: false })
+        }
+        if (autopilotOn) {
+          // Mirror the Autopilot master-off behaviour on /routing/sr: turning the
+          // master off also hard-disables its decision flags.
+          await merchantFeatures.setFeatureEnabled('autopilot', false)
+          await merchantFeatures.setFeatureEnabled('elimination', false)
+          await merchantFeatures.setFeatureEnabled('multi-objective-routing', false)
+          await merchantFeatures.setFeatureEnabled('auto-calibration', false)
+        }
       } else if (strategyId === 'rules' && activeRuleAlgorithm) {
         await apiPost('/routing/deactivate', { created_by: merchantId, routing_algorithm_id: activeRuleAlgorithm.id })
         await Promise.all([
@@ -137,12 +158,12 @@ export function RoutingHubPage() {
   const strategies: StrategyRow[] = [
     {
       id: 'auth-rate',
-      title: 'Auth-rate based',
+      title: 'Multi-objective',
       description: 'Steers traffic toward the best authorization rate using live connector score signals.',
       useCase: 'Use when you want automatic gateway selection driven by real-time success-rate data.',
       icon: TrendingUp,
-      state: hasAuthRateConfig ? 'configured' : 'not_set',
-      canDeactivate: hasAuthRateConfig,
+      state: hasMultiObjectiveConfig ? 'configured' : autopilotOn ? 'autopilot' : 'not_set',
+      canDeactivate: hasMultiObjectiveConfig || autopilotOn,
       href: 'sr',
     },
     {
@@ -249,8 +270,8 @@ export function RoutingHubPage() {
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
                         <p className="text-sm font-semibold text-slate-950 dark:text-white">{strategy.title}</p>
-                        {strategy.state === 'enabled' || strategy.state === 'configured'
-                          ? <Badge variant="green">{strategy.state === 'configured' ? 'Configured' : 'Enabled'}</Badge>
+                        {strategy.state !== 'not_set'
+                          ? <Badge variant="green">{strategyStateLabel(strategy.state)}</Badge>
                           : <Badge variant="gray">Not set</Badge>}
                       </div>
                       <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-[#8390a7]">
@@ -307,7 +328,7 @@ export function RoutingHubPage() {
                         </span>
                       </div>
                       <Badge variant="green">
-                        {s.state === 'configured' ? 'Configured' : 'Enabled'}
+                        {strategyStateLabel(s.state)}
                       </Badge>
                     </div>
                   )
@@ -365,11 +386,11 @@ export function RoutingHubPage() {
               )}
             </div>
 
-            {/* Auth-rate config */}
-            {hasAuthRateConfig && srData && (
+            {/* Multi-objective config */}
+            {hasMultiObjectiveConfig && srData && (
               <div className="border-t border-slate-100 pt-6 dark:border-[#1e2535]">
                 <div className="flex items-center justify-between gap-2">
-                  <SurfaceLabel>Auth-rate config</SurfaceLabel>
+                  <SurfaceLabel>Multi-objective config</SurfaceLabel>
                   <Badge variant="green">Configured</Badge>
                 </div>
                 <div className="mt-3 divide-y divide-slate-100 dark:divide-[#1e2535]">

--- a/website/src/components/pages/SRRoutingPage.tsx
+++ b/website/src/components/pages/SRRoutingPage.tsx
@@ -9,6 +9,7 @@ import { Button } from '../ui/Button'
 import { ErrorMessage } from '../ui/ErrorMessage'
 import { Spinner } from '../ui/Spinner'
 import { useMerchantStore } from '../../store/merchantStore'
+import { useAuthStore } from '../../store/authStore'
 import { apiPost, fetcher } from '../../lib/api'
 import { PAYMENT_METHOD_TYPES, PAYMENT_METHODS } from '../../lib/constants'
 import { Plus, Trash2, Eye, PowerOff, Info } from 'lucide-react'
@@ -222,7 +223,11 @@ function CurrentConfigDetails({ config }: { config: SRConfigResponse['config'] }
 type SRTab = 'autopilot' | 'manual' | 'flags'
 
 export function SRRoutingPage() {
-  const { merchantId } = useMerchantStore()
+  // Same merchant resolution as OverviewPage/RoutingHubPage — this page must
+  // never disagree with the Overview setup checklist about what is configured.
+  const selectedMerchantId = useMerchantStore((state) => state.merchantId)
+  const authMerchantId = useAuthStore((state) => state.user?.merchantId || '')
+  const merchantId = selectedMerchantId || authMerchantId
   const [activeTab, setActiveTab] = useState<SRTab>('autopilot')
   const [manualTab, setManualTab] = useState<'scoring' | 'elimination' | 'dimensions'>('scoring')
   const [saving, setSaving] = useState(false)
@@ -234,8 +239,10 @@ export function SRRoutingPage() {
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [lastSavedAt, setLastSavedAt] = useState<string | null>(null)
 
+  // Shares the SWR key used by OverviewPage/RoutingHubPage so all three surfaces
+  // read (and invalidate) the same cached config.
   const { data: existing, isLoading, mutate } = useSWR<SRConfigResponse>(
-    merchantId ? ['rule-sr', merchantId] : null,
+    merchantId ? ['/rule/get', 'successRate', merchantId] : null,
     () => apiPost('/rule/get', { merchant_id: merchantId, algorithm: 'successRate' }),
     { shouldRetryOnError: false, revalidateOnFocus: false }
   )


### PR DESCRIPTION
Bug fixed
Analytics and events bugs

1. analytics page to have multi -objective routing where ever we have auth-based
2. landing page currently shows 1/4 steps done when nothing is configure(auto pilot is off still it shows 1/4)
3. cost saving count should tell what type of decision 


<img width="1374" height="140" alt="image" src="https://github.com/user-attachments/assets/62e500cc-c3c8-4a18-8b68-248d82d7de1e" />

The reason number does not match with the decide gateway call is that it does not include hedging txn


This pull request updates the terminology and user interface across the analytics and routing pages to consistently use "Multi-objective" instead of "Auth-rate based" or "Auth-rate," and introduces clearer handling of the "Autopilot" feature flag for merchants. It also improves internal logic to ensure all relevant pages are synchronized in how they determine and display configuration states, especially for multi-objective routing. The changes affect both the Cypress UI tests and the main web application code.

**Terminology and UI consistency:**

- Replaced all instances of "Auth-rate based" or "Auth-rate" with "Multi-objective" in analytics, audit, and routing pages, including button labels, tab names, and descriptive text. [[1]](diffhunk://#diff-4835fac5bb63d7adadfc6cfb47cc1ced235a34cebd644c21df44e9773509e32cL74-R74) [[2]](diffhunk://#diff-2d7ac5264b34320cea0c47b69191d85087e1648f8516aa29185d0b3068231f3cL49-R49) [[3]](diffhunk://#diff-7ad49717dc01ea2a29d9398c30909de7ba0e94515ac58d8c7b98756928653afaL39-R40) [[4]](diffhunk://#diff-7ad49717dc01ea2a29d9398c30909de7ba0e94515ac58d8c7b98756928653afaL140-R166) [[5]](diffhunk://#diff-ecb6818807e7daa29104695d099d962a2dda1d1ad71e9ce82f3c5e7f32ba6669L81-R81) [[6]](diffhunk://#diff-ecb6818807e7daa29104695d099d962a2dda1d1ad71e9ce82f3c5e7f32ba6669L98-R98) [[7]](diffhunk://#diff-ecb6818807e7daa29104695d099d962a2dda1d1ad71e9ce82f3c5e7f32ba6669L110-R110)
- Updated purpose and description texts to reference "multi-objective" instead of "auth-rate" where appropriate, ensuring clarity for users. [[1]](diffhunk://#diff-4835fac5bb63d7adadfc6cfb47cc1ced235a34cebd644c21df44e9773509e32cL185-R185) [[2]](diffhunk://#diff-2d7ac5264b34320cea0c47b69191d85087e1648f8516aa29185d0b3068231f3cL651-R651)

**Feature flag and config logic improvements:**

- Added use of the `autopilot` merchant feature flag to determine if multi-objective routing is enabled, and updated logic to treat both manual config and Autopilot as valid setups. [[1]](diffhunk://#diff-bcda51886afd9ffb83fb2951830996b08ee68f19fbc382294493f7cacf703550L220-R236) [[2]](diffhunk://#diff-bcda51886afd9ffb83fb2951830996b08ee68f19fbc382294493f7cacf703550L239-R257) [[3]](diffhunk://#diff-7ad49717dc01ea2a29d9398c30909de7ba0e94515ac58d8c7b98756928653afaL87-R103) [[4]](diffhunk://#diff-7ad49717dc01ea2a29d9398c30909de7ba0e94515ac58d8c7b98756928653afaR119-R130)
- Ensured deactivating multi-objective routing disables both the manual config and all related Autopilot feature flags for the merchant.

**UI enhancements for state representation:**

- Introduced a new "Auto-pilot" state and improved badge/status logic for strategies and setup checklists to reflect the new state and terminology. [[1]](diffhunk://#diff-7ad49717dc01ea2a29d9398c30909de7ba0e94515ac58d8c7b98756928653afaR59-R71) [[2]](diffhunk://#diff-bcda51886afd9ffb83fb2951830996b08ee68f19fbc382294493f7cacf703550R472-R483) [[3]](diffhunk://#diff-7ad49717dc01ea2a29d9398c30909de7ba0e94515ac58d8c7b98756928653afaL252-R274) [[4]](diffhunk://#diff-7ad49717dc01ea2a29d9398c30909de7ba0e94515ac58d8c7b98756928653afaL310-R331)
- Updated checklist and config section labels to match the new terminology and state logic. [[1]](diffhunk://#diff-bcda51886afd9ffb83fb2951830996b08ee68f19fbc382294493f7cacf703550L239-R257) [[2]](diffhunk://#diff-7ad49717dc01ea2a29d9398c30909de7ba0e94515ac58d8c7b98756928653afaL368-R393)

**SWR/caching and merchant resolution alignment:**

- Standardized how merchant IDs are resolved across `OverviewPage`, `RoutingHubPage`, and `SRRoutingPage` to ensure all reference the same merchant and config state.
- Updated SWR keys and API calls so all three pages share the same cache and invalidate config consistently.

**Test coverage updates:**

- Adjusted Cypress UI tests to match the new button labels and text, ensuring tests remain valid after terminology changes. [[1]](diffhunk://#diff-ecb6818807e7daa29104695d099d962a2dda1d1ad71e9ce82f3c5e7f32ba6669L81-R81) [[2]](diffhunk://#diff-ecb6818807e7daa29104695d099d962a2dda1d1ad71e9ce82f3c5e7f32ba6669L98-R98) [[3]](diffhunk://#diff-ecb6818807e7daa29104695d099d962a2dda1d1ad71e9ce82f3c5e7f32ba6669L110-R110)


