### PR TITLE
fix(cost-ingestion): fix clickhouse alb connection timeout issue

### DIFF
--- a/src/cost_ingestion/blended.rs
+++ b/src/cost_ingestion/blended.rs
@@ -140,12 +140,7 @@ fn build_snapshot_filter(scope: &ClusterScope<'_>) -> String {
 
 fn client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(TIMEOUT)
-            .build()
-            .expect("failed to build clickhouse blend client")
-    })
+    CLIENT.get_or_init(|| super::ch_http::client(TIMEOUT))
 }
 
 /// The merchant's highest-GMV GOOD segments ranked by settled volume, narrowed by `scope` (empty =

--- a/src/cost_ingestion/ch_http.rs
+++ b/src/cost_ingestion/ch_http.rs
@@ -1,0 +1,36 @@
+//! Shared HTTP client builder for the cost pipeline's direct ClickHouse calls.
+//!
+//! Unlike the analytics read path (which uses the pooled `clickhouse` crate), the cost pipeline
+//! talks to ClickHouse over hand-rolled `reqwest` requests: `app → ALB → ClickHouse`. These calls
+//! fire infrequently — the serving refresh every 5 min, dashboards on demand — so a pooled keep-alive
+//! connection sits idle between uses. An AWS ALB silently closes idle connections at its idle timeout
+//! (~60s); a connection left idle past that is reaped, and reqwest then hands the *reaped* socket back
+//! from its pool for the next request, which fails at the transport layer with the opaque
+//! `error sending request for url (...)` — the symptom that looked like a ClickHouse outage but was a
+//! stale connection. (See `scratch/repro-ch-stale-conn` for a local reproduction, and note the analytics
+//! `payment-audit` path never hit this because it is used often enough to keep its pool warm.)
+//!
+//! Every cost ClickHouse client is built here so the pool settings can't drift between call sites:
+//! bound the idle-pool lifetime well under the ALB idle timeout and enable TCP keepalive, so a
+//! connection reqwest reuses is either fresh or provably alive — never one the ALB already dropped.
+
+use std::time::Duration;
+
+/// Evict idle pooled connections after this long. Must stay comfortably below the ALB idle timeout
+/// (~60s) so reqwest opens a fresh connection rather than reusing one the load balancer has reaped.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// TCP keepalive so a connection kept between the infrequent cost queries is actively probed rather
+/// than silently going stale.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(15);
+
+/// Build a cost-pipeline ClickHouse HTTP client. Callers pass their own total-request `timeout`
+/// (inserts/fits get a longer budget than reads); the pool/keepalive hardening is shared.
+pub fn client(timeout: Duration) -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .tcp_keepalive(TCP_KEEPALIVE)
+        .build()
+        .expect("failed to build clickhouse cost http client")
+}

--- a/src/cost_ingestion/coverage.rs
+++ b/src/cost_ingestion/coverage.rs
@@ -75,12 +75,7 @@ FORMAT TSV
 
 fn client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(TIMEOUT)
-            .build()
-            .expect("failed to build clickhouse coverage client")
-    })
+    CLIENT.get_or_init(|| super::ch_http::client(TIMEOUT))
 }
 
 /// Coverage of a merchant's latest fitted snapshot across all its connectors/accounts.

--- a/src/cost_ingestion/detect.rs
+++ b/src/cost_ingestion/detect.rs
@@ -133,10 +133,5 @@ pub async fn price_changes(
 
 fn client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(TIMEOUT)
-            .build()
-            .expect("failed to build clickhouse detect client")
-    })
+    CLIENT.get_or_init(|| super::ch_http::client(TIMEOUT))
 }

--- a/src/cost_ingestion/fit.rs
+++ b/src/cost_ingestion/fit.rs
@@ -32,12 +32,7 @@ pub struct FitSummary {
 
 fn client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(FIT_TIMEOUT)
-            .build()
-            .expect("failed to build clickhouse fit client")
-    })
+    CLIENT.get_or_init(|| super::ch_http::client(FIT_TIMEOUT))
 }
 
 /// The OLS fit as nested aggregation. `__DB__` is replaced with the configured database (the

--- a/src/cost_ingestion/mod.rs
+++ b/src/cost_ingestion/mod.rs
@@ -10,6 +10,7 @@
 //! staging, fit, and serving never change.
 
 pub mod blended;
+pub mod ch_http;
 pub mod connectors;
 pub mod coverage;
 pub mod creds;

--- a/src/cost_ingestion/serving.rs
+++ b/src/cost_ingestion/serving.rs
@@ -761,12 +761,7 @@ async fn query(
 
 fn client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(QUERY_TIMEOUT)
-            .build()
-            .expect("failed to build clickhouse serving client")
-    })
+    CLIENT.get_or_init(|| super::ch_http::client(QUERY_TIMEOUT))
 }
 
 #[cfg(test)]

--- a/src/cost_ingestion/sink.rs
+++ b/src/cost_ingestion/sink.rs
@@ -21,6 +21,16 @@ use super::types::IngestError;
 
 const INSERT_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Max buckets per INSERT request. A large or high-cardinality report (e.g. Braintree's free-text
+/// `Interchange Description` → `ic_category`) can roll up into far more buckets than fit comfortably
+/// in one HTTP body. Sending them all at once produced multi-MB requests that could exceed the ~30s
+/// proxy timeout in front of ClickHouse and get the connection reset mid-send — surfacing as an
+/// opaque transport error (`error sending request`) rather than a ClickHouse error. Chunking bounds
+/// each request's size and duration; ~25k JSONEachRow rows is a few MB. Because `cost_daily_stats`
+/// is a `ReplacingMergeTree` keyed by the bucket identity, splitting the buckets across requests is
+/// safe: each bucket is still written exactly once.
+const INSERT_CHUNK_ROWS: usize = 25_000;
+
 /// Columns we provide; `ingested_at` is intentionally omitted so ClickHouse applies its DEFAULT.
 const COLUMNS: &str =
     "connector,account,merchant_id,txn_date,ingestion_id,card_network,variant,funding,\
@@ -28,19 +38,16 @@ issuer_country,currency,ic_category,channel,band,n,sx,sy,sxx,sxy,syy,su,suu,suy,
 
 fn client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(INSERT_TIMEOUT)
-            .build()
-            .expect("failed to build clickhouse sink client")
-    })
+    CLIENT.get_or_init(|| super::ch_http::client(INSERT_TIMEOUT))
 }
 
 /// Bulk-insert one report's aggregated per-day buckets into `cost_daily_stats`, stamped with the
 /// ingestion context. Each bucket's `txn_date` is a transaction (booking) day. `ingestion_id` ties
 /// every bucket to its `cost_ingestion` job so an ingestion can later be deleted. A day re-delivered
 /// by a later report collapses onto the same key — the latest `ingested_at` wins (see the table's
-/// `ReplacingMergeTree` in `035_cost_model.sh`). Returns the number of buckets written.
+/// `ReplacingMergeTree` in `035_cost_model.sh`). The buckets are sent in bounded chunks (see
+/// [`INSERT_CHUNK_ROWS`]) so a large report stays within the request budget. Returns the number of
+/// buckets written.
 pub async fn insert_daily_stats(
     cfg: &ClickHouseAnalyticsConfig,
     connector: &str,
@@ -53,6 +60,24 @@ pub async fn insert_daily_stats(
         return Ok(0);
     }
 
+    // Split into bounded requests so one big report can't exceed the proxy/ClickHouse request budget
+    // (see [`INSERT_CHUNK_ROWS`]). Any chunk failing aborts the whole insert; the buckets already
+    // written are harmless — a re-run overwrites them via the `ReplacingMergeTree` key.
+    for chunk in rows.chunks(INSERT_CHUNK_ROWS) {
+        insert_chunk(cfg, connector, account, merchant_id, ingestion_id, chunk).await?;
+    }
+    Ok(rows.len())
+}
+
+/// Insert one bounded batch of buckets in a single `FORMAT JSONEachRow` request. Caller chunks.
+async fn insert_chunk(
+    cfg: &ClickHouseAnalyticsConfig,
+    connector: &str,
+    account: &str,
+    merchant_id: &str,
+    ingestion_id: &str,
+    rows: &[DailyStatRow],
+) -> Result<(), IngestError> {
     let mut body = String::with_capacity(rows.len() * 256);
     for r in rows {
         let obj = json!({
@@ -110,7 +135,7 @@ pub async fn insert_daily_stats(
             "clickhouse insert failed ({status}): {text}"
         )));
     }
-    Ok(rows.len())
+    Ok(())
 }
 
 /// Delete the daily buckets an ingestion last wrote, identified by its `ingestion_id`, then the

--- a/website/src/components/pages/CostCoverageCard.tsx
+++ b/website/src/components/pages/CostCoverageCard.tsx
@@ -72,8 +72,8 @@ function VerdictTable({ coverage }: { coverage: CoverageSummary }) {
       gross: coverage.thin_gross,
     },
     {
-      verdict: 'NON_LINEAR',
-      note: 'non-linear cost — needs attention',
+      verdict: 'Poor fit',
+      note: 'model failed to converge',
       dot: 'bg-amber-500',
       txns: coverage.non_linear_txns,
       gross: coverage.non_linear_gross,


### PR DESCRIPTION
This pull request introduces two main improvements to the cost ingestion pipeline: (1) it centralizes and hardens the construction of all ClickHouse HTTP clients to avoid issues with stale connections, and (2) it makes the ingestion sink more robust by chunking large bulk-insert requests to stay within proxy and ClickHouse request size/time budgets. There is also a minor UI improvement to clarify a coverage verdict label.

**HTTP client hardening and centralization:**

* A new module, `ch_http`, is added to centralize the construction of all cost pipeline ClickHouse HTTP clients. This ensures consistent use of connection pool settings (short idle timeout and TCP keepalive) to avoid stale connections caused by AWS ALB reaping idle sockets. All cost ingestion modules now use this shared client builder instead of duplicating their own. 

**Bulk-insert robustness:**

* The `insert_daily_stats` function in `sink.rs` now splits large sets of rows into bounded chunks (25,000 rows per request) to avoid oversized HTTP requests that could exceed proxy timeouts and cause transport errors. A new constant, `INSERT_CHUNK_ROWS`, and helper function, `insert_chunk`, are introduced for this purpose. 

**UI improvement:**

* The verdict label in the cost coverage card UI is updated from `'NON_LINEAR'` to `'Poor fit'` with a clearer note, improving user understanding of model convergence issues.