### PR TITLE
feat: Add support for stripe cost data ingestion 

### DIFF
--- a/oneclick.sh
+++ b/oneclick.sh
@@ -61,6 +61,9 @@ EXPECTED_CLICKHOUSE_TABLES=(
     analytics_domain_events_queue
     analytics_api_events
     analytics_domain_events
+    cost_daily_stats
+    cost_fee_model
+    connector_markup_overlay
 )
 
 check_and_kill_ports() {
@@ -538,9 +541,24 @@ run_infra_checklist
 
 if ! check_clickhouse_schema; then
     echo ""
-    echo "ClickHouse is reachable but the analytics schema is incomplete."
-    echo "Run 'make reset-analytics-clickhouse' to recreate the ClickHouse analytics volume."
-    cleanup 1
+    echo "ClickHouse schema is incomplete — attempting to (re)create cost-ingestion tables..."
+    # The cost tables (cost_daily_stats / cost_fee_model / connector_markup_overlay) come from
+    # 035_cost_model.sh, which the container only auto-runs on a fresh clickhouse-data volume.
+    # All its DDL is IF NOT EXISTS, so re-running it against an existing DB is idempotent and
+    # non-destructive — this heals a pre-existing volume without wiping analytics data.
+    if docker compose exec -T clickhouse sh /docker-entrypoint-initdb.d/035_cost_model.sh >/dev/null 2>&1; then
+        echo "  Ran 035_cost_model.sh."
+    else
+        echo "  Could not run 035_cost_model.sh in the clickhouse container."
+    fi
+
+    if ! check_clickhouse_schema; then
+        echo ""
+        echo "ClickHouse schema is still incomplete after re-running the cost-model DDL."
+        echo "Run 'make reset-analytics-clickhouse' to recreate the ClickHouse analytics volume."
+        cleanup 1
+    fi
+    echo "ClickHouse schema is now complete."
 fi
 
 echo "Running Postgres migrations..."

--- a/src/cost_ingestion/connectors/mod.rs
+++ b/src/cost_ingestion/connectors/mod.rs
@@ -9,3 +9,4 @@ pub mod braintree;
 pub mod chase;
 pub mod checkout;
 pub mod csv_reader;
+pub mod stripe;

--- a/src/cost_ingestion/connectors/stripe.rs
+++ b/src/cost_ingestion/connectors/stripe.rs
@@ -1,0 +1,333 @@
+//! Stripe "Payments Fee Report" `SettlementReportSource`.
+//!
+//! Normalizes Stripe's monthly fee report onto the canonical [`SettledFeeRow`]. Everything
+//! Stripe-specific — the report's column labels and the aggregate row shape — is contained in this
+//! file; the queue, staging, fit, and serving never see anything Stripe-specific.
+//!
+//! # IMPORTANT: this report is *aggregated*, not per-transaction
+//!
+//! Unlike the Adyen and Braintree settlement reports (one row = one settled transaction, with a
+//! unique reference), the Stripe fee report is a **roll-up**: each row is a
+//! `(card brand, shopper interaction, regionality, funding source, payment-method variant, fee
+//! name, rate)` bucket carrying a `Count` (number of transactions), a `Gross Qty` (turnover the
+//! fee applied to), and a `Cost Qty` (fee charged for that one line). A single transaction's total
+//! cost is therefore spread across many `Fee Name` rows, and different fee lines within the same
+//! cluster cover different transaction subsets (their `Count`s differ).
+//!
+//! Consequences the caller must know about:
+//!   * There is no per-transaction id. `txn_ref` is a *synthetic* deterministic key built from the
+//!     row's identifying fields so a re-upload of the same month replaces (not duplicates) its
+//!     rows under the ReplacingMergeTree — it is NOT a real transaction reference.
+//!   * `gross`/`total_fee` here are aggregate turnover/fee for a bucket, not one transaction. The
+//!     per-transaction OLS in `fit.rs` (`total_fee = slope·gross + intercept`, `n ≥ 200`) assumes
+//!     transaction-level scatter; fed these aggregate lines it will not produce meaningful `GOOD`
+//!     clusters. Serving this connector needs an aggregate-fit path (compute `pct_bps` from
+//!     `Variable Fee` and `fixed` from `Fixed Fee`, both of which this report already carries) —
+//!     that lives outside this parser.
+//!
+//! Two report fields this parser cannot fill (the report simply does not carry them):
+//!   * `issuer_country` — the report only has `Regionality` (DOMESTIC / INTER_REGIONAL), which is
+//!     relative to the acquirer, not an ISO issuer country. Left empty.
+//!   * `ic_category` — `Fee Name` is the fee *type* (many per cluster), not the interchange
+//!     category. Left empty.
+//!
+//! Notification/download is NOT implemented — the intended path for this connector is the manual
+//! dashboard upload (which only calls `parse_rows`). The webhook/download methods return a
+//! descriptive error until Stripe's report-ready webhook and download auth are wired.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use axum::http::HeaderMap;
+use bytes::Bytes;
+use masking::Secret;
+
+use crate::cost_ingestion::source::SettlementReportSource;
+use crate::cost_ingestion::types::{ConnectorCreds, IngestError, ReportNotification, SettledFeeRow};
+
+/// `Refund Flag` value for forward (settled) fees. `Refund` rows are fee reversals whose amounts
+/// would pollute the gross→fee relationship, so they're skipped (mirrors Adyen's record-type
+/// filter and Braintree's sale-only filter).
+const SETTLE_FLAG: &str = "settle";
+
+#[allow(dead_code)] // used once download_report is implemented
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
+
+pub struct StripeReportSource;
+
+impl StripeReportSource {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for StripeReportSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(dead_code)] // used once download_report is implemented
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(DOWNLOAD_TIMEOUT)
+            .build()
+            .expect("failed to build stripe report reqwest client")
+    })
+}
+
+#[async_trait]
+impl SettlementReportSource for StripeReportSource {
+    fn connector(&self) -> &'static str {
+        "stripe"
+    }
+
+    fn peek_account(&self, _raw_body: &[u8]) -> Result<String, IngestError> {
+        // TODO(stripe-webhook): extract the connected-account id from the unverified event body
+        // once Stripe's report-ready webhook is wired. Manual upload passes the account explicitly.
+        Err(not_implemented("peek_account"))
+    }
+
+    fn verify_and_parse_notification(
+        &self,
+        _headers: &HeaderMap,
+        _raw_body: &[u8],
+        _secret: &Secret<String>,
+    ) -> Result<ReportNotification, IngestError> {
+        // TODO(stripe-webhook): verify the `Stripe-Signature` header (HMAC-SHA256 over
+        // `timestamp.payload`) and pull the report handle from the event.
+        Err(not_implemented("verify_and_parse_notification"))
+    }
+
+    async fn download_report(
+        &self,
+        _creds: &ConnectorCreds,
+        _note: &ReportNotification,
+    ) -> Result<Bytes, IngestError> {
+        // TODO(stripe-webhook): fetch the report file via the Files API using the merchant's key.
+        Err(not_implemented("download_report"))
+    }
+
+    fn parse_rows(
+        &self,
+        reader: Box<dyn std::io::Read + Send>,
+        on_row: &mut dyn FnMut(SettledFeeRow) -> Result<(), IngestError>,
+    ) -> Result<(), IngestError> {
+
+        let mut reader = csv::ReaderBuilder::new().flexible(true).from_reader(reader);
+
+        let headers = reader
+            .headers()
+            .map_err(|e| IngestError::Parse(e.to_string()))?
+            .clone();
+        let idx = |name: &str| headers.iter().position(|h| h == name);
+        let col = |name: &str| -> Result<usize, IngestError> {
+            idx(name).ok_or_else(|| IngestError::Parse(format!("missing column: {name}")))
+        };
+
+        let c_brand = col("Card Brand")?;
+        let c_interaction = col("Shopper Interaction")?;
+        let c_funding = col("Funding Source")?;
+        let c_variant = col("Payment Method Variant")?;
+        let c_gross = col("Gross Qty")?;
+        let c_cost = col("Cost Qty")?;
+        let c_refund_flag = col("Refund Flag")?;
+        // Currency: prefer the gross-side currency, fall back to the cost-side.
+        let c_gross_ccy = col("Gross Ccy")?;
+        let c_cost_ccy = idx("Cost Ccy");
+        // Optional — used only for the ingested report's period, and to make `txn_ref` unique.
+        let c_month = idx("Month");
+        // Optional — carried into the synthetic key so different fee lines/rates in the same
+        // cluster don't collapse onto one another under the ReplacingMergeTree dedup.
+        let c_fee_name = idx("Fee Name");
+        let c_variable_fee = idx("Variable Fee");
+        let c_fixed_fee = idx("Fixed Fee");
+
+        for record in reader.records() {
+            let record = record.map_err(|e| IngestError::Parse(e.to_string()))?;
+            let get = |i: usize| record.get(i).unwrap_or("");
+            let get_opt = |i: Option<usize>| i.map(get).unwrap_or("");
+
+            // Keep only forward (settled) fees; skip refund/reversal lines.
+            if get(c_refund_flag).trim().to_lowercase() != SETTLE_FLAG {
+                continue;
+            }
+
+            let gross = to_float(get(c_gross));
+            let total_fee = to_float(get(c_cost));
+
+            let card_network = normalize_network(get(c_brand));
+            let variant = get(c_variant).trim().to_lowercase();
+            let funding = funding_from_source(get(c_funding));
+            let currency = {
+                let g = get(c_gross_ccy).trim();
+                if g.is_empty() { get_opt(c_cost_ccy).trim() } else { g }.to_string()
+            };
+            let channel = channel_from_interaction(get(c_interaction));
+            let month = get_opt(c_month).trim();
+            let txn_date = parse_month(month);
+
+            on_row(SettledFeeRow {
+                // Synthetic, deterministic key (see module docs): identifies this aggregate line so
+                // a same-month re-upload replaces rather than duplicates. NOT a real txn reference.
+                txn_ref: synth_ref(&[
+                    &variant,
+                    get(c_interaction).trim(),
+                    get(c_funding).trim(),
+                    get_opt(c_fee_name).trim(),
+                    get_opt(c_variable_fee).trim(),
+                    get_opt(c_fixed_fee).trim(),
+                    &currency,
+                    month,
+                ]),
+                card_network,
+                variant,
+                funding,
+                issuer_country: String::new(),
+                currency,
+                ic_category: String::new(),
+                txn_date,
+                channel,
+                gross,
+                total_fee,
+                // Stripe decomposes fee lines as fixed vs. variable (see `Fixed Fee` / `Variable
+                // Fee`), not interchange/scheme/markup/commission, so the four split fields stay 0.
+                // The fit only reads `gross` and `total_fee`, so this does not affect estimation.
+                interchange: 0.0,
+                scheme_fee: 0.0,
+                markup: 0.0,
+                commission: 0.0,
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// Placeholder error for the not-yet-wired notification/download path.
+fn not_implemented(method: &str) -> IngestError {
+    IngestError::MalformedNotification(format!(
+        "stripe connector: {method} not yet implemented (webhook/download shape TBD)"
+    ))
+}
+
+/// Build a deterministic key from a row's identifying parts, joined with a delimiter unlikely to
+/// appear in the values. Stable across re-uploads ⇒ idempotent staging via the ReplacingMergeTree.
+fn synth_ref(parts: &[&str]) -> String {
+    format!("stripe|{}", parts.join("\u{1f}"))
+}
+
+/// Map Stripe's `Funding Source` (`DEBIT` / `CREDIT` / `PREPAID` / blank) onto the canonical
+fn funding_from_source(source: &str) -> String {
+    match source.trim().to_lowercase().as_str() {
+        "debit" => "debit".to_string(),
+        "credit" => "credit".to_string(),
+        "prepaid" => "prepaid".to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Canonicalize a Stripe card-brand label to the lowercased network ids the rest of the pipeline
+fn normalize_network(raw: &str) -> String {
+    match raw.trim().to_lowercase().as_str() {
+        "" => String::new(),
+        "mastercard" | "master card" => "mc".to_string(),
+        "visa" => "visa".to_string(),
+        "american express" | "amex" => "amex".to_string(),
+        "discover" => "discover".to_string(),
+        "diners" | "diners club" => "diners".to_string(),
+        "jcb" => "jcb".to_string(),
+        other => other.replace(' ', ""),
+    }
+}
+
+/// Derive the acceptance channel from Stripe's `Shopper Interaction`. Card-present / POS maps to
+/// `pos`; everything else (`Ecommerce`, `ContAuth`, MOTO, …) is treated as online `ecom`.
+fn channel_from_interaction(interaction: &str) -> String {
+    let i = interaction.trim().to_lowercase();
+    if i.contains("pos") || i.contains("cardpresent") || i.contains("card present") {
+        "pos".to_string()
+    } else {
+        "ecom".to_string()
+    }
+}
+
+/// Parse Stripe's `Month` (`"2025/01"`) to the first day of that month — used only for the
+/// ingested report's period. Blank/odd values yield `None`.
+fn parse_month(s: &str) -> Option<chrono::NaiveDate> {
+    let s = s.trim();
+    let (year, month) = s.split_once('/')?;
+    let year: i32 = year.trim().parse().ok()?;
+    let month: u32 = month.trim().parse().ok()?;
+    chrono::NaiveDate::from_ymd_opt(year, month, 1)
+}
+
+/// Parse a money cell; blanks/garbage become `0.0` (mirrors the Adyen/Braintree parsers).
+fn to_float(s: &str) -> f64 {
+    s.trim().parse::<f64>().unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_settled_lines_and_skips_refunds() {
+        // Header order intentionally not the code's order — indices resolve by label.
+        let csv = "\
+Company,Merchant,Card Brand,Shopper Interaction,Regionality,Funding Source,Payment Method Variant,Fee Name,Fee,Count,Gross Ccy,Gross Qty,Cost Ccy,Cost Qty,Month,Lookup String,Refund Flag,Fixed Fee Ccy,Fixed Fee,Fixed Fee in USD,Variable Fee,USD Amount,USD Fee,Fixed Amount,Variable Amount\n\
+Merchant-A,Merchant-A-Stripe-US,mc,Ecommerce,DOMESTIC,DEBIT,maestro,Clearing Sender Connectivity Fee,1.65% + USD 0.1500,23155,USD,453160.54,USD,10950.39891,2025/01,GGH-ADYEN-USmcUSD,Settle,USD,0.15,0.15,0.0165,453160.54,10950.39891,3473.25,7477.14891\n\
+Merchant-A,Merchant-A-Stripe-US,mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,Clearing Sender Connectivity Fee,2.16%,9,USD,497828.26,USD,10753.09042,2025/01,GGH-ADYEN-USmcUSD,Refund,,0.0,0.0,0.0216,497828.26,10753.09042,0.0,10753.09042\n";
+        let rows = StripeReportSource::new().parse_report(csv.as_bytes()).unwrap();
+        assert_eq!(rows.len(), 1, "only the Settle row is kept");
+        let r = &rows[0];
+        assert_eq!(r.card_network, "mc");
+        assert_eq!(r.variant, "maestro");
+        assert_eq!(r.funding, "debit");
+        assert_eq!(r.currency, "USD");
+        assert_eq!(r.channel, "ecom");
+        assert_eq!(r.issuer_country, "", "not present in the Stripe report");
+        assert_eq!(r.ic_category, "", "Fee Name is not the interchange category");
+        assert!((r.gross - 453160.54).abs() < 1e-6, "Gross Qty");
+        assert!((r.total_fee - 10950.39891).abs() < 1e-6, "Cost Qty");
+        assert_eq!(r.txn_date, chrono::NaiveDate::from_ymd_opt(2025, 1, 1));
+        assert!(r.txn_ref.starts_with("stripe|"), "synthetic key");
+    }
+
+    #[test]
+    fn synthetic_ref_is_stable_and_distinguishes_fee_lines() {
+        // Same cluster, two different fee lines ⇒ two distinct keys (so neither dedups the other).
+        let csv = "\
+Card Brand,Shopper Interaction,Regionality,Funding Source,Payment Method Variant,Fee Name,Gross Qty,Cost Qty,Gross Ccy,Cost Ccy,Month,Refund Flag,Fixed Fee,Variable Fee\n\
+mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,Interchange,100000,2100,USD,USD,2025/01,Settle,0.10,0.019\n\
+mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,Scheme Fee,100000,150,USD,USD,2025/01,Settle,0.00,0.0015\n";
+        let rows = StripeReportSource::new().parse_report(csv.as_bytes()).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_ne!(rows[0].txn_ref, rows[1].txn_ref, "distinct fee lines keep distinct keys");
+    }
+
+    #[test]
+    fn missing_required_column_errors() {
+        let csv = "Card Brand,Shopper Interaction\nmc,Ecommerce\n";
+        let err = StripeReportSource::new().parse_report(csv.as_bytes()).unwrap_err();
+        assert!(matches!(err, IngestError::Parse(_)));
+    }
+
+    #[test]
+    fn helpers() {
+        assert_eq!(funding_from_source("DEBIT"), "debit");
+        assert_eq!(funding_from_source("CREDIT"), "credit");
+        assert_eq!(funding_from_source("PREPAID"), "prepaid");
+        assert_eq!(funding_from_source(""), "");
+        assert_eq!(normalize_network("mc"), "mc");
+        assert_eq!(normalize_network("MasterCard"), "mc");
+        assert_eq!(normalize_network("Visa"), "visa");
+        assert_eq!(channel_from_interaction("Ecommerce"), "ecom");
+        assert_eq!(channel_from_interaction("ContAuth"), "ecom");
+        assert_eq!(channel_from_interaction("CardPresent"), "pos");
+        assert_eq!(parse_month("2025/01"), chrono::NaiveDate::from_ymd_opt(2025, 1, 1));
+        assert_eq!(parse_month(""), None);
+    }
+}

--- a/src/cost_ingestion/connectors/stripe.rs
+++ b/src/cost_ingestion/connectors/stripe.rs
@@ -15,9 +15,12 @@
 //! cluster cover different transaction subsets (their `Count`s differ).
 //!
 //! Consequences the caller must know about:
-//!   * There is no per-transaction id. `txn_ref` is a *synthetic* deterministic key built from the
-//!     row's identifying fields so a re-upload of the same month replaces (not duplicates) its
-//!     rows under the ReplacingMergeTree — it is NOT a real transaction reference.
+//!   * There is no per-transaction id. `txn_ref` is a *synthetic* best-effort key built from the
+//!     row's identifying fields — provenance only. Nothing downstream reads it: the rollup
+//!     (`rollup.rs`) sums each row into a `(cluster, day, band, channel)` bucket keyed by the real
+//!     fields, and ClickHouse `cost_daily_stats` de-dups per bucket by `ingested_at` ("latest
+//!     report per day wins"), never by `txn_ref`. It is NOT a real transaction reference, and NOT
+//!     a dedup key — so which fields go into it does not affect aggregation.
 //!   * `gross`/`total_fee` here are aggregate turnover/fee for a bucket, not one transaction. The
 //!     per-transaction OLS in `fit.rs` (`total_fee = slope·gross + intercept`, `n ≥ 200`) assumes
 //!     transaction-level scatter; fed these aggregate lines it will not produce meaningful `GOOD`
@@ -44,7 +47,9 @@ use bytes::Bytes;
 use masking::Secret;
 
 use crate::cost_ingestion::source::SettlementReportSource;
-use crate::cost_ingestion::types::{ConnectorCreds, IngestError, ReportNotification, SettledFeeRow};
+use crate::cost_ingestion::types::{
+    ConnectorCreds, IngestError, ReportNotification, SettledFeeRow,
+};
 
 /// `Refund Flag` value for forward (settled) fees. `Refund` rows are fee reversals whose amounts
 /// would pollute the gross→fee relationship, so they're skipped (mirrors Adyen's record-type
@@ -116,7 +121,6 @@ impl SettlementReportSource for StripeReportSource {
         reader: Box<dyn std::io::Read + Send>,
         on_row: &mut dyn FnMut(SettledFeeRow) -> Result<(), IngestError>,
     ) -> Result<(), IngestError> {
-
         let mut reader = csv::ReaderBuilder::new().flexible(true).from_reader(reader);
 
         let headers = reader
@@ -138,10 +142,10 @@ impl SettlementReportSource for StripeReportSource {
         // Currency: prefer the gross-side currency, fall back to the cost-side.
         let c_gross_ccy = col("Gross Ccy")?;
         let c_cost_ccy = idx("Cost Ccy");
-        // Optional — used only for the ingested report's period, and to make `txn_ref` unique.
+        // Optional — used for the ingested report's period, and folded into the synthetic `txn_ref`.
         let c_month = idx("Month");
-        // Optional — carried into the synthetic key so different fee lines/rates in the same
-        // cluster don't collapse onto one another under the ReplacingMergeTree dedup.
+        // Optional — folded into the synthetic `txn_ref` so distinct fee lines/rates get distinct
+        // keys. Provenance only; `txn_ref` is not a dedup key (see module docs).
         let c_fee_name = idx("Fee Name");
         let c_variable_fee = idx("Variable Fee");
         let c_fixed_fee = idx("Fixed Fee");
@@ -164,15 +168,20 @@ impl SettlementReportSource for StripeReportSource {
             let funding = funding_from_source(get(c_funding));
             let currency = {
                 let g = get(c_gross_ccy).trim();
-                if g.is_empty() { get_opt(c_cost_ccy).trim() } else { g }.to_string()
+                if g.is_empty() {
+                    get_opt(c_cost_ccy).trim()
+                } else {
+                    g
+                }
+                .to_string()
             };
             let channel = channel_from_interaction(get(c_interaction));
             let month = get_opt(c_month).trim();
             let txn_date = parse_month(month);
 
             on_row(SettledFeeRow {
-                // Synthetic, deterministic key (see module docs): identifies this aggregate line so
-                // a same-month re-upload replaces rather than duplicates. NOT a real txn reference.
+                // Synthetic best-effort key (see module docs). Provenance only — not a real txn
+                // reference and not a dedup key; the rollup aggregates by the cluster fields below.
                 txn_ref: synth_ref(&[
                     &variant,
                     get(c_interaction).trim(),
@@ -214,7 +223,7 @@ fn not_implemented(method: &str) -> IngestError {
 }
 
 /// Build a deterministic key from a row's identifying parts, joined with a delimiter unlikely to
-/// appear in the values. Stable across re-uploads ⇒ idempotent staging via the ReplacingMergeTree.
+/// appear in the values.
 fn synth_ref(parts: &[&str]) -> String {
     format!("stripe|{}", parts.join("\u{1f}"))
 }
@@ -280,7 +289,9 @@ mod tests {
 Company,Merchant,Card Brand,Shopper Interaction,Regionality,Funding Source,Payment Method Variant,Fee Name,Fee,Count,Gross Ccy,Gross Qty,Cost Ccy,Cost Qty,Month,Lookup String,Refund Flag,Fixed Fee Ccy,Fixed Fee,Fixed Fee in USD,Variable Fee,USD Amount,USD Fee,Fixed Amount,Variable Amount\n\
 Merchant-A,Merchant-A-Stripe-US,mc,Ecommerce,DOMESTIC,DEBIT,maestro,Clearing Sender Connectivity Fee,1.65% + USD 0.1500,23155,USD,453160.54,USD,10950.39891,2025/01,GGH-ADYEN-USmcUSD,Settle,USD,0.15,0.15,0.0165,453160.54,10950.39891,3473.25,7477.14891\n\
 Merchant-A,Merchant-A-Stripe-US,mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,Clearing Sender Connectivity Fee,2.16%,9,USD,497828.26,USD,10753.09042,2025/01,GGH-ADYEN-USmcUSD,Refund,,0.0,0.0,0.0216,497828.26,10753.09042,0.0,10753.09042\n";
-        let rows = StripeReportSource::new().parse_report(csv.as_bytes()).unwrap();
+        let rows = StripeReportSource::new()
+            .parse_report(csv.as_bytes())
+            .unwrap();
         assert_eq!(rows.len(), 1, "only the Settle row is kept");
         let r = &rows[0];
         assert_eq!(r.card_network, "mc");
@@ -289,7 +300,10 @@ Merchant-A,Merchant-A-Stripe-US,mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,
         assert_eq!(r.currency, "USD");
         assert_eq!(r.channel, "ecom");
         assert_eq!(r.issuer_country, "", "not present in the Stripe report");
-        assert_eq!(r.ic_category, "", "Fee Name is not the interchange category");
+        assert_eq!(
+            r.ic_category, "",
+            "Fee Name is not the interchange category"
+        );
         assert!((r.gross - 453160.54).abs() < 1e-6, "Gross Qty");
         assert!((r.total_fee - 10950.39891).abs() < 1e-6, "Cost Qty");
         assert_eq!(r.txn_date, chrono::NaiveDate::from_ymd_opt(2025, 1, 1));
@@ -298,20 +312,28 @@ Merchant-A,Merchant-A-Stripe-US,mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,
 
     #[test]
     fn synthetic_ref_is_stable_and_distinguishes_fee_lines() {
-        // Same cluster, two different fee lines ⇒ two distinct keys (so neither dedups the other).
+        // Same cluster, two different fee lines ⇒ two distinct synthetic keys (a property of
+        // synth_ref itself; txn_ref is provenance only and not used for dedup).
         let csv = "\
 Card Brand,Shopper Interaction,Regionality,Funding Source,Payment Method Variant,Fee Name,Gross Qty,Cost Qty,Gross Ccy,Cost Ccy,Month,Refund Flag,Fixed Fee,Variable Fee\n\
 mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,Interchange,100000,2100,USD,USD,2025/01,Settle,0.10,0.019\n\
 mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,Scheme Fee,100000,150,USD,USD,2025/01,Settle,0.00,0.0015\n";
-        let rows = StripeReportSource::new().parse_report(csv.as_bytes()).unwrap();
+        let rows = StripeReportSource::new()
+            .parse_report(csv.as_bytes())
+            .unwrap();
         assert_eq!(rows.len(), 2);
-        assert_ne!(rows[0].txn_ref, rows[1].txn_ref, "distinct fee lines keep distinct keys");
+        assert_ne!(
+            rows[0].txn_ref, rows[1].txn_ref,
+            "distinct fee lines keep distinct keys"
+        );
     }
 
     #[test]
     fn missing_required_column_errors() {
         let csv = "Card Brand,Shopper Interaction\nmc,Ecommerce\n";
-        let err = StripeReportSource::new().parse_report(csv.as_bytes()).unwrap_err();
+        let err = StripeReportSource::new()
+            .parse_report(csv.as_bytes())
+            .unwrap_err();
         assert!(matches!(err, IngestError::Parse(_)));
     }
 
@@ -327,7 +349,10 @@ mc,Ecommerce,DOMESTIC,CREDIT,mccommercialcredit,Scheme Fee,100000,150,USD,USD,20
         assert_eq!(channel_from_interaction("Ecommerce"), "ecom");
         assert_eq!(channel_from_interaction("ContAuth"), "ecom");
         assert_eq!(channel_from_interaction("CardPresent"), "pos");
-        assert_eq!(parse_month("2025/01"), chrono::NaiveDate::from_ymd_opt(2025, 1, 1));
+        assert_eq!(
+            parse_month("2025/01"),
+            chrono::NaiveDate::from_ymd_opt(2025, 1, 1)
+        );
         assert_eq!(parse_month(""), None);
     }
 }

--- a/src/cost_ingestion/source.rs
+++ b/src/cost_ingestion/source.rs
@@ -17,6 +17,7 @@ use super::connectors::adyen::AdyenReportSource;
 use super::connectors::braintree::BraintreeReportSource;
 use super::connectors::chase::ChaseReportSource;
 use super::connectors::checkout::CheckoutReportSource;
+use super::connectors::stripe::StripeReportSource;
 use super::types::{ConnectorCreds, IngestError, ReadyReport, ReportNotification, SettledFeeRow};
 
 /// Everything connector-specific lives behind this trait. All methods are pure functions of
@@ -135,6 +136,7 @@ impl ConnectorRegistry {
         Self::register(&mut sources, Arc::new(BraintreeReportSource::new()));
         Self::register(&mut sources, Arc::new(ChaseReportSource::new()));
         Self::register(&mut sources, Arc::new(CheckoutReportSource::new()));
+        Self::register(&mut sources, Arc::new(StripeReportSource::new()));
         Self { sources }
     }
 

--- a/src/cost_ingestion/types.rs
+++ b/src/cost_ingestion/types.rs
@@ -13,7 +13,10 @@ use masking::Secret;
 /// stamped by the worker from the queue row, so the parser stays reusable and testable.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SettledFeeRow {
-    /// Connector's unique transaction id (e.g. Adyen `Psp Reference`) — the staging dedup key.
+    /// Connector's per-transaction id when the report carries one (e.g. Adyen `Psp Reference`),
+    /// else a synthetic best-effort key (Stripe's aggregated report). Provenance only: the rollup
+    /// aggregates by the cluster fields below (read straight off this struct) and nothing
+    /// downstream reads `txn_ref`, so it is NOT a dedup key.
     pub txn_ref: String,
     /// Card network, lowercased: `visa`, `mc`, …
     pub card_network: String,

--- a/website/src/components/pages/CostRoutingShared.tsx
+++ b/website/src/components/pages/CostRoutingShared.tsx
@@ -8,6 +8,7 @@ export const UPLOAD_CONNECTORS = [
   { value: 'braintree', label: 'Braintree' },
   { value: 'chase', label: 'Chase' },
   { value: 'checkout', label: 'Checkout' },
+  { value: 'stripe', label: 'Stripe' },
 ] as const
 
 /** Shared input styling for the cost-routing forms (credentials + manual upload). */

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -162,6 +162,8 @@ interface SimulationResult {
   costSavedBps?: number | null
   costWon?: boolean
   authWon?: boolean
+  // Cost source that priced the chosen gateway (IN_HOUSE | SEED | HYPERSENSE); null when no cost data.
+  costSource?: string | null
   // Captured on cost-override decisions so the run can value the auth-rate the
   // override risked: (headAuthRate − chosenAuthRate) × amount × margin.
   headAuthRate?: number | null
@@ -2054,6 +2056,7 @@ export function DecisionSimulatorPage() {
         costSavedBps: mo?.costSavedBps ?? null,
         costWon: mo?.outcome === 'COST_WON',
         authWon: mo?.outcome === 'AUTH_WON',
+        costSource: mo?.chosen?.costSource ?? null,
         headAuthRate: mo?.srHead?.authRate ?? null,
         chosenAuthRate: mo?.chosen?.authRate ?? null,
         margin: mo?.margin ?? null,
@@ -2503,6 +2506,7 @@ export function DecisionSimulatorPage() {
     const outcomes = new Set<string>()
     const retryGateways = new Set<string>()
     const retryOutcomes = new Set<string>()
+    const costSources = new Set<string>()
     for (const res of deferredSimulationResults) {
       gateways.add(res.decidedGateway)
       if (res.cardNetwork) networks.add(res.cardNetwork)
@@ -2511,6 +2515,7 @@ export function DecisionSimulatorPage() {
       if (res.status) outcomes.add(res.status)
       if (res.retryGateway) retryGateways.add(res.retryGateway)
       if (res.retryStatus) retryOutcomes.add(res.retryStatus)
+      if (res.costSource) costSources.add(res.costSource)
     }
     const sorted = (s: Set<string>) => Array.from(s).sort()
     return {
@@ -2521,6 +2526,7 @@ export function DecisionSimulatorPage() {
       outcomes: sorted(outcomes),
       retryGateways: sorted(retryGateways),
       retryOutcomes: sorted(retryOutcomes),
+      costSources: sorted(costSources),
     }
   }, [deferredSimulationResults])
 
@@ -2543,6 +2549,7 @@ export function DecisionSimulatorPage() {
       if (f.outcome && res.status !== f.outcome) return false
       if (f.retryGateway && (res.retryGateway ?? '') !== f.retryGateway) return false
       if (f.retryOutcome && (res.retryStatus ?? '') !== f.retryOutcome) return false
+      if (f.costSource && (res.costSource ?? '') !== f.costSource) return false
       if (f.amount && !formatCurrencyValue(res.amount, res.currency).toLowerCase().includes(f.amount.toLowerCase())) return false
       if (f.sr && !srText(res).includes(f.sr)) return false
       if (f.evGap && !(res.evGapTop2 != null ? (res.evGapTop2 * 100).toFixed(2) : '').includes(f.evGap)) return false
@@ -4864,6 +4871,7 @@ export function DecisionSimulatorPage() {
                       <th className="text-left px-3 py-2">Routing</th>
                       <th className="text-left px-3 py-2">Outcome</th>
                       <th className="text-right px-3 py-2 whitespace-nowrap">Cost Savings</th>
+                      <th className="text-left px-3 py-2 whitespace-nowrap">Cost Source</th>
                       {smartRetryEnabled && <th className="text-left px-3 py-2 whitespace-nowrap">Retry Gateway</th>}
                       {smartRetryEnabled && <th className="text-left px-3 py-2">Retry Outcome</th>}
                     </tr>
@@ -4900,6 +4908,7 @@ export function DecisionSimulatorPage() {
                               <option value="no">None</option>
                             </select>
                           </th>
+                          <th className="px-2 py-1.5">{sel('costSource', txFilterOptions.costSources, 'All')}</th>
                           {smartRetryEnabled && <th className="px-2 py-1.5">{sel('retryGateway', txFilterOptions.retryGateways, 'All')}</th>}
                           {smartRetryEnabled && <th className="px-2 py-1.5">{sel('retryOutcome', txFilterOptions.retryOutcomes, 'All')}</th>}
                         </tr>
@@ -4964,6 +4973,15 @@ export function DecisionSimulatorPage() {
                             </span>
                           ) : null}
                         </td>
+                        <td className="px-3 py-2 whitespace-nowrap">
+                          {res.costSource ? (
+                            <span className={`text-xs font-medium ${res.costSource === 'IN_HOUSE' ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-500 dark:text-slate-400'}`}>
+                              {res.costSource}
+                            </span>
+                          ) : (
+                            <span className="text-[11px] text-slate-400">—</span>
+                          )}
+                        </td>
                         {smartRetryEnabled && (
                           <td className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
                             {res.retryGateway ?? '—'}
@@ -4982,7 +5000,7 @@ export function DecisionSimulatorPage() {
                     ))}
                     {txFilteredRows.length === 0 && (
                       <tr>
-                        <td colSpan={smartRetryEnabled ? 12 : 10} className="px-3 py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+                        <td colSpan={smartRetryEnabled ? 13 : 11} className="px-3 py-8 text-center text-sm text-slate-400 dark:text-slate-500">
                           No transactions match the current filters.
                         </td>
                       </tr>
@@ -5003,6 +5021,7 @@ export function DecisionSimulatorPage() {
                         <td className="px-3 py-2" />
                         <td className="px-3 py-2" />
                         <td className="px-3 py-2 text-right whitespace-nowrap tabular-nums text-emerald-700 dark:text-emerald-400">{formatCurrencyValue(txColumnTotals.savings, txColumnTotals.currency)}</td>
+                        <td className="px-3 py-2" />
                         {smartRetryEnabled && <td className="px-3 py-2" />}
                         {smartRetryEnabled && <td className="px-3 py-2" />}
                       </tr>

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -162,8 +162,6 @@ interface SimulationResult {
   costSavedBps?: number | null
   costWon?: boolean
   authWon?: boolean
-  // Cost source that priced the chosen gateway (IN_HOUSE | SEED | HYPERSENSE); null when no cost data.
-  costSource?: string | null
   // Captured on cost-override decisions so the run can value the auth-rate the
   // override risked: (headAuthRate − chosenAuthRate) × amount × margin.
   headAuthRate?: number | null
@@ -2056,7 +2054,6 @@ export function DecisionSimulatorPage() {
         costSavedBps: mo?.costSavedBps ?? null,
         costWon: mo?.outcome === 'COST_WON',
         authWon: mo?.outcome === 'AUTH_WON',
-        costSource: mo?.chosen?.costSource ?? null,
         headAuthRate: mo?.srHead?.authRate ?? null,
         chosenAuthRate: mo?.chosen?.authRate ?? null,
         margin: mo?.margin ?? null,
@@ -2506,7 +2503,6 @@ export function DecisionSimulatorPage() {
     const outcomes = new Set<string>()
     const retryGateways = new Set<string>()
     const retryOutcomes = new Set<string>()
-    const costSources = new Set<string>()
     for (const res of deferredSimulationResults) {
       gateways.add(res.decidedGateway)
       if (res.cardNetwork) networks.add(res.cardNetwork)
@@ -2515,7 +2511,6 @@ export function DecisionSimulatorPage() {
       if (res.status) outcomes.add(res.status)
       if (res.retryGateway) retryGateways.add(res.retryGateway)
       if (res.retryStatus) retryOutcomes.add(res.retryStatus)
-      if (res.costSource) costSources.add(res.costSource)
     }
     const sorted = (s: Set<string>) => Array.from(s).sort()
     return {
@@ -2526,7 +2521,6 @@ export function DecisionSimulatorPage() {
       outcomes: sorted(outcomes),
       retryGateways: sorted(retryGateways),
       retryOutcomes: sorted(retryOutcomes),
-      costSources: sorted(costSources),
     }
   }, [deferredSimulationResults])
 
@@ -2549,7 +2543,6 @@ export function DecisionSimulatorPage() {
       if (f.outcome && res.status !== f.outcome) return false
       if (f.retryGateway && (res.retryGateway ?? '') !== f.retryGateway) return false
       if (f.retryOutcome && (res.retryStatus ?? '') !== f.retryOutcome) return false
-      if (f.costSource && (res.costSource ?? '') !== f.costSource) return false
       if (f.amount && !formatCurrencyValue(res.amount, res.currency).toLowerCase().includes(f.amount.toLowerCase())) return false
       if (f.sr && !srText(res).includes(f.sr)) return false
       if (f.evGap && !(res.evGapTop2 != null ? (res.evGapTop2 * 100).toFixed(2) : '').includes(f.evGap)) return false
@@ -4871,7 +4864,6 @@ export function DecisionSimulatorPage() {
                       <th className="text-left px-3 py-2">Routing</th>
                       <th className="text-left px-3 py-2">Outcome</th>
                       <th className="text-right px-3 py-2 whitespace-nowrap">Cost Savings</th>
-                      <th className="text-left px-3 py-2 whitespace-nowrap">Cost Source</th>
                       {smartRetryEnabled && <th className="text-left px-3 py-2 whitespace-nowrap">Retry Gateway</th>}
                       {smartRetryEnabled && <th className="text-left px-3 py-2">Retry Outcome</th>}
                     </tr>
@@ -4908,7 +4900,6 @@ export function DecisionSimulatorPage() {
                               <option value="no">None</option>
                             </select>
                           </th>
-                          <th className="px-2 py-1.5">{sel('costSource', txFilterOptions.costSources, 'All')}</th>
                           {smartRetryEnabled && <th className="px-2 py-1.5">{sel('retryGateway', txFilterOptions.retryGateways, 'All')}</th>}
                           {smartRetryEnabled && <th className="px-2 py-1.5">{sel('retryOutcome', txFilterOptions.retryOutcomes, 'All')}</th>}
                         </tr>
@@ -4973,15 +4964,6 @@ export function DecisionSimulatorPage() {
                             </span>
                           ) : null}
                         </td>
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          {res.costSource ? (
-                            <span className={`text-xs font-medium ${res.costSource === 'IN_HOUSE' ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-500 dark:text-slate-400'}`}>
-                              {res.costSource}
-                            </span>
-                          ) : (
-                            <span className="text-[11px] text-slate-400">—</span>
-                          )}
-                        </td>
                         {smartRetryEnabled && (
                           <td className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
                             {res.retryGateway ?? '—'}
@@ -5000,7 +4982,7 @@ export function DecisionSimulatorPage() {
                     ))}
                     {txFilteredRows.length === 0 && (
                       <tr>
-                        <td colSpan={smartRetryEnabled ? 13 : 11} className="px-3 py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+                        <td colSpan={smartRetryEnabled ? 12 : 10} className="px-3 py-8 text-center text-sm text-slate-400 dark:text-slate-500">
                           No transactions match the current filters.
                         </td>
                       </tr>
@@ -5021,7 +5003,6 @@ export function DecisionSimulatorPage() {
                         <td className="px-3 py-2" />
                         <td className="px-3 py-2" />
                         <td className="px-3 py-2 text-right whitespace-nowrap tabular-nums text-emerald-700 dark:text-emerald-400">{formatCurrencyValue(txColumnTotals.savings, txColumnTotals.currency)}</td>
-                        <td className="px-3 py-2" />
                         {smartRetryEnabled && <td className="px-3 py-2" />}
                         {smartRetryEnabled && <td className="px-3 py-2" />}
                       </tr>

--- a/website/src/types/api.ts
+++ b/website/src/types/api.ts
@@ -17,10 +17,15 @@ export interface DecideGatewayResponse {
 
 export type MultiObjectiveOutcome = 'COST_WON' | 'AUTH_WON'
 
+// Which source priced a PSP's cost: our own ingested data, the config seed table, or live Hypersense.
+export type CostSource = 'IN_HOUSE' | 'SEED' | 'HYPERSENSE'
+
 export interface PspSummary {
   psp: string
   authRate: number
   costBps: number | null
+  // Where costBps came from; null when the PSP had no cost data.
+  costSource?: CostSource | null
 }
 
 export interface MultiObjectiveInfo {

--- a/website/src/types/api.ts
+++ b/website/src/types/api.ts
@@ -25,7 +25,7 @@ export interface PspSummary {
   authRate: number
   costBps: number | null
   // Where costBps came from; null when the PSP had no cost data.
-  costSource?: CostSource | null
+  costSource: CostSource | null
 }
 
 export interface MultiObjectiveInfo {


### PR DESCRIPTION
This pull request adds support for ingesting Stripe's "Payments Fee Report" as a new cost connector, including backend parsing, registration, and frontend visibility. It also improves ClickHouse schema management to ensure required cost tables are present and can be auto-healed if missing. Additionally, it introduces a new `CostSource` type to clarify the provenance of cost data in API responses.

**Stripe connector integration:**

* Added a new `StripeReportSource` implementation that parses Stripe's aggregated fee report CSV format into canonical `SettledFeeRow` records, including robust handling of Stripe-specific fields, synthetic id generation, and comprehensive tests.
* Registered the Stripe connector in the ingestion backend (`mod.rs`, `source.rs`), making it available for cost ingestion. [[1]](diffhunk://#diff-6b9b875673b423825d3d4e6ddc1674c5e871a97e88d66a3d4ae3b08d70fbb1f8R12) [[2]](diffhunk://#diff-c23343c73639293581c23d917da73ccd6dc71ccbbf7b50050763c3aa88d465d7R20) [[3]](diffhunk://#diff-c23343c73639293581c23d917da73ccd6dc71ccbbf7b50050763c3aa88d465d7R139)
* Enabled Stripe as an upload option in the website's cost routing UI.

**ClickHouse schema improvements:**

* Updated the ClickHouse schema checklist in `oneclick.sh` to include the new cost tables (`cost_daily_stats`, `cost_fee_model`, `connector_markup_overlay`) and added logic to auto-run their DDL if missing, healing pre-existing volumes without data loss. [[1]](diffhunk://#diff-c927a1340095206adcece931c7776ad2f73fe7f11d8f47be05e424a5ea003aa3R64-R66) [[2]](diffhunk://#diff-c927a1340095206adcece931c7776ad2f73fe7f11d8f47be05e424a5ea003aa3L541-R562)

**API enhancements:**

* Introduced a `CostSource` type and added an optional `costSource` field to `PspSummary`, indicating whether cost data came from in-house ingestion, the config seed, or Hypersense.


<img width="1654" height="920" alt="image" src="https://github.com/user-attachments/assets/44e0fa9a-65a0-4176-8279-ae2b9e750882" />


<img width="1451" height="912" alt="image" src="https://github.com/user-attachments/assets/f3f1f7c2-d357-4e4e-99a1-cc8f345d9f8d" />

![Uploading image.png…]()

