### PR TITLE
feat: add support for sample files in report ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
+ "aws-sdk-s3",
  "aws-sdk-sesv2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ redis_compression = ["dep:zstd"]
 gsm = { path = "crates/gsm", features = ["loader", "s3"] }
 aws-config = { version = "1.5.5" }
 aws-sdk-kms = { version = "1.40.0", optional = true }
+aws-sdk-s3 = { version = "1" }
 aws-sdk-sesv2 = { version = "1" }
 aws-smithy-runtime = { version = "1", features = ["connector-hyper-0-14-x"] }
 aws-smithy-runtime-api = { version = "1" }

--- a/config/development.toml
+++ b/config/development.toml
@@ -102,6 +102,11 @@ creds_encryption_current = "v1"
 report_poll_enabled = false
 # Short interval so a locally-configured pull source is picked up quickly during testing.
 report_poll_interval_secs = 30
+# Curated demo reports for "Use a sample file". Only the bucket and region are configured here;
+# each supported connector's sample is expected at `<connector>_report.csv` (e.g.
+# `chase_report.csv`) and is filed under `acc_<connector>` automatically.
+aws_bucket = ""
+aws_region = ""
 
 [cost_ingestion.creds_encryption_keys]
 # key-id = AES-256 key (hex, 64 chars). Dev-only placeholder; per environment generate with

--- a/src/app.rs
+++ b/src/app.rs
@@ -443,6 +443,12 @@ where
             )),
         )
         .route(
+            // "Use a sample file": run a curated demo report (fetched from configured URL) through
+            // the same pipeline, so a merchant without a report file can still exercise the flow.
+            "/merchant-account/:merchant-id/connectors/:connector/report/sample",
+            post(routes::report_upload::run_sample_report),
+        )
+        .route(
             "/merchant-account/:merchant-id/connectors/:connector/invoice",
             // Invoices are small (a few hundred lines): buffered and processed synchronously, so the
             // computed cost add-on is returned in the response. Cap the body to reject a settlement

--- a/src/config.rs
+++ b/src/config.rs
@@ -318,6 +318,13 @@ pub struct CostIngestionConfig {
     pub report_poll_enabled: bool,
     /// How often the report poller lists reports, in seconds. Reports are daily, so hourly is ample.
     pub report_poll_interval_secs: u64,
+    /// S3 bucket for curated sample reports used by the "Use a sample file" flow. Each connector's
+    /// sample is expected at `<connector>_report.csv` inside this bucket, and is filed under the
+    /// account `acc_<connector>`. If empty, the sample endpoint returns 404.
+    pub aws_bucket: String,
+    /// AWS region for S3 sample downloads. If omitted, the SDK uses the default region provider
+    /// chain (env vars, profile, IMDS, etc.).
+    pub aws_region: Option<String>,
 }
 
 impl Default for CostIngestionConfig {
@@ -330,6 +337,8 @@ impl Default for CostIngestionConfig {
             worker_batch_size: 20,
             report_poll_enabled: false,
             report_poll_interval_secs: 3600,
+            aws_bucket: String::new(),
+            aws_region: None,
         }
     }
 }

--- a/src/cost_ingestion/store.rs
+++ b/src/cost_ingestion/store.rs
@@ -117,6 +117,33 @@ pub async fn create_manual(
     Ok(id)
 }
 
+/// Create a `processing` row for a **sample** run (the "Use a sample file" flow) and return its id.
+/// Identical to [`create_manual`] but tagged `source = "sample"` so history/coverage can label it a
+/// demo run; it still shares the pipeline, progress ticking, and undo path (`delete_ingestion`).
+pub async fn create_sample(
+    merchant_id: &str,
+    connector: &str,
+    account: &str,
+    report_ref: &str,
+) -> Result<String, IngestError> {
+    let app_state = get_tenant_app_state().await;
+    let id = generate_uuid();
+    let new = CostIngestionNew {
+        id: id.clone(),
+        merchant_id: merchant_id.to_string(),
+        connector: connector.to_string(),
+        account: account.to_string(),
+        source: "sample".to_string(),
+        notification_id: None,
+        report_ref: report_ref.to_string(),
+        status: "processing".to_string(),
+    };
+    generics::generic_insert::<<CostIngestion as HasTable>::Table, _>(&app_state.db, new)
+        .await
+        .map_err(|e| IngestError::Storage(e.to_string()))?;
+    Ok(id)
+}
+
 /// Claim up to `limit` pending jobs by compare-and-swapping each `pending → processing`. The CAS
 /// (`WHERE id = ? AND status = 'pending'` affecting exactly one row) makes this safe with multiple
 /// workers without `FOR UPDATE SKIP LOCKED`: a row another worker already flipped updates zero rows

--- a/src/routes/report_upload.rs
+++ b/src/routes/report_upload.rs
@@ -381,7 +381,17 @@ async fn process_sample(
 ) {
     let download_result = fetch_sample_from_s3(&bucket, &key, region.as_deref(), &path).await;
     let result = match download_result {
-        Ok(()) => run_ingest(&job_id, &path, &clickhouse, &connector, &account, &merchant_id).await,
+        Ok(()) => {
+            run_ingest(
+                &job_id,
+                &path,
+                &clickhouse,
+                &connector,
+                &account,
+                &merchant_id,
+            )
+            .await
+        }
         Err(e) => Err(e),
     };
 
@@ -426,7 +436,9 @@ async fn fetch_sample_from_s3(
         .key(key)
         .send()
         .await
-        .map_err(|e| IngestError::Download(format!("s3 get_object s3://{bucket}/{key} failed: {e}")))?;
+        .map_err(|e| {
+            IngestError::Download(format!("s3 get_object s3://{bucket}/{key} failed: {e}"))
+        })?;
 
     let mut file = tokio::fs::File::create(path).await.map_err(|e| {
         IngestError::Download(format!("could not open temp file {path:?} for sample: {e}"))
@@ -434,18 +446,21 @@ async fn fetch_sample_from_s3(
 
     let mut total: usize = 0;
     while let Some(chunk) = output.body.next().await {
-        let chunk = chunk.map_err(|e| IngestError::Download(format!("s3 body stream error: {e}")))?;
+        let chunk =
+            chunk.map_err(|e| IngestError::Download(format!("s3 body stream error: {e}")))?;
         total = total.saturating_add(chunk.len());
         if total > MAX_UPLOAD_BYTES {
             return Err(IngestError::Download(format!(
                 "sample exceeds {MAX_UPLOAD_BYTES} byte limit"
             )));
         }
-        file.write_all(&chunk).await.map_err(|e| {
-            IngestError::Download(format!("temp file write failed: {e}"))
-        })?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| IngestError::Download(format!("temp file write failed: {e}")))?;
     }
-    file.flush().await.map_err(|e| IngestError::Download(format!("temp flush failed: {e}")))?;
+    file.flush()
+        .await
+        .map_err(|e| IngestError::Download(format!("temp flush failed: {e}")))?;
 
     if total == 0 {
         return Err(IngestError::Download("empty sample object".to_string()));

--- a/src/routes/report_upload.rs
+++ b/src/routes/report_upload.rs
@@ -294,6 +294,165 @@ pub async fn upload_report(
     ))
 }
 
+/// `POST /merchant-account/:id/connectors/:connector/report/sample` — run a curated **sample**
+/// report for `connector` through the normal pipeline, so a merchant without a report file of their
+/// own can still exercise the ingest → fit → coverage flow. The sample CSV is fetched from S3 at
+/// `<sample_bucket>/<connector>_report.csv` and filed under `acc_<connector>`. If the connector is
+/// not one that supports manual/report ingestion, or no `sample_bucket` is configured, the endpoint
+/// returns 404. Like the manual upload, it returns the job id immediately (202) and processes in
+/// the background — the dashboard polls the same history/progress.
+pub async fn run_sample_report(
+    Path((merchant_id, connector)): Path<(String, String)>,
+) -> Result<(StatusCode, Json<UploadAccepted>), (StatusCode, String)> {
+    // Only connectors that support report ingestion can have samples.
+    let registry = crate::cost_ingestion::source::ConnectorRegistry::with_builtins();
+    let _ = registry.get(&connector).map_err(|_| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("connector {connector} does not support sample reports"),
+        )
+    })?;
+
+    // Sample config + ClickHouse both live on the global config.
+    let state = crate::app::APP_STATE.get().ok_or((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "app state not initialized".to_string(),
+    ))?;
+    let cost_cfg = &state.global_config.cost_ingestion;
+    let bucket = Some(cost_cfg.aws_bucket.clone())
+        .filter(|b| !b.is_empty())
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            "no sample bucket configured".to_string(),
+        ))?;
+    let region = cost_cfg.aws_region.clone();
+
+    let account = format!("acc_{connector}");
+    let key = format!("{connector}_report.csv");
+    let report_ref = format!("s3://{bucket}/{key}");
+    let clickhouse = state.global_config.analytics.clickhouse.clone();
+
+    // Create the ingestion row (status=processing) up front so the dashboard can poll it. The row
+    // records the S3 location as its ref, mirroring how a manual upload records its temp path.
+    let job_id = store::create_sample(&merchant_id, &connector, &account, &report_ref)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("could not create ingestion job: {e:?}"),
+            )
+        })?;
+
+    let path = temp_report_path();
+    tokio::spawn(process_sample(
+        job_id.clone(),
+        path,
+        clickhouse,
+        connector,
+        account,
+        merchant_id,
+        bucket,
+        key,
+        region,
+    ));
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(UploadAccepted {
+            id: job_id,
+            status: "processing".to_string(),
+        }),
+    ))
+}
+
+/// Background task for a sample run: download the sample CSV from S3 to a temp file, run it through
+/// the same parse → stage → fit pipeline as an upload, and record the outcome. Progress ticks
+/// against `job_id` as batches stage.
+async fn process_sample(
+    job_id: String,
+    path: PathBuf,
+    clickhouse: crate::config::ClickHouseAnalyticsConfig,
+    connector: String,
+    account: String,
+    merchant_id: String,
+    bucket: String,
+    key: String,
+    region: Option<String>,
+) {
+    let download_result = fetch_sample_from_s3(&bucket, &key, region.as_deref(), &path).await;
+    let result = match download_result {
+        Ok(()) => run_ingest(&job_id, &path, &clickhouse, &connector, &account, &merchant_id).await,
+        Err(e) => Err(e),
+    };
+
+    finish_ingest(&job_id, result, &clickhouse, &merchant_id).await;
+
+    // Always remove the temp file, success or failure. Ignore "not found" — that just means the
+    // download failed before the file was created.
+    if let Err(e) = tokio::fs::remove_file(&path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            logger::warn!(
+                tag = "report_upload",
+                "sample temp cleanup {:?} failed: {}",
+                path,
+                e
+            );
+        }
+    }
+}
+
+/// Download a sample report from S3 into `path`. Streams chunks so multi-GB samples don't need to
+/// be held in memory. Credentials come from the default AWS credential chain in the runtime
+/// environment (IAM role, env vars, profile, etc.).
+async fn fetch_sample_from_s3(
+    bucket: &str,
+    key: &str,
+    region: Option<&str>,
+    path: &PathBuf,
+) -> Result<(), crate::cost_ingestion::IngestError> {
+    use crate::cost_ingestion::IngestError;
+    use aws_config::BehaviorVersion;
+
+    let mut loader = aws_config::defaults(BehaviorVersion::latest());
+    if let Some(region) = region {
+        loader = loader.region(aws_config::Region::new(region.to_string()));
+    }
+    let sdk_config = loader.load().await;
+    let client = aws_sdk_s3::Client::new(&sdk_config);
+
+    let mut output = client
+        .get_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| IngestError::Download(format!("s3 get_object s3://{bucket}/{key} failed: {e}")))?;
+
+    let mut file = tokio::fs::File::create(path).await.map_err(|e| {
+        IngestError::Download(format!("could not open temp file {path:?} for sample: {e}"))
+    })?;
+
+    let mut total: usize = 0;
+    while let Some(chunk) = output.body.next().await {
+        let chunk = chunk.map_err(|e| IngestError::Download(format!("s3 body stream error: {e}")))?;
+        total = total.saturating_add(chunk.len());
+        if total > MAX_UPLOAD_BYTES {
+            return Err(IngestError::Download(format!(
+                "sample exceeds {MAX_UPLOAD_BYTES} byte limit"
+            )));
+        }
+        file.write_all(&chunk).await.map_err(|e| {
+            IngestError::Download(format!("temp file write failed: {e}"))
+        })?;
+    }
+    file.flush().await.map_err(|e| IngestError::Download(format!("temp flush failed: {e}")))?;
+
+    if total == 0 {
+        return Err(IngestError::Download("empty sample object".to_string()));
+    }
+    Ok(())
+}
+
 /// Stream a request body to `path`, enforcing `MAX_UPLOAD_BYTES`. Never holds the whole body in RAM.
 async fn stream_to_file(path: &PathBuf, body: Body) -> Result<(), (StatusCode, String)> {
     let mut file = tokio::fs::File::create(path).await.map_err(|e| {
@@ -355,9 +514,31 @@ async fn process_upload(
     )
     .await;
 
+    finish_ingest(&job_id, result, &clickhouse, &merchant_id).await;
+
+    // Always remove the temp file, success or failure.
+    if let Err(e) = tokio::fs::remove_file(&path).await {
+        logger::warn!(
+            tag = "report_upload",
+            "temp cleanup {:?} failed: {}",
+            path,
+            e
+        );
+    }
+}
+
+/// Record the outcome of an ingest run: on success mark the job completed and refresh this
+/// merchant's served models immediately (so a just-ingested cluster doesn't fall back for ~5 min);
+/// on failure mark it failed with the error. Shared by the manual upload and sample flows.
+async fn finish_ingest(
+    job_id: &str,
+    result: Result<pipeline::IngestOutcome, crate::cost_ingestion::IngestError>,
+    clickhouse: &crate::config::ClickHouseAnalyticsConfig,
+    merchant_id: &str,
+) {
     match result {
         Ok(outcome) => {
-            if let Err(e) = store::mark_completed(&job_id, &outcome.to_completion()).await {
+            if let Err(e) = store::mark_completed(job_id, &outcome.to_completion()).await {
                 logger::warn!(
                     tag = "report_upload",
                     "mark_completed {} failed: {:?}",
@@ -370,7 +551,7 @@ async fn process_upload(
             // Per-merchant: only this merchant's models are rebuilt, keeping the upload off the
             // ~2s global-refresh path (the periodic ticker still does the full rebuild).
             if let Err(e) =
-                crate::cost_ingestion::serving::refresh_merchant(&clickhouse, &merchant_id).await
+                crate::cost_ingestion::serving::refresh_merchant(clickhouse, merchant_id).await
             {
                 logger::warn!(
                     tag = "report_upload",
@@ -381,13 +562,8 @@ async fn process_upload(
         }
         Err(e) => {
             let msg = format!("{e:?}");
-            logger::warn!(
-                tag = "report_upload",
-                "manual ingest {} failed: {}",
-                job_id,
-                msg
-            );
-            if let Err(e2) = store::mark_failed(&job_id, &msg).await {
+            logger::warn!(tag = "report_upload", "ingest {} failed: {}", job_id, msg);
+            if let Err(e2) = store::mark_failed(job_id, &msg).await {
                 logger::warn!(
                     tag = "report_upload",
                     "mark_failed {} failed: {:?}",
@@ -396,16 +572,6 @@ async fn process_upload(
                 );
             }
         }
-    }
-
-    // Always remove the temp file, success or failure.
-    if let Err(e) = tokio::fs::remove_file(&path).await {
-        logger::warn!(
-            tag = "report_upload",
-            "temp cleanup {:?} failed: {}",
-            path,
-            e
-        );
     }
 }
 

--- a/website/src/components/pages/ManualReportUpload.tsx
+++ b/website/src/components/pages/ManualReportUpload.tsx
@@ -5,11 +5,14 @@ import { Button } from '../ui/Button'
 import { ErrorMessage } from '../ui/ErrorMessage'
 import { Spinner } from '../ui/Spinner'
 import {
+  runSampleReport,
   uploadReport,
   useCostCoverage,
   useIngestionHistory,
 } from '../../hooks/useCostRouting'
 import { Field, UPLOAD_CONNECTORS, inputClass } from './CostRoutingShared'
+
+type IngestMode = 'upload' | 'sample'
 
 /**
  * Manual-ingestion tab: upload a settlement report file directly. The upload returns immediately
@@ -23,6 +26,7 @@ export function ManualReportUpload({ merchantId }: { merchantId?: string }) {
   const { ingestions, mutate: mutateHistory } = useIngestionHistory(merchantId)
 
   const fileRef = useRef<HTMLInputElement>(null)
+  const [mode, setMode] = useState<IngestMode>('upload')
   const [connector, setConnector] = useState('adyen')
   const [account, setAccount] = useState('')
   const [file, setFile] = useState<File | null>(null)
@@ -30,6 +34,9 @@ export function ManualReportUpload({ merchantId }: { merchantId?: string }) {
   const [uploadPct, setUploadPct] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const [activeJobId, setActiveJobId] = useState<number | null>(null)
+
+  const connectorLabel =
+    UPLOAD_CONNECTORS.find((c) => c.value === connector)?.label ?? connector
 
   const activeJob = activeJobId != null ? ingestions.find((j) => j.id === activeJobId) : undefined
 
@@ -70,6 +77,32 @@ export function ManualReportUpload({ merchantId }: { merchantId?: string }) {
     }
   }
 
+  async function handleRunSample() {
+    if (!merchantId) {
+      setError('Set a merchant ID first')
+      return
+    }
+    setUploading(true)
+    setUploadPct(100)
+    setError(null)
+    setActiveJobId(null)
+    try {
+      const res = await runSampleReport(merchantId, connector)
+      setActiveJobId(res.id)
+      await mutateHistory() // start polling immediately
+    } catch (e: unknown) {
+      // A 404 means no sample is configured for this connector — surface it plainly.
+      const msg = e instanceof Error ? e.message : ''
+      setError(
+        /404|not found|no sample/i.test(msg)
+          ? `No sample report available for ${connectorLabel}.`
+          : msg || 'Failed to run sample report',
+      )
+    } finally {
+      setUploading(false)
+    }
+  }
+
   const processing = activeJob?.status === 'processing'
   const done = activeJob?.status === 'completed'
   const failed = activeJob?.status === 'failed'
@@ -88,9 +121,36 @@ export function ManualReportUpload({ merchantId }: { merchantId?: string }) {
         </div>
       </CardHeader>
       <CardBody className="space-y-4">
+        {/* Choose between a real file upload and a curated sample, for merchants without a report. */}
+        <div className="inline-flex rounded-lg border border-slate-200 p-0.5 dark:border-[#2a3344]">
+          {(
+            [
+              ['upload', 'Upload a file'],
+              ['sample', 'Use a sample file'],
+            ] as [IngestMode, string][]
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                setMode(value)
+                setError(null)
+              }}
+              className={
+                'rounded-md px-3 py-1.5 text-sm font-medium transition-colors ' +
+                (mode === value
+                  ? 'bg-brand-500 text-white'
+                  : 'text-slate-500 hover:text-slate-700 dark:text-[#9ca7ba] dark:hover:text-white')
+              }
+            >
+              {label}
+            </button>
+          ))}
+        </div>
         <p className="text-sm text-slate-500 dark:text-[#9ca7ba]">
-          Upload a settlement report file directly — no webhook needed. Processing runs in the
-          background (the upload won't hang on large files); watch progress below and in the history.
+          {mode === 'upload'
+            ? "Upload a settlement report file directly — no webhook needed. Processing runs in the background (the upload won't hang on large files); watch progress below and in the history."
+            : `No report file? Run a curated ${connectorLabel} sample report through the exact same fit, so you can see the ingest → cost-coverage flow end to end. Progress shows below and in the history.`}
         </p>
         <Field label="Connector">
           <select
@@ -105,40 +165,61 @@ export function ManualReportUpload({ merchantId }: { merchantId?: string }) {
             ))}
           </select>
         </Field>
-        <Field label="Account" hint="Connector-side account the report belongs to">
-          <input
-            className={inputClass}
-            value={account}
-            onChange={(e) => setAccount(e.target.value)}
-            placeholder="AcmeMerchantEU"
-          />
-        </Field>
-        <Field label="Report file" hint="The connector's settlement / PAR report (CSV)">
-          <input
-            ref={fileRef}
-            type="file"
-            accept=".csv,text/csv,text/plain"
-            className={inputClass}
-            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-          />
-        </Field>
+        {mode === 'upload' && (
+          <>
+            <Field label="Account" hint="Connector-side account the report belongs to">
+              <input
+                className={inputClass}
+                value={account}
+                onChange={(e) => setAccount(e.target.value)}
+                placeholder="AcmeMerchantEU"
+              />
+            </Field>
+            <Field label="Report file" hint="The connector's settlement / PAR report (CSV)">
+              <input
+                ref={fileRef}
+                type="file"
+                accept=".csv,text/csv,text/plain"
+                className={inputClass}
+                onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              />
+            </Field>
+          </>
+        )}
 
         <div className="flex items-center gap-3">
-          <Button onClick={handleUpload} disabled={!merchantId || uploading || processing}>
-            {uploading || processing ? (
-              <>
-                <Spinner size={14} />
-                {uploading ? 'Uploading…' : 'Processing…'}
-              </>
-            ) : (
-              'Upload & fit'
-            )}
-          </Button>
-          <span className="text-xs text-slate-400">Runs in the background after upload.</span>
+          {mode === 'upload' ? (
+            <Button onClick={handleUpload} disabled={!merchantId || uploading || processing}>
+              {uploading || processing ? (
+                <>
+                  <Spinner size={14} />
+                  {uploading ? 'Uploading…' : 'Processing…'}
+                </>
+              ) : (
+                'Upload & fit'
+              )}
+            </Button>
+          ) : (
+            <Button onClick={handleRunSample} disabled={!merchantId || uploading || processing}>
+              {uploading || processing ? (
+                <>
+                  <Spinner size={14} />
+                  {uploading ? 'Starting…' : 'Processing…'}
+                </>
+              ) : (
+                'Run sample'
+              )}
+            </Button>
+          )}
+          <span className="text-xs text-slate-400">
+            {mode === 'upload'
+              ? 'Runs in the background after upload.'
+              : 'Fetches the sample and runs in the background.'}
+          </span>
         </div>
 
-        {/* Upload transfer bar */}
-        {uploading && (
+        {/* Upload transfer bar (file upload only) */}
+        {mode === 'upload' && uploading && (
           <ProgressBar
             label={`Uploading report… ${uploadPct}%`}
             pct={uploadPct}

--- a/website/src/hooks/useCostRouting.ts
+++ b/website/src/hooks/useCostRouting.ts
@@ -291,6 +291,18 @@ export async function uploadReport(
 }
 
 /**
+ * Run a curated sample report for a connector ("Use a sample file") — for merchants without a
+ * report file of their own. The server downloads the configured sample and runs the identical
+ * pipeline, returning a job id (202) to poll via {@link useIngestionHistory}. Rejects with a 404 if
+ * no sample is configured for the connector.
+ */
+export async function runSampleReport(merchantId: string, connector: string) {
+  return apiPost<UploadAccepted>(
+    `/merchant-account/${merchantId}/connectors/${connector}/report/sample`,
+  )
+}
+
+/**
  * Delete (undo) an ingestion: removes its fitted snapshot + staged rows and its history row.
  * Coverage/serving revert to the previous snapshot automatically.
  */


### PR DESCRIPTION
This pull request introduces a new "Use a sample file" flow for cost ingestion, allowing merchants to run a curated sample report for any supported connector without uploading their own file. It adds backend support for fetching sample reports from S3, creates a new API endpoint, and updates the frontend to let users select between uploading a file or running a sample. Several supporting changes were made to configuration, error handling, and UI.

**Backend: Sample report ingestion support**
- Added a new API endpoint (`POST /merchant-account/:merchant-id/connectors/:connector/report/sample`) that triggers ingestion of a curated sample report for the chosen connector, fetching the sample CSV from a configured S3 bucket. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R445-R450) [[2]](diffhunk://#diff-9577666ccac333e1521e623472f806fc6b6fe62dc307457e4803cbd84c086ef6R297-R455)
- Implemented S3 download logic, background processing, and ingestion row creation for sample reports, ensuring the flow mirrors manual uploads (including progress, error handling, and cleanup). [[1]](diffhunk://#diff-9577666ccac333e1521e623472f806fc6b6fe62dc307457e4803cbd84c086ef6R297-R455) [[2]](diffhunk://#diff-f4d28e1f243be98bcef4612fd79af1b3cff6f4aa96b72fa743d80c1c07995cfeR120-R146)

**Configuration: Sample report S3 settings**
- Added `aws_bucket` and `aws_region` options to the cost ingestion config, allowing environments to specify where sample reports are stored in S3. If not set, the sample endpoint returns 404. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR321-R327) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR340-R341) [[3]](diffhunk://#diff-eeba5fd66f2753499ebdfe068ce07b9712c29d509dbd25e20eae2df0648c5c4eR105-R109)
- Updated dependencies to include `aws-sdk-s3` for S3 integration.

**Frontend: UI and UX for sample reports**
- Updated the manual report upload page to let users choose between uploading a file or running a curated sample, with clear UI and error handling for missing samples. The sample flow disables account/file selection and provides tailored messaging. [[1]](diffhunk://#diff-16312ec3c9872ed23a55e3fe2b0c2be4cd8b28feee144d071ca11f6a25f6acd4R8-R16) [[2]](diffhunk://#diff-16312ec3c9872ed23a55e3fe2b0c2be4cd8b28feee144d071ca11f6a25f6acd4R29) [[3]](diffhunk://#diff-16312ec3c9872ed23a55e3fe2b0c2be4cd8b28feee144d071ca11f6a25f6acd4R80-R105) [[4]](diffhunk://#diff-16312ec3c9872ed23a55e3fe2b0c2be4cd8b28feee144d071ca11f6a25f6acd4R124-R153) [[5]](diffhunk://#diff-16312ec3c9872ed23a55e3fe2b0c2be4cd8b28feee144d071ca11f6a25f6acd4R168-R169) [[6]](diffhunk://#diff-16312ec3c9872ed23a55e3fe2b0c2be4cd8b28feee144d071ca11f6a25f6acd4R187-R191) [[7]](diffhunk://#diff-16312ec3c9872ed23a55e3fe2b0c2be4cd8b28feee144d071ca11f6a25f6acd4L137-R222)

**Refactoring and shared logic**
- Refactored ingestion completion logic into a shared `finish_ingest` function, used by both manual and sample flows for consistent status updates, error handling, and model refresh. [[1]](diffhunk://#diff-9577666ccac333e1521e623472f806fc6b6fe62dc307457e4803cbd84c086ef6R517-R541) [[2]](diffhunk://#diff-9577666ccac333e1521e623472f806fc6b6fe62dc307457e4803cbd84c086ef6L373-R554) [[3]](diffhunk://#diff-9577666ccac333e1521e623472f806fc6b6fe62dc307457e4803cbd84c086ef6L384-R566) [[4]](diffhunk://#diff-9577666ccac333e1521e623472f806fc6b6fe62dc307457e4803cbd84c086ef6L400-L409)

These changes together enable a "try without your own data" experience, improving onboarding and demo capabilities for cost routing.