### PR TITLE
fix: merchant session sync after create

### DIFF
--- a/website/src/components/layout/AuthGuard.tsx
+++ b/website/src/components/layout/AuthGuard.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Navigate, Outlet } from 'react-router-dom'
 import { Loader2 } from 'lucide-react'
 import useSWR from 'swr'
 import { useAuthStore } from '../../store/authStore'
 import { useMerchantStore } from '../../store/merchantStore'
 import { fetcher } from '../../lib/api'
+import { refreshSessionScopedSWRCache } from '../../lib/swrCache'
 
 interface MeResponse {
   user_id: string
@@ -36,12 +37,19 @@ export function AuthGuard() {
   const setAuth = useAuthStore((s) => s.setAuth)
   const clearAuth = useAuthStore((s) => s.clearAuth)
   const setMerchantId = useMerchantStore((s) => s.setMerchantId)
+  const previousTokenRef = useRef<string | null>(null)
 
   const { data: me, error, isValidating } = useSWR<MeResponse>(
     token && hasHydrated ? ['/auth/me', token] : null,
     ([url]) => fetcher(url),
     { revalidateOnFocus: false, shouldRetryOnError: false },
   )
+
+  useEffect(() => {
+    if (!hasHydrated || !token || previousTokenRef.current === token) return
+    previousTokenRef.current = token
+    refreshSessionScopedSWRCache()
+  }, [hasHydrated, token])
 
   useEffect(() => {
     if (!me || !token) return

--- a/website/src/components/layout/AuthGuard.tsx
+++ b/website/src/components/layout/AuthGuard.tsx
@@ -38,8 +38,8 @@ export function AuthGuard() {
   const setMerchantId = useMerchantStore((s) => s.setMerchantId)
 
   const { data: me, error, isValidating } = useSWR<MeResponse>(
-    token && hasHydrated ? '/auth/me' : null,
-    fetcher,
+    token && hasHydrated ? ['/auth/me', token] : null,
+    ([url]) => fetcher(url),
     { revalidateOnFocus: false, shouldRetryOnError: false },
   )
 

--- a/website/src/components/layout/TopBar.tsx
+++ b/website/src/components/layout/TopBar.tsx
@@ -42,7 +42,6 @@ export function TopBar() {
       updateMerchant(res.token, res.merchant_id, res.merchants)
       setMerchantId(res.merchant_id)
       setMerchantOpen(false)
-      window.location.reload()
     } catch {
       // ignore
     } finally {

--- a/website/src/lib/swrCache.ts
+++ b/website/src/lib/swrCache.ts
@@ -1,0 +1,18 @@
+import { mutate } from 'swr'
+
+function getCachePath(key: unknown): string | null {
+  if (typeof key === 'string') return key
+  if (Array.isArray(key) && typeof key[0] === 'string') return key[0]
+  return null
+}
+
+function isSessionScopedApiKey(key: unknown): boolean {
+  const path = getCachePath(key)
+  if (!path?.startsWith('/')) return false
+
+  return path !== '/auth/me' && !path.startsWith('/health')
+}
+
+export function refreshSessionScopedSWRCache() {
+  void mutate(isSessionScopedApiKey, undefined, { revalidate: true }).catch(() => undefined)
+}

--- a/website/src/pages/AuthPage.tsx
+++ b/website/src/pages/AuthPage.tsx
@@ -13,7 +13,6 @@ import {
 } from 'lucide-react'
 import { useAuthStore, MerchantInfo } from '../store/authStore'
 import { useMerchantStore } from '../store/merchantStore'
-import { mutate } from 'swr'
 import { apiFetch } from '../lib/api'
 import { getResolvedThemePreference, persistThemePreference } from '../lib/theme'
 import { SurfaceLabel } from '../components/ui/Card'
@@ -204,9 +203,6 @@ export function AuthPage() {
         authRes.merchants,
       )
       if (authRes.merchant_id) setMerchantId(authRes.merchant_id)
-      // Clear any stale /auth/me error from a previous expired session so AuthGuard
-      // doesn't see the cached 401 and clear the fresh token before revalidating.
-      mutate('/auth/me', undefined, { revalidate: false })
 
       const pendingRaw = localStorage.getItem('pending_merchant_name')
       const pending = pendingRaw ? (() => { try { return JSON.parse(pendingRaw) } catch { return null } })() : null


### PR DESCRIPTION
## Summary

This PR fixes the issue where creating a new merchant did not immediately switch the dashboard to that merchant unless the page was refreshed.

## Problem

After merchant creation, the backend returned a new token and merchant ID, and the frontend updated the auth and merchant stores. However, `AuthGuard` was still using a static SWR cache key for `/auth/me`.

Because of that, SWR could reuse stale session data from the previous token and overwrite the newly selected merchant in the store. A browser refresh fixed it because the in-memory cache was cleared.

## Fix

- Scope the `/auth/me` SWR cache by token.
- Remove the old manual `/auth/me` cache clearing from login.
- Remove the forced `window.location.reload()` from merchant switching.
- Let the dashboard update merchant context through React/Zustand state directly.
