### PR TITLE
feat(skills): add Decision Engine orchestrator integration skill

### DIFF
--- a/skills/decision-engine-integration/SKILL.md
+++ b/skills/decision-engine-integration/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: decision-engine-integration
+description: >-
+  Wire a self-hosted Juspay Decision Engine into a merchant's own payment
+  orchestrator so PSP/gateway selection is delegated to Decision Engine. Use this
+  skill whenever the user is working in their orchestration / payment-routing /
+  checkout backend and wants to call Decision Engine's `decide-gateway` (to pick
+  the best PSP before authorizing) and `update-gateway-score` (to feed the
+  auth/charge outcome back), or mentions "Decision Engine", "decide gateway",
+  "gateway score", "PSP routing", "dynamic routing", "success-rate routing",
+  "which gateway should I use", or hooking a Vault/tokenized-card checkout up to
+  smart routing. Trigger this even when the user only describes the goal
+  ("route this payment to the best acquirer", "add smart routing before we
+  charge the PSP") without naming the APIs. This skill covers discovering the
+  authorize/charge path in the orchestrator, inserting the two calls in the
+  right place, mapping the tokenized-card + BIN metadata into the request,
+  failing open safely, and certifying the integration with runnable tests and
+  AI evals. It can also stand up Decision Engine locally if it is not running.
+---
+
+# Decision Engine Integration
+
+You are integrating a **self-hosted Juspay Decision Engine** into a merchant's
+**own orchestrator** — the service that already decides which PSP/acquirer to
+send a payment to and then makes the Authorize/Charge call. After this
+integration, that PSP choice is delegated to Decision Engine.
+
+Decision Engine is a stateless HTTP routing brain. It never sees the PAN. Your
+orchestrator asks it *"given this payment, which of my gateways should I use?"*
+(`POST /decide-gateway`) and later tells it *"here's how that attempt turned
+out"* (`POST /update-gateway-score`) so its success-rate model keeps improving.
+
+```
+Vault checkout (tokenizes card)                 Decision Engine (self-hosted)
+        │  token + metadata (incl. card BIN)          ▲            │
+        ▼                                             │ decide     │ decision
+  Merchant server ──────────────────────────────────┘            ▼
+        │                                        ┌── decided_gateway + order
+        ▼                                        │
+  Orchestrator ── Authorize/Charge ──▶ chosen PSP
+        │                                        │
+        └──────────── update-gateway-score ◀─────┘  (auth outcome feedback)
+```
+
+## The critical mental model
+
+Two calls, placed around the code that already picks + charges a PSP:
+
+1. **`decide-gateway`** goes in **right before** the orchestrator selects the
+   PSP for the Authorize/Charge call. It *replaces or informs* whatever static
+   priority list is there today. Input = the payment context (amount, currency,
+   payment method, **card BIN**, eligible gateways). Output = the ordered
+   gateway the orchestrator should try.
+
+2. **`update-gateway-score`** goes **after** the PSP returns a terminal
+   Authorize/Charge result. It reports the outcome (`CHARGED`, `AUTHORIZED`,
+   `AUTHORIZATION_FAILED`, …) keyed by the *same* `paymentId` and `gateway` you
+   just used, so the success-rate model learns.
+
+Get these two placements right and the integration is 90% done. Everything else
+(config, fail-open, mapping) is in service of these two.
+
+## Workflow
+
+Work through these phases in order. Do not skip discovery — placing the calls in
+the wrong function is the most common way this integration goes wrong.
+
+### Phase 0 — Confirm Decision Engine is reachable
+
+Ask the user (or check env/config) for the base URL and API key. Then:
+
+```bash
+curl -sS "$DECISION_ENGINE_URL/health"          # expect {"status":"UP"} style body, 200
+curl -sS "$DECISION_ENGINE_URL/health/ready"     # expect 200 when DB/Redis are wired
+```
+
+- If it responds → record `DECISION_ENGINE_URL`, the `x-api-key`, and the
+  `merchantId`, and go to Phase 1.
+- If the user does **not** have Decision Engine running → read
+  [references/local-setup.md](references/local-setup.md) and stand it up locally
+  (Docker Compose one-liner + merchant/API-key bootstrap). **Skip this if they
+  already have a running instance** (self-hosted, sandbox, or otherwise).
+
+### Phase 1 — Discover the orchestrator's payment path
+
+Before writing anything, map the existing flow. Search the repo for:
+
+- The **PSP/gateway selection** point — where the code picks an acquirer/connector
+  (look for a hard-coded priority list, a `switch`/`match` on gateway, a
+  "connectors"/"gateways"/"acquirers" config, a `select_gateway`-style function).
+- The **Authorize/Charge call site** — where the chosen PSP's API is invoked.
+- The **card/token intake** — where the Vault checkout token + metadata land on
+  the merchant server. This is where the **card BIN** (`cardIsin`, first 6–8
+  digits) lives. Decision Engine needs the BIN, never the PAN or the token.
+- The **outcome handler** — where the PSP's Authorize/Charge response is parsed
+  into success/failure.
+
+Report back a short map: *"selection happens in X, authorize in Y, outcome in Z,
+BIN is available at W."* Confirm with the user if any of these are ambiguous —
+guessing here produces a broken integration.
+
+### Phase 2 — Insert `decide-gateway` before PSP selection
+
+Add a client call that, at the selection point, sends the payment context to
+`decide-gateway` and uses `decided_gateway` as the PSP to authorize with (and
+`gateway_priority_map` / `priorityLogicOutput.gws` as the fallback order).
+
+Map the orchestrator's data into the request. **Full field reference and every
+enum value is in [references/api-contract.md](references/api-contract.md)** —
+read it before writing the client. The essential mapping:
+
+| Decision Engine field | Source in the orchestrator |
+| --- | --- |
+| `merchantId` | your configured merchant id |
+| `eligibleGatewayList` | the PSPs this payment is actually allowed to use |
+| `rankingAlgorithm` | `SR_BASED_ROUTING` for success-rate routing (default) |
+| `paymentInfo.paymentId` | your payment/attempt id (**reuse in the score call**) |
+| `paymentInfo.amount` / `currency` / `country` | the order |
+| `paymentInfo.paymentMethodType` | `CARD` |
+| `paymentInfo.paymentMethod` | `CREDIT` or `DEBIT` |
+| `paymentInfo.authType` | `THREE_DS` / `NO_THREE_DS` |
+| `paymentInfo.cardIsin` | **the card BIN from the Vault token metadata** |
+
+Critical implementation rules — explain these in code comments so future
+maintainers understand the *why*:
+
+- **Fail open.** `decide-gateway` sits in the live authorization path. If it
+  errors, times out (set a tight timeout, e.g. 150–300 ms), or returns a gateway
+  not in your eligible list, **fall back to the orchestrator's existing routing**
+  and continue. A routing brain outage must never block payments.
+- **Never send the PAN or the raw token.** Only the BIN (`cardIsin`) plus
+  non-sensitive metadata go to Decision Engine. This keeps it out of PCI scope.
+- **Keep `paymentId` stable** for this attempt — you must send the same value to
+  `update-gateway-score` or the feedback won't attribute to the right decision.
+
+### Phase 3 — Insert `update-gateway-score` after the outcome
+
+After the PSP returns a **terminal** Authorize/Charge result, report it:
+
+- Send `merchantId`, `gateway` (the PSP you actually used), `paymentId` (the
+  same one from Phase 2), and `status` mapped to a Decision Engine `TxnStatus`.
+- Success → `CHARGED` (captured) or `AUTHORIZED`. Failure →
+  `AUTHORIZATION_FAILED` (most common), `FAILURE`, `AUTHENTICATION_FAILED`, or
+  `JUSPAY_DECLINED`. **Do not report non-terminal states** like `PENDING` /
+  `AUTHORIZING` — wait for the final outcome. Full status table is in the API
+  contract reference.
+- Make this call **out of the critical path** (fire-and-forget / async / queued)
+  and idempotent per `paymentId` so retries don't double-count. A failed score
+  update must not fail the payment.
+- **Skip the score call** for `NTW_BASED_ROUTING` debit runs where
+  `decided_gateway` is a network rather than the PSP you charged — see the
+  contract reference note.
+
+### Phase 4 — Configuration & wiring
+
+Externalize `DECISION_ENGINE_URL`, the `x-api-key`, `merchantId`, the timeout,
+and a **feature flag / kill-switch** to disable the whole integration and revert
+to legacy routing instantly. Match the surrounding codebase's config idiom
+(env vars, config service, secrets manager) — don't invent a new one.
+
+### Phase 5 — Certify the integration
+
+An integration that compiles is not a working integration. Certify it with the
+runnable tests and AI evals in
+[references/testing-and-evals.md](references/testing-and-evals.md). At minimum:
+
+- Run [scripts/smoke_test.sh](scripts/smoke_test.sh) against a live/local
+  Decision Engine to prove the round trip (bootstrap → decide → charge → score).
+- Add the integration test cases (happy path, fallback ordering, **fail-open when
+  Decision Engine is down**, BIN propagation, feedback attribution, debit-skip)
+  to the orchestrator's own test suite.
+- Run the AI eval rubric in the reference to grade the integration code for
+  correctness and safety before shipping.
+
+## Reference material
+
+Read these as needed — don't load them all upfront:
+
+- **[references/api-contract.md](references/api-contract.md)** — exact
+  request/response schemas, every enum value, error shapes, auth headers, and
+  the debit/BIN metadata format. Read before writing the client (Phase 2/3).
+- **[references/local-setup.md](references/local-setup.md)** — download, run,
+  and bootstrap Decision Engine locally, including merchant + API key + SR config
+  creation. Read only if the user needs a local instance (Phase 0).
+- **[references/testing-and-evals.md](references/testing-and-evals.md)** — the
+  test matrix and the AI eval rubric to certify the integration (Phase 5).
+- **[scripts/smoke_test.sh](scripts/smoke_test.sh)** — end-to-end round-trip
+  check against a running Decision Engine.
+- **[scripts/certify_integration.py](scripts/certify_integration.py)** — a
+  contract-level certifier that exercises decide + score and checks invariants.

--- a/skills/decision-engine-integration/SKILL.md
+++ b/skills/decision-engine-integration/SKILL.md
@@ -145,8 +145,8 @@ After the PSP returns a **terminal** Authorize/Charge result, report it:
 - Send `merchantId`, `gateway` (the PSP you actually used), `paymentId` (the
   same one from Phase 2), and `status` mapped to a Decision Engine `TxnStatus`.
 - Success → `CHARGED` (captured) or `AUTHORIZED`. Failure →
-  `AUTHORIZATION_FAILED` (most common), `FAILURE`, `AUTHENTICATION_FAILED`, or
-  `JUSPAY_DECLINED`. **Do not report non-terminal states** like `PENDING` /
+  `AUTHORIZATION_FAILED` (most common), `FAILURE`, `DECLINED`, or
+  `AUTHENTICATION_FAILED`. **Do not report non-terminal states** like `PENDING` /
   `AUTHORIZING` — wait for the final outcome. Full status table is in the API
   contract reference.
 - Make this call **out of the critical path** (fire-and-forget / async / queued)

--- a/skills/decision-engine-integration/SKILL.md
+++ b/skills/decision-engine-integration/SKILL.md
@@ -103,7 +103,12 @@ guessing here produces a broken integration.
 
 Add a client call that, at the selection point, sends the payment context to
 `decide-gateway` and uses `decided_gateway` as the PSP to authorize with (and
-`gateway_priority_map` / `priorityLogicOutput.gws` as the fallback order).
+`gateway_priority_map` / `priority_logic_output.gws` as the fallback order).
+
+Note the casing: **request** bodies use camelCase (`merchantId`, `paymentInfo`,
+`cardIsin`), but the **response** uses snake_case (`decided_gateway`,
+`gateway_priority_map`, `priority_logic_output`). The contract reference spells
+this out field by field.
 
 Map the orchestrator's data into the request. **Full field reference and every
 enum value is in [references/api-contract.md](references/api-contract.md)** —

--- a/skills/decision-engine-integration/evals/evals.json
+++ b/skills/decision-engine-integration/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "decision-engine-integration",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We self-host Juspay Decision Engine. In our Node/Express payment orchestrator, before we call the PSP's authorize API we currently pick the acquirer from a hard-coded priority array in services/routing.js. I want to replace that with a call to Decision Engine's decide-gateway, and then report the auth result back with update-gateway-score. Our checkout uses a Vault that tokenizes the card and sends us the token plus metadata including the card BIN. Wire this up.",
+      "expected_output": "Agent discovers the selection point and authorize call, inserts a decide-gateway client call mapping amount/currency/paymentMethod/cardIsin(BIN), uses decided_gateway, then calls update-gateway-score after the terminal outcome with the same paymentId. Fail-open on DE error/timeout, no PAN sent, bounded timeout, kill-switch/config externalized. Adds tests.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "I don't have Decision Engine running yet. Can you set it up locally and then connect our Python orchestrator's charge flow to it so it decides which gateway to use and learns from the outcome?",
+      "expected_output": "Agent stands up Decision Engine via docker compose, bootstraps a merchant + API key + SR config, verifies with a smoke test, then integrates decide-gateway before the charge and update-gateway-score after it in the orchestrator, with fail-open and BIN mapping.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We already added the decide-gateway call to our routing layer last week. Before we ship, can you certify the integration is correct and safe? I especially want to be sure a Decision Engine outage can't take down checkout.",
+      "expected_output": "Agent runs/writes the behavioral test matrix (esp. fail-open, BIN-not-PAN, paymentId attribution), runs the smoke/certify scripts against the engine, and applies the AI eval rubric, reporting a PASS/FAIL verdict with evidence rather than a vague thumbs-up.",
+      "files": []
+    }
+  ]
+}

--- a/skills/decision-engine-integration/references/api-contract.md
+++ b/skills/decision-engine-integration/references/api-contract.md
@@ -202,11 +202,12 @@ auth feedback:
 | Category | Values | Send when |
 | --- | --- | --- |
 | Success | `CHARGED`, `AUTHORIZED`, `PARTIAL_CHARGED` | Payment authorized/captured. `CHARGED` = captured, `AUTHORIZED` = auth-only. |
-| Failure | `AUTHORIZATION_FAILED`, `FAILURE`, `DECLINED`, `JUSPAY_DECLINED`, `AUTHENTICATION_FAILED` | PSP declined / auth failed / 3DS failed. `AUTHORIZATION_FAILED` is the common card-decline case. |
+| Failure | `AUTHORIZATION_FAILED`, `FAILURE`, `DECLINED`, `AUTHENTICATION_FAILED` | PSP declined / auth failed / 3DS failed. `AUTHORIZATION_FAILED` is the common card-decline case. |
 | **Do NOT send (non-terminal)** | `STARTED`, `PENDING`, `PENDING_VBV`, `AUTHORIZING`, `TO_BE_CHARGED`, `CAPTURE_INITIATED`, `VOID_INITIATED` | Wait for a terminal state first. |
 
-Full enum (for reference): `STARTED`, `AUTHENTICATION_FAILED`,
-`JUSPAY_DECLINED`, `PENDING_VBV`, `VBV_SUCCESSFUL`, `AUTHORIZED`,
+Other `TxnStatus` values the engine defines (for reference; map your PSP
+outcome to the closest generic status in the table above): `STARTED`,
+`AUTHENTICATION_FAILED`, `PENDING_VBV`, `VBV_SUCCESSFUL`, `AUTHORIZED`,
 `AUTHORIZATION_FAILED`, `CHARGED`, `AUTHORIZING`, `COD_INITIATED`, `VOIDED`,
 `VOID_INITIATED`, `NOP`, `CAPTURE_INITIATED`, `CAPTURE_FAILED`, `VOID_FAILED`,
 `AUTO_REFUNDED`, `PARTIAL_CHARGED`, `TO_BE_CHARGED`, `PENDING`, `FAILURE`,

--- a/skills/decision-engine-integration/references/api-contract.md
+++ b/skills/decision-engine-integration/references/api-contract.md
@@ -1,0 +1,253 @@
+# Decision Engine API Contract
+
+Everything the orchestrator client needs for the two integration endpoints.
+Fields are the exact wire names (camelCase). All bodies are JSON.
+
+## Table of contents
+
+- [Auth & base URL](#auth--base-url)
+- [POST /decide-gateway](#post-decide-gateway)
+  - [Request](#decide-gateway-request)
+  - [paymentInfo fields](#paymentinfo-fields)
+  - [Response](#decide-gateway-response)
+  - [Ranking algorithms](#ranking-algorithms)
+  - [routing_approach values](#routing_approach-values)
+- [POST /update-gateway-score](#post-update-gateway-score)
+  - [TxnStatus values](#txnstatus-values)
+- [Debit / network routing & the BIN metadata](#debit--network-routing--the-bin-metadata)
+- [Error shape](#error-shape)
+- [Where these come from in the source](#where-these-come-from-in-the-source)
+
+## Auth & base URL
+
+- Base URL of a local/self-hosted instance: `http://localhost:8080`.
+- Both endpoints are **protected**. Send one of:
+  - `x-api-key: DE_<key>` (server-to-server — use this for the orchestrator), or
+  - `Authorization: Bearer <jwt>` (dashboard sessions).
+- Content type is `application/json`.
+- If routing through Hyperswitch sandbox, also add `x-feature: decision-engine`.
+
+## POST /decide-gateway
+
+Picks the gateway for one payment attempt. Call it at the PSP-selection point,
+before Authorize/Charge.
+
+### decide-gateway request
+
+```json
+{
+  "merchantId": "merchant_demo",
+  "eligibleGatewayList": ["stripe", "adyen", "checkout"],
+  "rankingAlgorithm": "SR_BASED_ROUTING",
+  "eliminationEnabled": true,
+  "paymentInfo": {
+    "paymentId": "attempt_abc123",
+    "amount": 1000,
+    "currency": "USD",
+    "country": "US",
+    "paymentType": "ORDER_PAYMENT",
+    "paymentMethodType": "CARD",
+    "paymentMethod": "CREDIT",
+    "authType": "THREE_DS",
+    "cardIsin": "424242",
+    "metadata": null
+  }
+}
+```
+
+Top-level fields:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `merchantId` | string | yes | Your merchant id in Decision Engine. |
+| `eligibleGatewayList` | string[] | recommended | The PSPs this payment may use. If omitted, DE uses the merchant's configured set. Pass the *actual* eligible list per payment. |
+| `rankingAlgorithm` | enum | yes | See [ranking algorithms](#ranking-algorithms). Default `SR_BASED_ROUTING`. |
+| `eliminationEnabled` | bool | optional | When true, gateways in detected downtime are deprioritized/excluded. |
+| `paymentInfo` | object | yes | The payment context, below. |
+
+### paymentInfo fields
+
+These map 1:1 to the `PaymentInfo` struct. Only a few are required; send what
+you have. The BIN (`cardIsin`) is what makes card-aware routing work.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `paymentId` | string | yes | Your attempt id. **Reuse verbatim in `update-gateway-score`.** |
+| `amount` | number | yes | Order amount (major units, e.g. `1000` = 1000.00). |
+| `currency` | enum | yes | ISO code, e.g. `USD`, `INR`. |
+| `country` | string | optional | ISO-2, e.g. `US`. |
+| `customerId` | string | optional | |
+| `preferredGateway` | string | optional | Hint a specific gateway. |
+| `paymentType` | enum | yes | Usually `ORDER_PAYMENT`. Also `MANDATE_PAYMENT`, `MANDATE_REGISTER`, `TPV_PAYMENT`, etc. |
+| `paymentMethodType` | string | yes | `CARD` for card flows. |
+| `paymentMethod` | string | yes | `CREDIT` or `DEBIT` (or `NET_BANKING`, `WALLET`, …). |
+| `authType` | enum | optional | `THREE_DS`, `NO_THREE_DS`, `OTP`, … |
+| `cardIsin` | string | **strongly recommended** | The **card BIN** (first 6–8 digits) from the Vault token metadata. Enables BIN/network-level routing. Never send the full PAN. |
+| `cardIssuerBankName` | string | optional | If Vault metadata provides it. |
+| `cardType` | string | optional | e.g. `CREDIT`, `DEBIT`. |
+| `metadata` | string (JSON) | optional | A **stringified** JSON blob. Required for debit/network routing (`co_badged_card_data`) — see [debit section](#debit--network-routing--the-bin-metadata). |
+| `internalMetadata` | string | optional | |
+| `isEmi` / `emiBank` / `emiTenure` | bool/string/int | optional | EMI payments. |
+| `udfs` | string[] | optional | User-defined fields. |
+| `cardSwitchProvider` | string | optional | |
+
+### decide-gateway response
+
+```json
+{
+  "decided_gateway": "stripe",
+  "gateway_priority_map": { "stripe": 0.94, "adyen": 0.91, "checkout": 0.88 },
+  "routing_approach": "SR_SELECTION_V3_ROUTING",
+  "gateway_before_evaluation": "stripe",
+  "priority_logic_output": {
+    "isEnforcement": false,
+    "gws": ["stripe", "adyen", "checkout"],
+    "priorityLogicTag": null,
+    "gatewayReferenceIds": {}
+  },
+  "reset_approach": "NO_RESET",
+  "routing_dimension": "ORDER_PAYMENT,CARD,CREDIT,UNKNOWN",
+  "routing_dimension_level": "CARD_LEVEL",
+  "debit_routing_output": null,
+  "is_scheduled_outage": false,
+  "is_rust_based_decider": true
+}
+```
+
+How the orchestrator uses it:
+
+- **`decided_gateway`** — the PSP to authorize with. This is your answer.
+- **`gateway_priority_map`** — score per gateway (higher = better). Use it, or
+  `priority_logic_output.gws`, as the **fallback order** if the primary
+  Authorize fails and you retry another PSP.
+- **`routing_approach`** — why this gateway was chosen (SR selection, downtime
+  hedging, priority logic, network-based). Useful to log for debugging.
+- **`debit_routing_output`** — present only for debit/network routing.
+
+Always validate that `decided_gateway` is in your `eligibleGatewayList` before
+acting on it; if not (or the field is absent), fall back to legacy routing.
+
+### Ranking algorithms
+
+| Value | Meaning |
+| --- | --- |
+| `SR_BASED_ROUTING` | Success-rate based. The default for smart card routing. Requires a success-rate config (see local-setup). |
+| `PL_BASED_ROUTING` | Priority-logic based: evaluates the merchant's active priority rule and returns the ordered connectors. |
+| `NTW_BASED_ROUTING` | Debit-network based; needs `co_badged_card_data` in `metadata` and the merchant debit-routing flag enabled. |
+| `NTW_SR_HYBRID_ROUTING` | Combines debit/network metadata with SR scoring. |
+
+### routing_approach values
+
+Returned for SR routing — log them, they explain the decision:
+
+- `SR_SELECTION_V3_ROUTING` — best eligible gateway by SR score.
+- `SR_V3_DOWNTIME_ROUTING` — some gateways deprioritized due to downtime.
+- `SR_V3_ALL_DOWNTIME_ROUTING` — all eligible down; best degraded option chosen.
+- `SR_V3_HEDGING` / `SR_V3_DOWNTIME_HEDGING` / `SR_V3_ALL_DOWNTIME_HEDGING` —
+  exploration modes.
+- `PRIORITY_LOGIC` — chosen by priority rule (`PL_BASED_ROUTING`).
+- `NTW_BASED_ROUTING` — chosen by debit-network routing.
+
+## POST /update-gateway-score
+
+Reports the terminal outcome so the SR model learns. Call after Authorize/Charge
+returns a final status.
+
+### update-gateway-score request
+
+```json
+{
+  "merchantId": "merchant_demo",
+  "gateway": "stripe",
+  "gatewayReferenceId": null,
+  "status": "CHARGED",
+  "paymentId": "attempt_abc123",
+  "enforceDynamicRoutingFailure": null
+}
+```
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `merchantId` | string | yes | Same merchant as the decide call. |
+| `gateway` | string | yes | The PSP you actually charged. |
+| `paymentId` | string | yes | **Must equal** the `paymentInfo.paymentId` sent to `decide-gateway`. |
+| `status` | enum | yes | Terminal `TxnStatus` — see below. |
+| `gatewayReferenceId` | string | optional | If you route by a specific gateway MID/reference. |
+| `enforceDynamicRoutingFailure` | bool | optional | Force-count as a routing failure; usually `null`. |
+| `txnLatency` | object | optional | `{ "gatewayLatency": <ms> }` if you measure PSP latency. |
+
+Success response body is the literal:
+
+```
+Success
+```
+
+(A JSON `{message, merchantId, gateway, paymentId}` may be returned depending on
+version; treat HTTP 200 as success.)
+
+### TxnStatus values
+
+Map your PSP's terminal outcome to one of these. The ones that matter for card
+auth feedback:
+
+| Category | Values | Send when |
+| --- | --- | --- |
+| Success | `CHARGED`, `AUTHORIZED`, `PARTIAL_CHARGED` | Payment authorized/captured. `CHARGED` = captured, `AUTHORIZED` = auth-only. |
+| Failure | `AUTHORIZATION_FAILED`, `FAILURE`, `DECLINED`, `JUSPAY_DECLINED`, `AUTHENTICATION_FAILED` | PSP declined / auth failed / 3DS failed. `AUTHORIZATION_FAILED` is the common card-decline case. |
+| **Do NOT send (non-terminal)** | `STARTED`, `PENDING`, `PENDING_VBV`, `AUTHORIZING`, `TO_BE_CHARGED`, `CAPTURE_INITIATED`, `VOID_INITIATED` | Wait for a terminal state first. |
+
+Full enum (for reference): `STARTED`, `AUTHENTICATION_FAILED`,
+`JUSPAY_DECLINED`, `PENDING_VBV`, `VBV_SUCCESSFUL`, `AUTHORIZED`,
+`AUTHORIZATION_FAILED`, `CHARGED`, `AUTHORIZING`, `COD_INITIATED`, `VOIDED`,
+`VOID_INITIATED`, `NOP`, `CAPTURE_INITIATED`, `CAPTURE_FAILED`, `VOID_FAILED`,
+`AUTO_REFUNDED`, `PARTIAL_CHARGED`, `TO_BE_CHARGED`, `PENDING`, `FAILURE`,
+`DECLINED`.
+
+## Debit / network routing & the BIN metadata
+
+For `NTW_BASED_ROUTING` / `NTW_SR_HYBRID_ROUTING`, the debit inputs go inside
+`paymentInfo.metadata` as a **stringified JSON**, and the merchant debit-routing
+flag must be enabled first (`POST /merchant-account/:merchant-id/debit-routing`).
+
+```json
+"metadata": "{\"merchant_category_code\":\"merchant_category_code_0001\",\"acquirer_country\":\"US\",\"co_badged_card_data\":{\"co_badged_card_networks\":[\"VISA\",\"NYCE\",\"PULSE\",\"STAR\"],\"issuer_country\":\"US\",\"is_regulated\":false,\"regulated_name\":null,\"card_type\":\"debit\"}}"
+```
+
+The response then carries `debit_routing_output` with per-network
+`saving_percentage`. **Important feedback rule:** for `NTW_BASED_ROUTING` runs
+where `decided_gateway` is the selected *network* (not the PSP you charged), do
+**not** call `update-gateway-score` for that run — it would corrupt SR data.
+
+## Error shape
+
+On a bad request the endpoints return an `ErrorResponse`:
+
+```json
+{
+  "status": "400",
+  "error_code": "400",
+  "error_message": "Error parsing request",
+  "error_info": {
+    "code": "INVALID_INPUT",
+    "user_message": "Invalid request params. Please verify your input.",
+    "developer_message": "<detail>"
+  },
+  "priority_logic_output": null,
+  "is_dynamic_mga_enabled": false
+}
+```
+
+Treat any non-2xx (or a body without a usable `decided_gateway`) as a signal to
+**fail open** to legacy routing rather than blocking the payment.
+
+## Where these come from in the source
+
+If you have the Decision Engine repo checked out and need to verify a field:
+
+- Routes registered in `src/app.rs` (`/decide-gateway`, `/update-gateway-score`).
+- `decide-gateway` request: `DomainDeciderRequestForApiCallV2` / `PaymentInfo`
+  in `src/decider/gatewaydecider/types.rs`.
+- `update-gateway-score` request: `UpdateScorePayload` in `src/feedback/types.rs`.
+- `TxnStatus` enum: `src/types/txn_details/types.rs`.
+- Worked curl examples: `docs/api-refs/decide-gateway-*.mdx` and
+  `docs/api-refs/update-gateway-score.mdx`.

--- a/skills/decision-engine-integration/references/api-contract.md
+++ b/skills/decision-engine-integration/references/api-contract.md
@@ -1,7 +1,16 @@
 # Decision Engine API Contract
 
 Everything the orchestrator client needs for the two integration endpoints.
-Fields are the exact wire names (camelCase). All bodies are JSON.
+All bodies are JSON.
+
+**Casing matters and is not uniform.** Request bodies use **camelCase**
+(`merchantId`, `paymentInfo`, `cardIsin`, `rankingAlgorithm`). The
+`/decide-gateway` **response uses snake_case** (`decided_gateway`,
+`gateway_priority_map`, `routing_approach`, `priority_logic_output`) — with the
+exception of the nested `priority_logic_output` object, whose inner keys are
+camelCase (`isEnforcement`, `gws`, `priorityLogicTag`, `gatewayReferenceIds`).
+Field names below are given exactly as they appear on the wire; deserialize
+against these, not a normalized guess.
 
 ## Table of contents
 

--- a/skills/decision-engine-integration/references/local-setup.md
+++ b/skills/decision-engine-integration/references/local-setup.md
@@ -1,0 +1,134 @@
+# Running Decision Engine locally
+
+Only do this if the user does **not** already have a Decision Engine instance to
+point the orchestrator at. If they do (self-hosted, staging, or Hyperswitch
+sandbox), skip straight to bootstrapping the merchant + API key against that host.
+
+## 1. Get the service running
+
+The fastest path is Docker Compose with a Postgres profile.
+
+```bash
+git clone https://github.com/juspay/decision-engine.git
+cd decision-engine
+
+# API only, prebuilt images, Postgres:
+docker compose --profile postgres-ghcr up -d
+
+# API + dashboard + docs (nice for exploring):
+docker compose --profile dashboard-postgres-ghcr up -d
+```
+
+The API comes up at `http://localhost:8080`. With the dashboard profile you also
+get the dashboard at `http://localhost:8081/dashboard/` and API docs at
+`http://localhost:8081/api-overview`.
+
+Profile cheat sheet (`--profile <name>`):
+
+| Profile | What you get |
+| --- | --- |
+| `postgres-ghcr` / `mysql-ghcr` | API only, prebuilt image, Postgres/MySQL. |
+| `postgres-local` / `mysql-local` | API only, built from local source. |
+| `dashboard-postgres-ghcr` (etc.) | API + dashboard + docs + nginx. |
+| `monitoring` | Prometheus/Grafana. |
+
+There is also a guided `./oneclick.sh` in the repo root that provisions
+dependencies (Postgres, Redis, ClickHouse, Kafka) and opens the docs — handy for
+a from-source run. From-source needs Rust 1.85+, a DB, and Redis; see the repo
+README.
+
+Verify:
+
+```bash
+curl -sS http://localhost:8080/health          # 200
+curl -sS http://localhost:8080/health/ready     # 200 once DB + Redis are ready
+```
+
+## 2. Bootstrap a merchant (gets you an API key)
+
+Merchant creation is the admin-bootstrap route. The local default admin secret in
+`config/development.toml` is `test_admin` (override for any real deployment).
+
+```bash
+export BASE_URL=http://localhost:8080
+
+curl -sS --location "$BASE_URL/merchant-account/create" \
+  --header "x-admin-secret: test_admin" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "merchant_id": "merchant_demo",
+    "gateway_success_rate_based_decider_input": null
+  }'
+```
+
+The response includes an `api_key` (prefixed `DE_`). Save it — that's the
+`x-api-key` your orchestrator will send:
+
+```json
+{ "message": "Merchant account created successfully",
+  "merchant_id": "merchant_demo", "api_key": "DE_..." }
+```
+
+Need another key later:
+
+```bash
+curl -sS "$BASE_URL/api-key/create" \
+  --header "x-api-key: DE_..." \
+  --header "Content-Type: application/json" \
+  --data '{ "merchant_id": "merchant_demo", "description": "orchestrator key" }'
+```
+
+## 3. Give the merchant something to route with
+
+`SR_BASED_ROUTING` needs a success-rate config, and you generally want an
+eligible gateway set. Create a success-rate config:
+
+```bash
+export AUTH="x-api-key: DE_..."
+
+curl -sS --location "$BASE_URL/rule/create" \
+  --header "$AUTH" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "merchant_id": "merchant_demo",
+    "config": {
+      "type": "successRate",
+      "data": {
+        "defaultBucketSize": 20,
+        "defaultLatencyThreshold": null,
+        "defaultHedgingPercent": null,
+        "subLevelInputConfig": {
+          "paymentMethodType": { "CARD": { "bucketSize": 30, "hedgingPercent": 0.05 } }
+        }
+      }
+    }
+  }'
+```
+
+Optionally create + activate a priority routing rule (for `PL_BASED_ROUTING`) via
+`POST /routing/create` then `POST /routing/activate` — see
+`docs/api-refs/routing-algorithm-*.mdx` in the Decision Engine repo.
+
+## 4. Smoke test the round trip
+
+Use [../scripts/smoke_test.sh](../scripts/smoke_test.sh):
+
+```bash
+DECISION_ENGINE_URL=http://localhost:8080 \
+ADMIN_SECRET=test_admin \
+MERCHANT_ID=merchant_demo \
+bash scripts/smoke_test.sh
+```
+
+It bootstraps (if needed), creates an SR config, calls `decide-gateway`, then
+`update-gateway-score`, and prints a PASS/FAIL summary. When it passes, hand the
+`DECISION_ENGINE_URL`, `x-api-key`, and `merchant_id` to Phase 4 of the main
+workflow.
+
+## Notes
+
+- Fresh merchants have no SR history, so early `decide-gateway` calls fall back
+  to configured priority/first-eligible until `update-gateway-score` feedback
+  accumulates. This is expected — the model warms up.
+- For anything beyond local testing, change the admin secret, use real secrets
+  management, and put the service behind TLS. The defaults here are for local dev.

--- a/skills/decision-engine-integration/references/testing-and-evals.md
+++ b/skills/decision-engine-integration/references/testing-and-evals.md
@@ -44,9 +44,14 @@ ready regardless of the rest.
 Against a real/local Decision Engine, run [../scripts/smoke_test.sh](../scripts/smoke_test.sh)
 (bootstrap → decide → score) and
 [../scripts/certify_integration.py](../scripts/certify_integration.py), which
-asserts contract invariants: `decided_gateway ∈ eligibleGatewayList`, decide is
-idempotent-safe, score accepts the same `paymentId`, and a malformed request is
-rejected with the documented error shape.
+asserts contract invariants: `decided_gateway ∈ eligibleGatewayList`, that
+`update-gateway-score` accepts the same `paymentId` and can be called again for
+that id without erroring (score is idempotent-safe for retries), and that a
+malformed request is rejected with the documented error shape so the
+orchestrator's fail-open branch is actually reachable. It does **not** re-run
+`decide-gateway` to compare outputs — SR routing is intentionally
+non-deterministic (exploration/hedging), so a stable-output assertion there
+would be wrong.
 
 ## Part 3 — AI eval rubric (LLM-as-judge)
 

--- a/skills/decision-engine-integration/references/testing-and-evals.md
+++ b/skills/decision-engine-integration/references/testing-and-evals.md
@@ -1,0 +1,117 @@
+# Certifying the integration: tests + AI evals
+
+A Decision Engine integration touches the live money path, so "it compiled" is
+not the bar. Certify it two ways:
+
+1. **Behavioral tests** — deterministic tests you add to the orchestrator's own
+   suite that prove the integration behaves correctly, including when Decision
+   Engine misbehaves.
+2. **AI evals** — an LLM-as-judge rubric that grades the *integration code* for
+   the correctness and safety properties that are easy to get subtly wrong.
+
+Do both. The tests catch regressions; the eval catches design mistakes a passing
+test wouldn't (e.g. blocking payments when DE is down).
+
+## Part 1 — Behavioral test matrix
+
+Implement each of these against the orchestrator's payment flow, mocking the
+Decision Engine HTTP client and the PSP client. Names are suggestions; adapt to
+the repo's test framework.
+
+| # | Test | Setup | Assert |
+| --- | --- | --- | --- |
+| T1 | `decide_gateway_chooses_returned_psp` | DE returns `decided_gateway: "adyen"` | Orchestrator authorizes against **adyen**. |
+| T2 | `decide_gateway_sends_card_bin` | Capture the outgoing DE request | `paymentInfo.cardIsin` equals the BIN from the Vault token metadata; **no PAN / full token** anywhere in the body. |
+| T3 | `fallback_order_used_on_primary_failure` | DE returns priority `["stripe","adyen"]`; stripe auth fails | Orchestrator retries **adyen** (if retry is in scope) per the returned order. |
+| T4 | `fail_open_when_de_unreachable` | DE client throws / times out | Payment still authorizes via **legacy routing**; no exception surfaces to the customer. |
+| T5 | `fail_open_on_de_error_response` | DE returns HTTP 400/500 or a body with no `decided_gateway` | Same as T4 — legacy routing, payment proceeds. |
+| T6 | `fail_open_on_ineligible_gateway` | DE returns a `decided_gateway` **not** in `eligibleGatewayList` | Orchestrator ignores it and falls back. |
+| T7 | `score_reports_terminal_success` | PSP returns captured | `update-gateway-score` called once with matching `paymentId`, `gateway`, and `status: CHARGED` (or `AUTHORIZED`). |
+| T8 | `score_reports_terminal_failure` | PSP declines | Score called with `status: AUTHORIZATION_FAILED` (or mapped failure). |
+| T9 | `score_not_sent_for_pending` | PSP returns pending/authorizing | **No** score call until a terminal outcome. |
+| T10 | `score_paymentid_matches_decide` | Full round trip | The `paymentId` in the score call is byte-identical to the one in the decide call. |
+| T11 | `score_failure_does_not_fail_payment` | `update-gateway-score` throws | Payment result is unaffected (score is out-of-band / best-effort). |
+| T12 | `kill_switch_disables_integration` | Feature flag off | Neither DE endpoint is called; legacy routing used. |
+| T13 | `debit_network_skip` (only if debit routing used) | `NTW_BASED_ROUTING` run where `decided_gateway` is a network | No `update-gateway-score` call for that run. |
+| T14 | `decide_timeout_is_bounded` | DE delays beyond the timeout | Client aborts within the configured budget and falls back (no unbounded wait in the auth path). |
+
+The non-negotiables are **T4/T5/T6 (fail-open)**, **T2 (BIN not PAN)**, and
+**T10 (paymentId attribution)**. If any of those fail, the integration is not
+ready regardless of the rest.
+
+## Part 2 — Live round-trip check
+
+Against a real/local Decision Engine, run [../scripts/smoke_test.sh](../scripts/smoke_test.sh)
+(bootstrap → decide → score) and
+[../scripts/certify_integration.py](../scripts/certify_integration.py), which
+asserts contract invariants: `decided_gateway ∈ eligibleGatewayList`, decide is
+idempotent-safe, score accepts the same `paymentId`, and a malformed request is
+rejected with the documented error shape.
+
+## Part 3 — AI eval rubric (LLM-as-judge)
+
+Use this to grade the integration diff/code. Point an agent at the changed files
+and the rubric below; have it return a per-criterion PASS/FAIL with a one-line
+evidence quote (file:line) for each. This catches design-level issues that unit
+tests may not.
+
+Score each criterion 0/1. **A failure on any "critical" item = the integration
+does not pass, regardless of total score.**
+
+```
+CRITICAL (any fail blocks release):
+[C1] Fail-open: every path where decide-gateway errors, times out, or returns an
+     unusable/ineligible gateway falls back to legacy routing and lets the
+     payment proceed. No path lets a routing-brain problem block or error a
+     payment. (evidence: file:line)
+[C2] No PAN / no raw token is sent to Decision Engine. Only the BIN (cardIsin)
+     and non-sensitive metadata cross the boundary. (evidence)
+[C3] The decide-gateway call has a bounded timeout appropriate for the live auth
+     path (roughly ≤300ms), not a default/infinite client timeout. (evidence)
+[C4] update-gateway-score uses the SAME paymentId that was sent to
+     decide-gateway, and the same gateway that was actually charged. (evidence)
+[C5] A failing/slow update-gateway-score call cannot fail or delay the payment
+     (it is async / fire-and-forget / queued / best-effort). (evidence)
+
+IMPORTANT (fails count against the grade):
+[I1] update-gateway-score is only sent on TERMINAL outcomes; non-terminal states
+     (PENDING/AUTHORIZING/etc.) are not reported. (evidence)
+[I2] Success/failure are mapped to valid TxnStatus values
+     (CHARGED/AUTHORIZED vs AUTHORIZATION_FAILED/FAILURE/…). (evidence)
+[I3] There is a kill-switch / feature flag to disable the integration and revert
+     to legacy routing without a code change. (evidence)
+[I4] The returned decided_gateway is validated against eligibleGatewayList before
+     use. (evidence)
+[I5] Config (URL, api key, merchantId, timeout) is externalized, not hard-coded;
+     the api key is handled as a secret. (evidence)
+[I6] eligibleGatewayList reflects the gateways actually valid for THIS payment,
+     not a stale global list.
+
+HYGIENE (nice to have):
+[H1] routing_approach / decision is logged for observability and debugging.
+[H2] The DE client matches the codebase's existing HTTP/client conventions
+     (retries, tracing, error types) rather than a bespoke one-off.
+[H3] The debit-network skip rule is honored if debit routing is in scope.
+[H4] Tests from the matrix above exist and cover at least the CRITICAL items.
+
+Output format, one line per item:
+  [C1] PASS — <quote> (path/to/file.ext:NN)
+  [C2] FAIL — <what's missing or wrong> (path/to/file.ext:NN)
+Then: VERDICT: PASS only if all CRITICAL pass; otherwise FAIL, listing the
+critical failures.
+```
+
+### Running the eval as a subagent (optional)
+
+If the coding agent supports subagents, spawn a fresh one with the rubric and the
+list of changed files so the judgment is independent of the author. Otherwise run
+the rubric inline as a final self-review pass before declaring the integration
+done. Report the verdict to the user with the evidence lines — don't just say
+"looks good."
+
+## What "certified" means
+
+Report the integration as ready only when: all CRITICAL rubric items pass, the
+fail-open + BIN + paymentId-attribution tests (T2, T4, T5, T6, T10) pass, and the
+live smoke test round-trips successfully. Anything short of that, say so
+explicitly and list what's outstanding.

--- a/skills/decision-engine-integration/scripts/certify_integration.py
+++ b/skills/decision-engine-integration/scripts/certify_integration.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+certify_integration.py — contract-level certification of a live Decision Engine.
+
+Exercises /decide-gateway and /update-gateway-score against a running instance
+and asserts the invariants an orchestrator integration relies on:
+
+  1. decide-gateway returns a decided_gateway that is IN the eligible list.
+  2. The same paymentId is accepted by update-gateway-score.
+  3. A malformed request is rejected (documented error shape), not silently
+     accepted — so the orchestrator's fail-open branch is actually reachable.
+  4. update-gateway-score is idempotent-safe for the same paymentId (a second
+     call does not error).
+
+This certifies the ENGINE side of the contract. The orchestrator-side behavior
+(fail-open, BIN-not-PAN, paymentId reuse) is certified by the behavioral test
+matrix in references/testing-and-evals.md.
+
+Usage:
+  DECISION_ENGINE_URL=http://localhost:8080 \
+  API_KEY=DE_xxx \
+  MERCHANT_ID=merchant_demo \
+  python3 certify_integration.py
+
+Only depends on the Python standard library.
+"""
+import json
+import os
+import sys
+import time
+import urllib.request
+import urllib.error
+
+BASE = os.environ.get("DECISION_ENGINE_URL", "http://localhost:8080").rstrip("/")
+API_KEY = os.environ.get("API_KEY", "")
+MERCHANT_ID = os.environ.get("MERCHANT_ID", "merchant_demo")
+ELIGIBLE = json.loads(os.environ.get("ELIGIBLE", '["stripe","adyen","checkout"]'))
+
+results = []
+
+
+def record(name, ok, detail=""):
+    results.append((name, ok, detail))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
+
+
+def call(path, body, extra_headers=None):
+    headers = {"Content-Type": "application/json"}
+    if API_KEY:
+        headers["x-api-key"] = API_KEY
+    if extra_headers:
+        headers.update(extra_headers)
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(BASE + path, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            raw = r.read().decode()
+            try:
+                return r.status, json.loads(raw)
+            except json.JSONDecodeError:
+                return r.status, raw
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            return e.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return e.code, raw
+
+
+def main():
+    if not API_KEY:
+        print("API_KEY is required (x-api-key). Set API_KEY=DE_...", file=sys.stderr)
+        sys.exit(2)
+
+    payment_id = f"cert_{int(time.time())}"
+    print(f"Certifying {BASE} for merchant '{MERCHANT_ID}' (paymentId={payment_id})\n")
+
+    # 1. decide-gateway happy path -------------------------------------------
+    status, body = call("/decide-gateway", {
+        "merchantId": MERCHANT_ID,
+        "eligibleGatewayList": ELIGIBLE,
+        "rankingAlgorithm": "SR_BASED_ROUTING",
+        "eliminationEnabled": True,
+        "paymentInfo": {
+            "paymentId": payment_id, "amount": 1000, "currency": "USD",
+            "country": "US", "paymentType": "ORDER_PAYMENT",
+            "paymentMethodType": "CARD", "paymentMethod": "CREDIT",
+            "authType": "THREE_DS", "cardIsin": "424242",
+        },
+    })
+    decided = body.get("decided_gateway") if isinstance(body, dict) else None
+    record("decide-gateway returns 200", status == 200, f"status={status}")
+    record("decided_gateway present", bool(decided), f"decided_gateway={decided}")
+    record("decided_gateway is eligible", decided in ELIGIBLE if decided else False,
+           f"{decided} in {ELIGIBLE}")
+
+    gateway = decided if decided in ELIGIBLE else ELIGIBLE[0]
+
+    # 2. update-gateway-score with the SAME paymentId ------------------------
+    status, body = call("/update-gateway-score", {
+        "merchantId": MERCHANT_ID, "gateway": gateway,
+        "gatewayReferenceId": None, "status": "CHARGED",
+        "paymentId": payment_id, "enforceDynamicRoutingFailure": None,
+    })
+    record("update-gateway-score accepts same paymentId", status == 200, f"status={status}")
+
+    # 3. idempotency-safe second score ---------------------------------------
+    status2, _ = call("/update-gateway-score", {
+        "merchantId": MERCHANT_ID, "gateway": gateway,
+        "gatewayReferenceId": None, "status": "CHARGED",
+        "paymentId": payment_id, "enforceDynamicRoutingFailure": None,
+    })
+    record("repeat score call does not error", status2 == 200, f"status={status2}")
+
+    # 4. malformed request is rejected (fail-open path is reachable) ---------
+    status, body = call("/decide-gateway", {"merchantId": MERCHANT_ID})  # missing paymentInfo
+    is_error = status >= 400
+    record("malformed decide-gateway rejected (>=400)", is_error, f"status={status}")
+
+    # summary ----------------------------------------------------------------
+    failed = [n for n, ok, _ in results if not ok]
+    print()
+    if failed:
+        print(f"CERTIFY: FAIL ({len(failed)} failing) -> {', '.join(failed)}")
+        sys.exit(1)
+    print(f"CERTIFY: PASS ({len(results)} checks)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/decision-engine-integration/scripts/certify_integration.py
+++ b/skills/decision-engine-integration/scripts/certify_integration.py
@@ -65,6 +65,11 @@ def call(path, body, extra_headers=None):
             return e.code, json.loads(raw)
         except json.JSONDecodeError:
             return e.code, raw
+    except urllib.error.URLError as e:
+        # Engine unreachable (connection refused / DNS / TLS). Surface a clean
+        # sentinel instead of a stack trace — a certifier that can't reach the
+        # engine should report FAIL, not crash.
+        return 0, {"error": f"unreachable: {e.reason}"}
 
 
 def main():

--- a/skills/decision-engine-integration/scripts/smoke_test.sh
+++ b/skills/decision-engine-integration/scripts/smoke_test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# smoke_test.sh — end-to-end round trip against a running Decision Engine.
+#
+# Proves the integration path: bootstrap merchant + API key (if needed),
+# create an SR config, call /decide-gateway, then /update-gateway-score.
+# Prints a PASS/FAIL summary. Read-only against your data except for creating
+# the demo merchant / SR config the first time.
+#
+# Usage:
+#   DECISION_ENGINE_URL=http://localhost:8080 \
+#   ADMIN_SECRET=test_admin \
+#   MERCHANT_ID=merchant_demo \
+#   [API_KEY=DE_xxx] \
+#   [ELIGIBLE='["stripe","adyen","checkout"]'] \
+#   bash smoke_test.sh
+#
+set -uo pipefail
+
+BASE_URL="${DECISION_ENGINE_URL:-http://localhost:8080}"
+ADMIN_SECRET="${ADMIN_SECRET:-test_admin}"
+MERCHANT_ID="${MERCHANT_ID:-merchant_demo}"
+API_KEY="${API_KEY:-}"
+ELIGIBLE="${ELIGIBLE:-[\"stripe\",\"adyen\",\"checkout\"]}"
+PAYMENT_ID="smoke_$(date +%s)_$RANDOM"
+
+pass=0; fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+hr()   { echo "----------------------------------------------------------------"; }
+
+echo "Decision Engine smoke test"
+echo "  base   : $BASE_URL"
+echo "  merchant: $MERCHANT_ID"
+echo "  paymentId: $PAYMENT_ID"
+hr
+
+# 1. Health -------------------------------------------------------------------
+code=$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/health")
+[ "$code" = "200" ] && ok "health 200" || { bad "health returned $code"; echo "Is Decision Engine running at $BASE_URL?"; exit 1; }
+
+# 2. Merchant + API key -------------------------------------------------------
+if [ -z "$API_KEY" ]; then
+  echo "No API_KEY provided; bootstrapping merchant '$MERCHANT_ID'..."
+  resp=$(curl -s --location "$BASE_URL/merchant-account/create" \
+    --header "x-admin-secret: $ADMIN_SECRET" \
+    --header "Content-Type: application/json" \
+    --data "{\"merchant_id\":\"$MERCHANT_ID\",\"gateway_success_rate_based_decider_input\":null}")
+  API_KEY=$(printf '%s' "$resp" | grep -o '"api_key"[^,}]*' | head -1 | sed 's/.*: *"//;s/"//')
+  if [ -n "$API_KEY" ]; then
+    ok "created merchant, got api key ${API_KEY:0:8}..."
+  else
+    echo "  (merchant may already exist; response: $resp)"
+    echo "  Re-run with API_KEY=DE_... to continue."
+    exit 1
+  fi
+fi
+AUTH="x-api-key: $API_KEY"
+
+# 3. SR config (idempotent-ish; ignore 'already exists') ----------------------
+curl -s --location "$BASE_URL/rule/create" \
+  --header "$AUTH" --header "Content-Type: application/json" \
+  --data "{\"merchant_id\":\"$MERCHANT_ID\",\"config\":{\"type\":\"successRate\",\"data\":{\"defaultBucketSize\":20,\"defaultLatencyThreshold\":null,\"defaultHedgingPercent\":null,\"subLevelInputConfig\":{\"paymentMethodType\":{\"CARD\":{\"bucketSize\":30,\"hedgingPercent\":0.05}}}}}}" \
+  >/dev/null 2>&1
+ok "SR config ensured"
+
+hr
+# 4. decide-gateway -----------------------------------------------------------
+decide_body="{\"merchantId\":\"$MERCHANT_ID\",\"eligibleGatewayList\":$ELIGIBLE,\"rankingAlgorithm\":\"SR_BASED_ROUTING\",\"eliminationEnabled\":true,\"paymentInfo\":{\"paymentId\":\"$PAYMENT_ID\",\"amount\":1000,\"currency\":\"USD\",\"country\":\"US\",\"paymentType\":\"ORDER_PAYMENT\",\"paymentMethodType\":\"CARD\",\"paymentMethod\":\"CREDIT\",\"authType\":\"THREE_DS\",\"cardIsin\":\"424242\"}}"
+
+decide_resp=$(curl -s --location "$BASE_URL/decide-gateway" \
+  --header "$AUTH" --header "Content-Type: application/json" --data "$decide_body")
+echo "decide-gateway response:"
+echo "  $decide_resp"
+
+decided=$(printf '%s' "$decide_resp" | grep -o '"decided_gateway"[^,}]*' | head -1 | sed 's/.*: *"//;s/"//')
+if [ -n "$decided" ] && [ "$decided" != "null" ]; then
+  ok "decided_gateway = $decided"
+  case "$ELIGIBLE" in
+    *"\"$decided\""*) ok "decided_gateway is within eligibleGatewayList" ;;
+    *) bad "decided_gateway '$decided' NOT in eligibleGatewayList" ;;
+  esac
+else
+  bad "no decided_gateway returned"
+  decided="stripe"
+fi
+
+hr
+# 5. update-gateway-score -----------------------------------------------------
+score_body="{\"merchantId\":\"$MERCHANT_ID\",\"gateway\":\"$decided\",\"gatewayReferenceId\":null,\"status\":\"CHARGED\",\"paymentId\":\"$PAYMENT_ID\",\"enforceDynamicRoutingFailure\":null}"
+score_code=$(curl -s -o /tmp/de_score_out -w '%{http_code}' --location "$BASE_URL/update-gateway-score" \
+  --header "$AUTH" --header "Content-Type: application/json" --data "$score_body")
+echo "update-gateway-score -> HTTP $score_code, body: $(cat /tmp/de_score_out)"
+[ "$score_code" = "200" ] && ok "score accepted (same paymentId)" || bad "score returned $score_code"
+
+hr
+echo "SUMMARY: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] && { echo "SMOKE TEST: PASS"; exit 0; } || { echo "SMOKE TEST: FAIL"; exit 1; }

--- a/skills/decision-engine-integration/scripts/smoke_test.sh
+++ b/skills/decision-engine-integration/scripts/smoke_test.sh
@@ -57,12 +57,19 @@ if [ -z "$API_KEY" ]; then
 fi
 AUTH="x-api-key: $API_KEY"
 
-# 3. SR config (idempotent-ish; ignore 'already exists') ----------------------
-curl -s --location "$BASE_URL/rule/create" \
+# 3. SR config (idempotent-ish; a repeat "already exists" is fine) ------------
+sr_out=$(mktemp)
+sr_code=$(curl -s -o "$sr_out" -w '%{http_code}' --location "$BASE_URL/rule/create" \
   --header "$AUTH" --header "Content-Type: application/json" \
-  --data "{\"merchant_id\":\"$MERCHANT_ID\",\"config\":{\"type\":\"successRate\",\"data\":{\"defaultBucketSize\":20,\"defaultLatencyThreshold\":null,\"defaultHedgingPercent\":null,\"subLevelInputConfig\":{\"paymentMethodType\":{\"CARD\":{\"bucketSize\":30,\"hedgingPercent\":0.05}}}}}}" \
-  >/dev/null 2>&1
-ok "SR config ensured"
+  --data "{\"merchant_id\":\"$MERCHANT_ID\",\"config\":{\"type\":\"successRate\",\"data\":{\"defaultBucketSize\":20,\"defaultLatencyThreshold\":null,\"defaultHedgingPercent\":null,\"subLevelInputConfig\":{\"paymentMethodType\":{\"CARD\":{\"bucketSize\":30,\"hedgingPercent\":0.05}}}}}}")
+sr_body=$(cat "$sr_out"); rm -f "$sr_out"
+if [ "$sr_code" = "200" ] || [ "$sr_code" = "201" ]; then
+  ok "SR config created"
+elif printf '%s' "$sr_body" | grep -qi 'exist'; then
+  ok "SR config already present"
+else
+  bad "SR config create failed (HTTP $sr_code): $sr_body"
+fi
 
 hr
 # 4. decide-gateway -----------------------------------------------------------
@@ -88,9 +95,11 @@ fi
 hr
 # 5. update-gateway-score -----------------------------------------------------
 score_body="{\"merchantId\":\"$MERCHANT_ID\",\"gateway\":\"$decided\",\"gatewayReferenceId\":null,\"status\":\"CHARGED\",\"paymentId\":\"$PAYMENT_ID\",\"enforceDynamicRoutingFailure\":null}"
-score_code=$(curl -s -o /tmp/de_score_out -w '%{http_code}' --location "$BASE_URL/update-gateway-score" \
+score_out=$(mktemp)
+score_code=$(curl -s -o "$score_out" -w '%{http_code}' --location "$BASE_URL/update-gateway-score" \
   --header "$AUTH" --header "Content-Type: application/json" --data "$score_body")
-echo "update-gateway-score -> HTTP $score_code, body: $(cat /tmp/de_score_out)"
+echo "update-gateway-score -> HTTP $score_code, body: $(cat "$score_out")"
+rm -f "$score_out"
 [ "$score_code" = "200" ] && ok "score accepted (same paymentId)" || bad "score returned $score_code"
 
 hr


### PR DESCRIPTION
## What

Adds a Claude skill — `skills/decision-engine-integration/` — that a merchant drops into their own orchestration repo (`.claude/skills/`) and hands to their coding agent to wire a **self-hosted Decision Engine** into their payment orchestrator via **`decide-gateway`** and **`update-gateway-score`**.

## Why

Self-hosting merchants need a repeatable, safe way to delegate PSP selection to Decision Engine from their in-house orchestration. This codifies the integration (Vault-tokenized checkout → BIN + metadata → decide-gateway → authorize → score feedback) so it's not re-derived by hand each time.

## Contents (7 files)

- `SKILL.md` — 6-phase workflow: confirm reachable → discover the authorize/charge path → insert `decide-gateway` before PSP selection → insert `update-gateway-score` after the terminal outcome → config/kill-switch → certify.
- `references/api-contract.md` — exact request/response schemas, ranking algorithms, full `TxnStatus` table, debit `co_badged_card_data` metadata, error shape. Grounded in `src/decider/gatewaydecider/types.rs`, `src/feedback/types.rs`, `src/types/txn_details/types.rs`, `src/app.rs`.
- `references/local-setup.md` — docker-compose bring-up + merchant/API-key/SR-config bootstrap (skippable if DE already runs).
- `references/testing-and-evals.md` — 14-case behavioral test matrix + LLM-as-judge rubric (CRITICAL/IMPORTANT/HYGIENE).
- `scripts/smoke_test.sh`, `scripts/certify_integration.py` — runnable round-trip + contract certification (stdlib only).

## Design non-negotiables baked in

- **Fail-open** — a Decision Engine outage must never block a payment.
- **BIN, not PAN** — only `cardIsin` + non-sensitive metadata cross the boundary; PAN/raw token never sent.
- **Stable `paymentId`** — reused between decide and score so success-rate feedback attributes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)