### PR TITLE
fix(id): move serial id to uuid for cost_ingestion id column

### DIFF
--- a/clickhouse/scripts/035_cost_model.sh
+++ b/clickhouse/scripts/035_cost_model.sh
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS cost_daily_stats (
     account          String,                    -- connector-side account (e.g. Adyen merchantAccountCode)
     merchant_id      String,                    -- our merchant that owns the account
     txn_date         Date,                      -- the TRANSACTION (booking) day this bucket aggregates
-    ingestion_id     Int64 DEFAULT 0,           -- the cost_ingestion row that last wrote this bucket (delete-by-ingestion)
+    ingestion_id     String DEFAULT '',         -- the cost_ingestion row (UUIDv7) that last wrote this bucket (delete-by-ingestion)
     card_network     LowCardinality(String),    -- 'visa', 'mc', …          ┐
     variant          String,                    -- 'visastandarddebit', …    │ cluster key
     funding          LowCardinality(String),    -- 'debit' | 'credit' | ''   │ (fit groups on this)

--- a/migrations/2026-07-05-000001_cost_ingestion/up.sql
+++ b/migrations/2026-07-05-000001_cost_ingestion/up.sql
@@ -1,7 +1,7 @@
 -- Unified settlement-report ingestion table: work queue + live progress + history (MySQL parity
 -- of the Postgres migration). See scratch/inhouse-cost-architecture.md §7.
 CREATE TABLE cost_ingestion (
-    id               BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    id               VARCHAR(36)  NOT NULL PRIMARY KEY,
     merchant_id      VARCHAR(255) NOT NULL,
     connector        VARCHAR(64)  NOT NULL,
     account          VARCHAR(255) NOT NULL,

--- a/migrations_pg/2026-07-05-000001_cost_ingestion/up.sql
+++ b/migrations_pg/2026-07-05-000001_cost_ingestion/up.sql
@@ -7,7 +7,7 @@
 -- so the dashboard can show ingestion history. Connector-generic: `connector` is a value, never a
 -- table. See scratch/inhouse-cost-architecture.md §7.
 CREATE TABLE cost_ingestion (
-    id               BIGSERIAL PRIMARY KEY,
+    id               VARCHAR(36)  PRIMARY KEY,
     merchant_id      VARCHAR(255) NOT NULL,          -- our merchant that owns the account
     connector        VARCHAR(64)  NOT NULL,          -- 'adyen', 'stripe', …
     account          VARCHAR(255) NOT NULL,          -- connector-side account (Adyen merchantAccountCode)

--- a/src/cost_ingestion/pipeline.rs
+++ b/src/cost_ingestion/pipeline.rs
@@ -76,7 +76,7 @@ pub async fn ingest_report_bytes(
     account: &str,
     merchant_id: &str,
     bytes: Bytes,
-    progress_job: Option<i64>,
+    progress_job: Option<&str>,
 ) -> Result<IngestOutcome, IngestError> {
     ingest_report_reader(
         clickhouse,
@@ -98,7 +98,7 @@ pub async fn ingest_report_reader(
     account: &str,
     merchant_id: &str,
     reader: Box<dyn Read + Send>,
-    progress_job: Option<i64>,
+    progress_job: Option<&str>,
 ) -> Result<IngestOutcome, IngestError> {
     let registry = ConnectorRegistry::with_builtins();
     let source = registry.get(connector)?;
@@ -171,7 +171,7 @@ pub async fn ingest_report_reader(
         connector,
         account,
         merchant_id,
-        progress_job.unwrap_or(0),
+        progress_job.unwrap_or_default(),
         &rows,
     )
     .await?;

--- a/src/cost_ingestion/sink.rs
+++ b/src/cost_ingestion/sink.rs
@@ -46,7 +46,7 @@ pub async fn insert_daily_stats(
     connector: &str,
     account: &str,
     merchant_id: &str,
-    ingestion_id: i64,
+    ingestion_id: &str,
     rows: &[DailyStatRow],
 ) -> Result<usize, IngestError> {
     if rows.is_empty() {
@@ -124,22 +124,21 @@ pub async fn delete_ingestion_rows(
     connector: &str,
     account: &str,
     merchant_id: &str,
-    ingestion_id: i64,
+    ingestion_id: &str,
 ) -> Result<(), IngestError> {
     let sql = format!(
         "DELETE FROM {}.cost_daily_stats WHERE connector = {{connector:String}} \
          AND account = {{account:String}} AND merchant_id = {{merchant_id:String}} \
-         AND ingestion_id = {{ingestion_id:Int64}}",
+         AND ingestion_id = {{ingestion_id:String}}",
         cfg.database
     );
-    let id = ingestion_id.to_string();
     let mut req = client()
         .post(cfg.url.trim_end_matches('/'))
         .query(&[
             ("param_connector", connector),
             ("param_account", account),
             ("param_merchant_id", merchant_id),
-            ("param_ingestion_id", id.as_str()),
+            ("param_ingestion_id", ingestion_id),
         ])
         .body(sql);
     if !cfg.user.is_empty() {

--- a/src/cost_ingestion/store.rs
+++ b/src/cost_ingestion/store.rs
@@ -22,6 +22,7 @@ use crate::storage::types::{
     CostIngestion, CostIngestionNew, CostIngestionOutcomeUpdate, CostIngestionProgressUpdate,
     CostIngestionStatusUpdate,
 };
+use crate::storage::utils::generate_uuid;
 
 use super::types::IngestError;
 
@@ -74,6 +75,7 @@ pub async fn enqueue_pending(
     }
 
     let new = CostIngestionNew {
+        id: generate_uuid(),
         merchant_id: merchant_id.to_string(),
         connector: connector.to_string(),
         account: account.to_string(),
@@ -89,16 +91,18 @@ pub async fn enqueue_pending(
 }
 
 /// Create a `processing` row for a manual upload and return its id, so the caller's background task
-/// can report progress and record the outcome against it. `report_ref` is the on-disk temp path,
-/// unique per upload, which is how we read the freshly-inserted id back.
+/// can report progress and record the outcome against it. The id is generated client-side (UUIDv7),
+/// so it's known up front — no read-back of the freshly-inserted row is needed.
 pub async fn create_manual(
     merchant_id: &str,
     connector: &str,
     account: &str,
     report_ref: &str,
-) -> Result<i64, IngestError> {
+) -> Result<String, IngestError> {
     let app_state = get_tenant_app_state().await;
+    let id = generate_uuid();
     let new = CostIngestionNew {
+        id: id.clone(),
         merchant_id: merchant_id.to_string(),
         connector: connector.to_string(),
         account: account.to_string(),
@@ -110,16 +114,7 @@ pub async fn create_manual(
     generics::generic_insert::<<CostIngestion as HasTable>::Table, _>(&app_state.db, new)
         .await
         .map_err(|e| IngestError::Storage(e.to_string()))?;
-
-    let row = generics::generic_find_one_optional::<
-        <CostIngestion as HasTable>::Table,
-        _,
-        CostIngestion,
-    >(&app_state.db, dsl::report_ref.eq(report_ref.to_string()))
-    .await
-    .map_err(|e| IngestError::Storage(e.to_string()))?
-    .ok_or_else(|| IngestError::Storage("manual ingestion row vanished after insert".into()))?;
-    Ok(row.id)
+    Ok(id)
 }
 
 /// Claim up to `limit` pending jobs by compare-and-swapping each `pending → processing`. The CAS
@@ -154,7 +149,7 @@ pub async fn claim_pending(limit: usize) -> Result<Vec<CostIngestion>, IngestErr
         let won = generics::generic_update_if_present::<<CostIngestion as HasTable>::Table, _, _>(
             &conn,
             dsl::id
-                .eq(row.id)
+                .eq(row.id.clone())
                 .and(dsl::status.eq("pending".to_string())),
             CostIngestionStatusUpdate {
                 status: "processing".to_string(),
@@ -172,7 +167,7 @@ pub async fn claim_pending(limit: usize) -> Result<Vec<CostIngestion>, IngestErr
 }
 
 /// Bump the staged-row counter the dashboard polls for progress.
-pub async fn update_progress(id: i64, staged_rows: i64) -> Result<(), IngestError> {
+pub async fn update_progress(id: &str, staged_rows: i64) -> Result<(), IngestError> {
     let app_state = get_tenant_app_state().await;
     let conn = app_state
         .db
@@ -181,7 +176,7 @@ pub async fn update_progress(id: i64, staged_rows: i64) -> Result<(), IngestErro
         .map_err(|_| IngestError::Storage("db connection".to_string()))?;
     generics::generic_update_if_present::<<CostIngestion as HasTable>::Table, _, _>(
         &conn,
-        dsl::id.eq(id),
+        dsl::id.eq(id.to_string()),
         CostIngestionProgressUpdate {
             staged_rows,
             updated_at: crate::utils::date_time::now(),
@@ -193,7 +188,7 @@ pub async fn update_progress(id: i64, staged_rows: i64) -> Result<(), IngestErro
 }
 
 /// Mark a job `completed` and record its full outcome for history.
-pub async fn mark_completed(id: i64, c: &Completion) -> Result<(), IngestError> {
+pub async fn mark_completed(id: &str, c: &Completion) -> Result<(), IngestError> {
     let app_state = get_tenant_app_state().await;
     let conn = app_state
         .db
@@ -217,7 +212,7 @@ pub async fn mark_completed(id: i64, c: &Completion) -> Result<(), IngestError> 
     };
     generics::generic_update_if_present::<<CostIngestion as HasTable>::Table, _, _>(
         &conn,
-        dsl::id.eq(id),
+        dsl::id.eq(id.to_string()),
         update,
     )
     .await
@@ -226,7 +221,7 @@ pub async fn mark_completed(id: i64, c: &Completion) -> Result<(), IngestError> 
 }
 
 /// Mark a job `failed`, recording the error for operators / the dashboard.
-pub async fn mark_failed(id: i64, error: &str) -> Result<(), IngestError> {
+pub async fn mark_failed(id: &str, error: &str) -> Result<(), IngestError> {
     let app_state = get_tenant_app_state().await;
     let conn = app_state
         .db
@@ -235,7 +230,7 @@ pub async fn mark_failed(id: i64, error: &str) -> Result<(), IngestError> {
         .map_err(|_| IngestError::Storage("db connection".to_string()))?;
     generics::generic_update_if_present::<<CostIngestion as HasTable>::Table, _, _>(
         &conn,
-        dsl::id.eq(id),
+        dsl::id.eq(id.to_string()),
         CostIngestionStatusUpdate {
             status: "failed".to_string(),
             last_error: Some(error.to_string()),
@@ -271,13 +266,13 @@ pub async fn list_for_merchant(
 /// A single ingestion by id, scoped to the merchant (used for progress polling).
 pub async fn get_for_merchant(
     merchant_id: &str,
-    id: i64,
+    id: &str,
 ) -> Result<Option<CostIngestion>, IngestError> {
     let app_state = get_tenant_app_state().await;
     generics::generic_find_one_optional::<<CostIngestion as HasTable>::Table, _, CostIngestion>(
         &app_state.db,
         dsl::id
-            .eq(id)
+            .eq(id.to_string())
             .and(dsl::merchant_id.eq(merchant_id.to_string())),
     )
     .await
@@ -286,7 +281,7 @@ pub async fn get_for_merchant(
 
 /// Hard-delete an ingestion's history row, scoped to the merchant. Returns `true` if a row was
 /// removed. The caller deletes the ClickHouse data separately (see `sink::delete_snapshot`).
-pub async fn delete(merchant_id: &str, id: i64) -> Result<bool, IngestError> {
+pub async fn delete(merchant_id: &str, id: &str) -> Result<bool, IngestError> {
     let app_state = get_tenant_app_state().await;
     let conn = app_state
         .db
@@ -296,7 +291,7 @@ pub async fn delete(merchant_id: &str, id: i64) -> Result<bool, IngestError> {
     let n = generics::generic_delete::<<CostIngestion as HasTable>::Table, _>(
         &conn,
         dsl::id
-            .eq(id)
+            .eq(id.to_string())
             .and(dsl::merchant_id.eq(merchant_id.to_string())),
     )
     .await

--- a/src/cost_ingestion/worker.rs
+++ b/src/cost_ingestion/worker.rs
@@ -66,12 +66,12 @@ async fn run_once(batch: usize, clickhouse: &ClickHouseAnalyticsConfig) {
     };
 
     for job in claimed {
-        let id = job.id;
+        let id = job.id.clone();
         let merchant_id = job.merchant_id.clone();
         match process(job, clickhouse).await {
             Ok(outcome) => {
-                log_fit(id, &outcome);
-                if let Err(e) = store::mark_completed(id, &outcome.to_completion()).await {
+                log_fit(&id, &outcome);
+                if let Err(e) = store::mark_completed(&id, &outcome.to_completion()).await {
                     logger::warn!(
                         tag = "ingest_worker",
                         "mark_completed {} failed: {:?}",
@@ -92,7 +92,7 @@ async fn run_once(batch: usize, clickhouse: &ClickHouseAnalyticsConfig) {
             Err(e) => {
                 let msg = format!("{e:?}");
                 logger::warn!(tag = "ingest_worker", "job {} failed: {}", id, msg);
-                if let Err(e2) = store::mark_failed(id, &msg).await {
+                if let Err(e2) = store::mark_failed(&id, &msg).await {
                     logger::warn!(tag = "ingest_worker", "mark_failed {} failed: {:?}", id, e2);
                 }
             }
@@ -145,14 +145,14 @@ async fn process(
         &job.account,
         &job.merchant_id,
         bytes,
-        Some(job.id),
+        Some(job.id.as_str()),
     )
     .await
 }
 
 /// Log the fit outcome. A snapshot with no GOOD clusters is written but flagged — serving only ever
 /// reads GOOD rows (§10), so this is "no coverage", never a bad cost.
-fn log_fit(id: i64, outcome: &IngestOutcome) {
+fn log_fit(id: &str, outcome: &IngestOutcome) {
     if outcome.summary.good_clusters == 0 {
         logger::warn!(
             tag = "ingest_worker",

--- a/src/routes/report_upload.rs
+++ b/src/routes/report_upload.rs
@@ -38,7 +38,7 @@ pub struct UploadParams {
 /// Returned immediately (202): the created job's id, which the dashboard polls for progress.
 #[derive(Debug, Serialize)]
 pub struct UploadAccepted {
-    pub id: i64,
+    pub id: String,
     pub status: String,
 }
 
@@ -49,7 +49,7 @@ const HISTORY_LIMIT: i64 = 50;
 /// currency/country lists split back into arrays).
 #[derive(Debug, Serialize)]
 pub struct IngestionDto {
-    pub id: i64,
+    pub id: String,
     pub connector: String,
     pub account: String,
     pub source: String,
@@ -110,9 +110,9 @@ pub async fn list_ingestions(
 /// so the served model reflects what remains, and deletes the history row. In-progress jobs can't
 /// be deleted.
 pub async fn delete_ingestion(
-    Path((merchant_id, ingestion_id)): Path<(String, i64)>,
+    Path((merchant_id, ingestion_id)): Path<(String, String)>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    let row = store::get_for_merchant(&merchant_id, ingestion_id)
+    let row = store::get_for_merchant(&merchant_id, &ingestion_id)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:?}")))?
         .ok_or((StatusCode::NOT_FOUND, "ingestion not found".to_string()))?;
@@ -142,7 +142,7 @@ pub async fn delete_ingestion(
         &row.connector,
         &row.account,
         &merchant_id,
-        ingestion_id,
+        &ingestion_id,
     )
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:?}")))?;
@@ -160,7 +160,7 @@ pub async fn delete_ingestion(
         logger::warn!(tag = "report_upload", "refit after delete failed: {:?}", e);
     }
 
-    store::delete(&merchant_id, ingestion_id)
+    store::delete(&merchant_id, &ingestion_id)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:?}")))?;
 
@@ -277,7 +277,7 @@ pub async fn upload_report(
 
     // Process in the background: the request returns now; the merchant watches progress via polling.
     tokio::spawn(process_upload(
-        job_id,
+        job_id.clone(),
         path,
         clickhouse,
         connector,
@@ -338,7 +338,7 @@ async fn stream_to_file(path: &PathBuf, body: Body) -> Result<(), (StatusCode, S
 /// Background task: run the same parse → stage → fit pipeline the worker uses, record the outcome,
 /// and clean up the temp file. Progress ticks against `job_id` as batches stage.
 async fn process_upload(
-    job_id: i64,
+    job_id: String,
     path: PathBuf,
     clickhouse: crate::config::ClickHouseAnalyticsConfig,
     connector: String,
@@ -346,7 +346,7 @@ async fn process_upload(
     merchant_id: String,
 ) {
     let result = run_ingest(
-        job_id,
+        &job_id,
         &path,
         &clickhouse,
         &connector,
@@ -357,7 +357,7 @@ async fn process_upload(
 
     match result {
         Ok(outcome) => {
-            if let Err(e) = store::mark_completed(job_id, &outcome.to_completion()).await {
+            if let Err(e) = store::mark_completed(&job_id, &outcome.to_completion()).await {
                 logger::warn!(
                     tag = "report_upload",
                     "mark_completed {} failed: {:?}",
@@ -387,7 +387,7 @@ async fn process_upload(
                 job_id,
                 msg
             );
-            if let Err(e2) = store::mark_failed(job_id, &msg).await {
+            if let Err(e2) = store::mark_failed(&job_id, &msg).await {
                 logger::warn!(
                     tag = "report_upload",
                     "mark_failed {} failed: {:?}",
@@ -411,7 +411,7 @@ async fn process_upload(
 
 /// Open the staged file as a blocking reader and run the ingest pipeline.
 async fn run_ingest(
-    job_id: i64,
+    job_id: &str,
     path: &PathBuf,
     clickhouse: &crate::config::ClickHouseAnalyticsConfig,
     connector: &str,

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -14,7 +14,8 @@ diesel::table! {
 
 diesel::table! {
     cost_ingestion (id) {
-        id -> Bigint,
+        #[max_length = 36]
+        id -> Varchar,
         #[max_length = 255]
         merchant_id -> Varchar,
         #[max_length = 64]

--- a/src/storage/schema_pg.rs
+++ b/src/storage/schema_pg.rs
@@ -54,7 +54,8 @@ diesel::table! {
 
 diesel::table! {
     cost_ingestion (id) {
-        id -> Int8,
+        #[max_length = 36]
+        id -> Varchar,
         #[max_length = 255]
         merchant_id -> Varchar,
         #[max_length = 64]

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -314,7 +314,7 @@ pub struct MerchantAccountUpdate {
 #[cfg_attr(feature = "mysql", diesel(table_name = schema::cost_ingestion))]
 #[cfg_attr(feature = "postgres", diesel(table_name = schema_pg::cost_ingestion))]
 pub struct CostIngestion {
-    pub id: i64,
+    pub id: String,
     pub merchant_id: String,
     pub connector: String,
     pub account: String,
@@ -346,6 +346,9 @@ pub struct CostIngestion {
 #[cfg_attr(feature = "mysql", diesel(table_name = schema::cost_ingestion))]
 #[cfg_attr(feature = "postgres", diesel(table_name = schema_pg::cost_ingestion))]
 pub struct CostIngestionNew {
+    /// Client-generated UUIDv7 primary key (`storage::utils::generate_uuid`). Set at insert so the
+    /// caller already holds the id — no read-back needed.
+    pub id: String,
     pub merchant_id: String,
     pub connector: String,
     pub account: String,


### PR DESCRIPTION
This pull request migrates the `cost_ingestion` job ID from an integer type to a string UUID (specifically UUIDv7) across the entire ingestion pipeline, including all database schemas, Rust backend types, and API endpoints. This change ensures globally unique, client-generated IDs for ingestion jobs, improving reliability and future scalability. The pull request also updates all related function signatures, queries, and API DTOs to use string IDs instead of integers.

**Database schema changes:**
- Migrated the `id` column in both MySQL and Postgres `cost_ingestion` tables from `BIGINT`/`BIGSERIAL` to `VARCHAR(36)` to store UUIDs. (`migrations/2026-07-05-000001_cost_ingestion/up.sql` [[1]](diffhunk://#diff-132b6a1c733a8cd978ee49c679859dca3cd20d7628e20adbdbe22c0dbd3bf739L4-R4) `migrations_pg/2026-07-05-000001_cost_ingestion/up.sql` [[2]](diffhunk://#diff-27b536ada816dcc3e2493874507f687350e5e4c776e09a226cc2dc2e087c4c55L10-R10)
- Changed the `ingestion_id` column in the ClickHouse `cost_daily_stats` table from `Int64` to `String` to match the new UUID format. (`clickhouse/scripts/035_cost_model.sh` [clickhouse/scripts/035_cost_model.shL43-R43](diffhunk://#diff-7b6c592b9c15532595c93f18077c53595e87e0bd7cc38414d3b0f3777e4c6987L43-R43))

**Backend code changes:**
- Updated all ingestion job-related function signatures, struct fields, and queries to use `String` or `&str` for IDs instead of `i64`, including in the ingestion pipeline, store, and worker modules.

**API and DTO changes:**
- Changed all API endpoints, DTOs, and handler signatures to use string IDs for ingestion jobs, including upload, delete, and listing endpoints. (`src/routes/report_upload.rs`

**Query and SQL updates:**
- Updated all SQL queries and parameters to use string-based IDs for ingestion jobs, including delete and insert operations in ClickHouse and the relational databases. (`src/cost_ingestion/sink.rs` [src/cost_ingestion/sink.rsL127-R141](diffhunk://#diff-be88e8ce454f674dcd8d8a6aef134697513f0603f2126bad64dbaca35a1a85abL127-R141))

**Worker and processing logic:**
- Updated the ingestion worker to handle string-based IDs throughout job claiming, processing, and logging. (`src/cost_ingestion/worker.rs` 

These changes ensure that ingestion job IDs are unique, consistent, and compatible across all storage backends and APIs.