### PR TITLE
feat: Add automated nightly build workflow at 5 AM IST

### DIFF
--- a/.github/workflows/NIGHTLY_BUILD_README.md
+++ b/.github/workflows/NIGHTLY_BUILD_README.md
@@ -41,7 +41,8 @@ You can manually trigger a nightly build from the GitHub Actions UI:
 
 1. Go to Actions → Nightly Build and Release
 2. Click "Run workflow"
-3. Optionally provide a tag suffix (e.g., `rc1` creates `nightly-2026.07.21-rc1`)
+3. Select the `main` branch (nightlies should only be published from the default branch)
+4. Optionally provide a tag suffix (e.g., `rc1` creates `nightly-2026.07.21-rc1`)
 
 ## Tag Format
 
@@ -54,7 +55,7 @@ Each nightly build creates a GitHub pre-release with:
 - Tag name and commit SHA
 - Build timestamp
 - Links to all Docker images
-- Automated release notes
+- Release description with build metadata and usage examples
 
 ## Configuration
 

--- a/.github/workflows/NIGHTLY_BUILD_README.md
+++ b/.github/workflows/NIGHTLY_BUILD_README.md
@@ -1,0 +1,87 @@
+# Nightly Build Workflow
+
+## Overview
+
+This workflow automatically creates nightly builds of the Decision Engine at **5:00 AM IST** every day.
+
+## What It Does
+
+1. **Creates a Git Tag** with format `nightly-YYYY.MM.DD` (e.g., `nightly-2026.07.21`)
+2. **Builds Docker Images** for all platforms:
+   - PostgreSQL variant (`ghcr.io/juspay/decision-engine/postgres`)
+   - MySQL variant (`ghcr.io/juspay/decision-engine`)
+   - Groovy runner (`ghcr.io/juspay/decision-engine/groovy-runner`)
+3. **Creates a GitHub Release** with the nightly tag (marked as pre-release)
+4. **Tags images** with both the date tag and `nightly-latest`
+
+## Schedule
+
+- **Automatic Run**: Daily at 5:00 AM IST (11:30 PM UTC previous day)
+- **Manual Trigger**: Available via GitHub Actions UI with optional tag suffix
+
+## Docker Images
+
+All images are multi-architecture (amd64 + arm64) and available at:
+
+```bash
+# Specific nightly version
+docker pull ghcr.io/juspay/decision-engine:nightly-2026.07.21
+docker pull ghcr.io/juspay/decision-engine/postgres:nightly-2026.07.21
+docker pull ghcr.io/juspay/decision-engine/groovy-runner:nightly-2026.07.21
+
+# Latest nightly (always points to the most recent nightly build)
+docker pull ghcr.io/juspay/decision-engine:nightly-latest
+docker pull ghcr.io/juspay/decision-engine/postgres:nightly-latest
+docker pull ghcr.io/juspay/decision-engine/groovy-runner:nightly-latest
+```
+
+## Manual Trigger
+
+You can manually trigger a nightly build from the GitHub Actions UI:
+
+1. Go to Actions → Nightly Build and Release
+2. Click "Run workflow"
+3. Optionally provide a tag suffix (e.g., `rc1` creates `nightly-2026.07.21-rc1`)
+
+## Tag Format
+
+- **Standard**: `nightly-YYYY.MM.DD` (e.g., `nightly-2026.07.21`)
+- **With Suffix**: `nightly-YYYY.MM.DD-<suffix>` (e.g., `nightly-2026.07.21-rc1`)
+
+## GitHub Releases
+
+Each nightly build creates a GitHub pre-release with:
+- Tag name and commit SHA
+- Build timestamp
+- Links to all Docker images
+- Automated release notes
+
+## Configuration
+
+The schedule is configured using GitHub Actions cron syntax:
+
+```yaml
+schedule:
+  - cron: '30 23 * * *'  # 11:30 PM UTC = 5:00 AM IST
+```
+
+To change the schedule, modify the cron expression in `.github/workflows/nightly-build.yml`.
+
+## Caching
+
+The workflow uses GitHub Actions cache to speed up builds:
+- Postgres builds: `nightly-postgres-{arch}`
+- MySQL builds: `nightly-mysql-{arch}`
+- Groovy builds: `nightly-groovy`
+
+## Notes
+
+- Nightly builds are marked as **pre-release** in GitHub
+- Images are automatically pushed to GitHub Container Registry (ghcr.io)
+- The workflow requires `contents: write` and `packages: write` permissions
+- Build time varies but typically completes within 30-45 minutes
+
+## Monitoring
+
+Check the workflow status at:
+https://github.com/juspay/decision-engine/actions/workflows/nightly-build.yml

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,312 @@
+name: Nightly Build and Release
+
+on:
+  schedule:
+    # Runs at 5:00 AM IST (11:30 PM UTC previous day) every day
+    - cron: '30 23 * * *'
+  workflow_dispatch:
+    inputs:
+      tag_suffix:
+        description: 'Optional tag suffix (e.g., "rc1" for nightly-2026.07.21-rc1)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  create-tag-and-build:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.create_tag.outputs.tag_name }}
+      short_sha: ${{ steps.create_tag.outputs.short_sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create nightly tag
+        id: create_tag
+        run: |
+          # Generate date-based tag (YYYY.MM.DD format)
+          DATE_TAG=$(TZ=Asia/Kolkata date +%Y.%m.%d)
+          TAG_SUFFIX="${{ github.event.inputs.tag_suffix }}"
+          
+          if [[ -n "$TAG_SUFFIX" ]]; then
+            TAG_NAME="nightly-${DATE_TAG}-${TAG_SUFFIX}"
+          else
+            TAG_NAME="nightly-${DATE_TAG}"
+          fi
+          
+          SHORT_SHA="${GITHUB_SHA::7}"
+          
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "Creating tag: ${TAG_NAME} at commit ${SHORT_SHA}"
+          
+          # Create and push tag
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG_NAME}" -m "Nightly build ${TAG_NAME} (${SHORT_SHA})"
+          git push origin "${TAG_NAME}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.create_tag.outputs.tag_name }}
+          name: Nightly Build ${{ steps.create_tag.outputs.tag_name }}
+          body: |
+            ## Nightly Build - ${{ steps.create_tag.outputs.tag_name }}
+            
+            **Commit:** ${{ steps.create_tag.outputs.short_sha }}
+            **Built:** $(TZ=Asia/Kolkata date '+%Y-%m-%d %H:%M:%S IST')
+            
+            ### Docker Images
+            This release includes the following Docker images:
+            - `ghcr.io/${{ github.repository }}/postgres:${{ steps.create_tag.outputs.tag_name }}`
+            - `ghcr.io/${{ github.repository }}:${{ steps.create_tag.outputs.tag_name }}`
+            - `ghcr.io/${{ github.repository }}/groovy-runner:${{ steps.create_tag.outputs.tag_name }}`
+            
+            ### Usage
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:${{ steps.create_tag.outputs.tag_name }}
+            ```
+            
+            ---
+            *This is an automated nightly build. Use at your own risk.*
+          draft: false
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-postgres-image:
+    needs: create-tag-and-build
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            tag: linux-amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            tag: linux-arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/postgres
+          tags: |
+            type=raw,value=${{ needs.create-tag-and-build.outputs.tag_name }}
+            type=raw,value=nightly-latest
+
+      - name: Build and push Postgres Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.postgres
+          platforms: ${{ matrix.platform }}
+          tags: ghcr.io/${{ github.repository }}/postgres:${{ needs.create-tag-and-build.outputs.tag_name }}-${{ matrix.tag }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=nightly-postgres-${{ matrix.tag }}
+          cache-to: type=gha,scope=nightly-postgres-${{ matrix.tag }},mode=max
+          push: true
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: "-A warnings"
+          SCCACHE_ENABLE: "true"
+
+  build-mysql-image:
+    needs: create-tag-and-build
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            tag: linux-amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            tag: linux-arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ needs.create-tag-and-build.outputs.tag_name }}
+            type=raw,value=nightly-latest
+
+      - name: Build and push MySQL Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          tags: ghcr.io/${{ github.repository }}:${{ needs.create-tag-and-build.outputs.tag_name }}-${{ matrix.tag }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=nightly-mysql-${{ matrix.tag }}
+          cache-to: type=gha,scope=nightly-mysql-${{ matrix.tag }},mode=max
+          push: true
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: "-A warnings"
+          SCCACHE_ENABLE: "true"
+
+  create-postgres-manifest:
+    needs: [create-tag-and-build, build-postgres-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          TAG_NAME="${{ needs.create-tag-and-build.outputs.tag_name }}"
+          
+          # Create manifest for nightly tag
+          docker buildx imagetools create --tag ghcr.io/${{ github.repository }}/postgres:${TAG_NAME} \
+            ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-amd64 \
+            ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-arm64
+          
+          # Create manifest for nightly-latest
+          docker buildx imagetools create --tag ghcr.io/${{ github.repository }}/postgres:nightly-latest \
+            ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-amd64 \
+            ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-arm64
+
+  create-mysql-manifest:
+    needs: [create-tag-and-build, build-mysql-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          TAG_NAME="${{ needs.create-tag-and-build.outputs.tag_name }}"
+          
+          # Create manifest for nightly tag
+          docker buildx imagetools create --tag ghcr.io/${{ github.repository }}:${TAG_NAME} \
+            ghcr.io/${{ github.repository }}:${TAG_NAME}-linux-amd64 \
+            ghcr.io/${{ github.repository }}:${TAG_NAME}-linux-arm64
+          
+          # Create manifest for nightly-latest
+          docker buildx imagetools create --tag ghcr.io/${{ github.repository }}:nightly-latest \
+            ghcr.io/${{ github.repository }}:${TAG_NAME}-linux-amd64 \
+            ghcr.io/${{ github.repository }}:${TAG_NAME}-linux-arm64
+
+  build-groovy-image:
+    needs: create-tag-and-build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/groovy-runner
+          tags: |
+            type=raw,value=${{ needs.create-tag-and-build.outputs.tag_name }}
+            type=raw,value=nightly-latest
+
+      - name: Build and push Groovy Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: groovy.Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}/groovy-runner:${{ needs.create-tag-and-build.outputs.tag_name }}
+            ghcr.io/${{ github.repository }}/groovy-runner:nightly-latest
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=nightly-groovy
+          cache-to: type=gha,scope=nightly-groovy,mode=max
+
+  notify-completion:
+    needs: [create-postgres-manifest, create-mysql-manifest, build-groovy-image]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check build status
+        run: |
+          echo "Nightly build completed!"
+          echo "Tag: ${{ needs.create-tag-and-build.outputs.tag_name }}"
+          echo "Images are available at:"
+          echo "  - ghcr.io/${{ github.repository }}/postgres:${{ needs.create-tag-and-build.outputs.tag_name }}"
+          echo "  - ghcr.io/${{ github.repository }}:${{ needs.create-tag-and-build.outputs.tag_name }}"
+          echo "  - ghcr.io/${{ github.repository }}/groovy-runner:${{ needs.create-tag-and-build.outputs.tag_name }}"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,11 +16,12 @@ permissions:
   packages: write
 
 jobs:
-  create-tag-and-build:
+  create-tag:
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.create_tag.outputs.tag_name }}
       short_sha: ${{ steps.create_tag.outputs.short_sha }}
+      built_at: ${{ steps.create_tag.outputs.built_at }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,10 +42,25 @@ jobs:
           fi
           
           SHORT_SHA="${GITHUB_SHA::7}"
+          BUILT_AT=$(TZ=Asia/Kolkata date '+%Y-%m-%d %H:%M:%S IST')
           
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "built_at=${BUILT_AT}" >> $GITHUB_OUTPUT
           echo "Creating tag: ${TAG_NAME} at commit ${SHORT_SHA}"
+          
+          # Check if tag already exists
+          if git rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
+            EXISTING_SHA=$(git rev-parse "${TAG_NAME}^{commit}")
+            if [[ "$EXISTING_SHA" == "$GITHUB_SHA" ]]; then
+              echo "Tag ${TAG_NAME} already exists and points to current commit. Reusing."
+              exit 0
+            else
+              echo "Error: Tag ${TAG_NAME} already exists but points to different commit (${EXISTING_SHA})"
+              echo "Current commit: ${GITHUB_SHA}"
+              exit 1
+            fi
+          fi
           
           # Create and push tag
           git config user.name "github-actions[bot]"
@@ -52,37 +68,8 @@ jobs:
           git tag -a "${TAG_NAME}" -m "Nightly build ${TAG_NAME} (${SHORT_SHA})"
           git push origin "${TAG_NAME}"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.create_tag.outputs.tag_name }}
-          name: Nightly Build ${{ steps.create_tag.outputs.tag_name }}
-          body: |
-            ## Nightly Build - ${{ steps.create_tag.outputs.tag_name }}
-            
-            **Commit:** ${{ steps.create_tag.outputs.short_sha }}
-            **Built:** $(TZ=Asia/Kolkata date '+%Y-%m-%d %H:%M:%S IST')
-            
-            ### Docker Images
-            This release includes the following Docker images:
-            - `ghcr.io/${{ github.repository }}/postgres:${{ steps.create_tag.outputs.tag_name }}`
-            - `ghcr.io/${{ github.repository }}:${{ steps.create_tag.outputs.tag_name }}`
-            - `ghcr.io/${{ github.repository }}/groovy-runner:${{ steps.create_tag.outputs.tag_name }}`
-            
-            ### Usage
-            ```bash
-            docker pull ghcr.io/${{ github.repository }}:${{ steps.create_tag.outputs.tag_name }}
-            ```
-            
-            ---
-            *This is an automated nightly build. Use at your own risk.*
-          draft: false
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build-postgres-image:
-    needs: create-tag-and-build
+    needs: create-tag
     permissions:
       contents: read
       packages: write
@@ -116,7 +103,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/postgres
           tags: |
-            type=raw,value=${{ needs.create-tag-and-build.outputs.tag_name }}
+            type=raw,value=${{ needs.create-tag.outputs.tag_name }}
             type=raw,value=nightly-latest
 
       - name: Build and push Postgres Docker image
@@ -125,7 +112,7 @@ jobs:
           context: .
           file: Dockerfile.postgres
           platforms: ${{ matrix.platform }}
-          tags: ghcr.io/${{ github.repository }}/postgres:${{ needs.create-tag-and-build.outputs.tag_name }}-${{ matrix.tag }}
+          tags: ghcr.io/${{ github.repository }}/postgres:${{ needs.create-tag.outputs.tag_name }}-${{ matrix.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=nightly-postgres-${{ matrix.tag }}
           cache-to: type=gha,scope=nightly-postgres-${{ matrix.tag }},mode=max
@@ -136,7 +123,7 @@ jobs:
           SCCACHE_ENABLE: "true"
 
   build-mysql-image:
-    needs: create-tag-and-build
+    needs: create-tag
     permissions:
       contents: read
       packages: write
@@ -170,7 +157,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=${{ needs.create-tag-and-build.outputs.tag_name }}
+            type=raw,value=${{ needs.create-tag.outputs.tag_name }}
             type=raw,value=nightly-latest
 
       - name: Build and push MySQL Docker image
@@ -179,7 +166,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: ${{ matrix.platform }}
-          tags: ghcr.io/${{ github.repository }}:${{ needs.create-tag-and-build.outputs.tag_name }}-${{ matrix.tag }}
+          tags: ghcr.io/${{ github.repository }}:${{ needs.create-tag.outputs.tag_name }}-${{ matrix.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=nightly-mysql-${{ matrix.tag }}
           cache-to: type=gha,scope=nightly-mysql-${{ matrix.tag }},mode=max
@@ -190,7 +177,7 @@ jobs:
           SCCACHE_ENABLE: "true"
 
   create-postgres-manifest:
-    needs: [create-tag-and-build, build-postgres-image]
+    needs: [create-tag, build-postgres-image]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -208,7 +195,7 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          TAG_NAME="${{ needs.create-tag-and-build.outputs.tag_name }}"
+          TAG_NAME="${{ needs.create-tag.outputs.tag_name }}"
           
           # Create manifest for nightly tag
           docker buildx imagetools create --tag ghcr.io/${{ github.repository }}/postgres:${TAG_NAME} \
@@ -221,7 +208,7 @@ jobs:
             ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-arm64
 
   create-mysql-manifest:
-    needs: [create-tag-and-build, build-mysql-image]
+    needs: [create-tag, build-mysql-image]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -239,7 +226,7 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          TAG_NAME="${{ needs.create-tag-and-build.outputs.tag_name }}"
+          TAG_NAME="${{ needs.create-tag.outputs.tag_name }}"
           
           # Create manifest for nightly tag
           docker buildx imagetools create --tag ghcr.io/${{ github.repository }}:${TAG_NAME} \
@@ -252,7 +239,7 @@ jobs:
             ghcr.io/${{ github.repository }}:${TAG_NAME}-linux-arm64
 
   build-groovy-image:
-    needs: create-tag-and-build
+    needs: create-tag
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -280,7 +267,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/groovy-runner
           tags: |
-            type=raw,value=${{ needs.create-tag-and-build.outputs.tag_name }}
+            type=raw,value=${{ needs.create-tag.outputs.tag_name }}
             type=raw,value=nightly-latest
 
       - name: Build and push Groovy Docker image
@@ -291,22 +278,67 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}/groovy-runner:${{ needs.create-tag-and-build.outputs.tag_name }}
+            ghcr.io/${{ github.repository }}/groovy-runner:${{ needs.create-tag.outputs.tag_name }}
             ghcr.io/${{ github.repository }}/groovy-runner:nightly-latest
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=nightly-groovy
           cache-to: type=gha,scope=nightly-groovy,mode=max
 
+  create-release:
+    needs: [create-tag, create-postgres-manifest, create-mysql-manifest, build-groovy-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.create-tag.outputs.tag_name }}
+          name: Nightly Build ${{ needs.create-tag.outputs.tag_name }}
+          body: |
+            ## Nightly Build - ${{ needs.create-tag.outputs.tag_name }}
+            
+            **Commit:** ${{ needs.create-tag.outputs.short_sha }}
+            **Built:** ${{ needs.create-tag.outputs.built_at }}
+            
+            ### Docker Images
+            This release includes the following Docker images:
+            - `ghcr.io/${{ github.repository }}/postgres:${{ needs.create-tag.outputs.tag_name }}`
+            - `ghcr.io/${{ github.repository }}:${{ needs.create-tag.outputs.tag_name }}`
+            - `ghcr.io/${{ github.repository }}/groovy-runner:${{ needs.create-tag.outputs.tag_name }}`
+            
+            All images are also available with the `nightly-latest` tag.
+            
+            ### Usage
+            ```bash
+            # Pull specific nightly version
+            docker pull ghcr.io/${{ github.repository }}:${{ needs.create-tag.outputs.tag_name }}
+            
+            # Pull latest nightly
+            docker pull ghcr.io/${{ github.repository }}:nightly-latest
+            ```
+            
+            ---
+            *This is an automated nightly build. Use at your own risk.*
+          draft: false
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   notify-completion:
-    needs: [create-postgres-manifest, create-mysql-manifest, build-groovy-image]
+    needs: [create-tag, create-release]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check build status
         run: |
           echo "Nightly build completed!"
-          echo "Tag: ${{ needs.create-tag-and-build.outputs.tag_name }}"
+          echo "Tag: ${{ needs.create-tag.outputs.tag_name }}"
+          echo "Release: https://github.com/${{ github.repository }}/releases/tag/${{ needs.create-tag.outputs.tag_name }}"
           echo "Images are available at:"
-          echo "  - ghcr.io/${{ github.repository }}/postgres:${{ needs.create-tag-and-build.outputs.tag_name }}"
-          echo "  - ghcr.io/${{ github.repository }}:${{ needs.create-tag-and-build.outputs.tag_name }}"
-          echo "  - ghcr.io/${{ github.repository }}/groovy-runner:${{ needs.create-tag-and-build.outputs.tag_name }}"
+          echo "  - ghcr.io/${{ github.repository }}/postgres:${{ needs.create-tag.outputs.tag_name }}"
+          echo "  - ghcr.io/${{ github.repository }}:${{ needs.create-tag.outputs.tag_name }}"
+          echo "  - ghcr.io/${{ github.repository }}/groovy-runner:${{ needs.create-tag.outputs.tag_name }}"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -30,12 +30,19 @@ jobs:
 
       - name: Create nightly tag
         id: create_tag
+        env:
+          TAG_SUFFIX: ${{ github.event.inputs.tag_suffix }}
         run: |
           # Generate date-based tag (YYYY.MM.DD format)
           DATE_TAG=$(TZ=Asia/Kolkata date +%Y.%m.%d)
-          TAG_SUFFIX="${{ github.event.inputs.tag_suffix }}"
           
+          # Validate tag suffix against allowed charset (alphanumeric, dash, dot only)
           if [[ -n "$TAG_SUFFIX" ]]; then
+            if [[ ! "$TAG_SUFFIX" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+              echo "Error: tag_suffix contains invalid characters. Only alphanumeric, dash, dot, and underscore are allowed."
+              echo "Provided: $TAG_SUFFIX"
+              exit 1
+            fi
             TAG_NAME="nightly-${DATE_TAG}-${TAG_SUFFIX}"
           else
             TAG_NAME="nightly-${DATE_TAG}"
@@ -331,6 +338,8 @@ jobs:
   notify-completion:
     needs: [create-tag, create-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: always()
     steps:
       - name: Check build status

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write
@@ -36,7 +40,7 @@ jobs:
           # Generate date-based tag (YYYY.MM.DD format)
           DATE_TAG=$(TZ=Asia/Kolkata date +%Y.%m.%d)
           
-          # Validate tag suffix against allowed charset (alphanumeric, dash, dot only)
+          # Validate tag suffix against allowed charset (alphanumeric, dash, dot, underscore only)
           if [[ -n "$TAG_SUFFIX" ]]; then
             if [[ ! "$TAG_SUFFIX" =~ ^[a-zA-Z0-9._-]+$ ]]; then
               echo "Error: tag_suffix contains invalid characters. Only alphanumeric, dash, dot, and underscore are allowed."
@@ -57,8 +61,8 @@ jobs:
           echo "Creating tag: ${TAG_NAME} at commit ${SHORT_SHA}"
           
           # Check if tag already exists
-          if git rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
-            EXISTING_SHA=$(git rev-parse "${TAG_NAME}^{commit}")
+          if git show-ref --tags --verify --quiet "refs/tags/${TAG_NAME}"; then
+            EXISTING_SHA=$(git rev-parse "refs/tags/${TAG_NAME}^{commit}")
             if [[ "$EXISTING_SHA" == "$GITHUB_SHA" ]]; then
               echo "Tag ${TAG_NAME} already exists and points to current commit. Reusing."
               exit 0
@@ -69,11 +73,10 @@ jobs:
             fi
           fi
           
-          # Create and push tag
+          # Create tag locally (will be pushed after successful builds)
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${TAG_NAME}" -m "Nightly build ${TAG_NAME} (${SHORT_SHA})"
-          git push origin "${TAG_NAME}"
 
   build-postgres-image:
     needs: create-tag
@@ -335,16 +338,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  notify-completion:
+  push-tag:
     needs: [create-tag, create-release]
     runs-on: ubuntu-latest
     permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Push tag to remote
+        run: |
+          TAG_NAME="${{ needs.create-tag.outputs.tag_name }}"
+          echo "Pushing tag ${TAG_NAME} to remote..."
+          git push origin "${TAG_NAME}"
+          echo "Tag pushed successfully!"
+
+  notify-completion:
+    needs: [create-tag, push-tag]
+    runs-on: ubuntu-latest
+    permissions:
       contents: read
-    if: always()
+    if: success()
     steps:
       - name: Check build status
         run: |
-          echo "Nightly build completed!"
+          echo "Nightly build completed successfully!"
           echo "Tag: ${{ needs.create-tag.outputs.tag_name }}"
           echo "Release: https://github.com/${{ github.repository }}/releases/tag/${{ needs.create-tag.outputs.tag_name }}"
           echo "Images are available at:"


### PR DESCRIPTION
## Overview

This PR adds an automated nightly build workflow that runs at **5:00 AM IST** every day to create versioned releases and Docker images.

## What's Included

### 1. Scheduled Workflow (`.github/workflows/nightly-build.yml`)
- **Schedule**: Runs daily at 5:00 AM IST (11:30 PM UTC previous day)
- **Manual Trigger**: Can be triggered manually with optional tag suffix

### 2. Features

✅ **Automatic Tagging**
- Creates date-based Git tags: `nightly-YYYY.MM.DD`
- Optional suffix support (e.g., `nightly-2026.07.21-rc1`)

✅ **Multi-Architecture Docker Builds**
- PostgreSQL variant (`ghcr.io/juspay/decision-engine/postgres`)
- MySQL variant (`ghcr.io/juspay/decision-engine`)
- Groovy runner (`ghcr.io/juspay/decision-engine/groovy-runner`)
- Both linux/amd64 and linux/arm64 platforms

✅ **Image Tagging**
- Date-specific tags: `nightly-2026.07.21`
- Latest tag: `nightly-latest` (always points to most recent)

✅ **GitHub Releases**
- Creates pre-release with build metadata
- Includes commit SHA and timestamp
- Lists all Docker image URLs

✅ **Build Optimization**
- Uses GitHub Actions cache for faster builds
- Separate cache scopes for different platforms

### 3. Documentation
- Comprehensive README at `.github/workflows/NIGHTLY_BUILD_README.md`
- Usage examples and configuration guide

## Usage

### Pulling Images
```bash
# Specific nightly version
docker pull ghcr.io/juspay/decision-engine:nightly-2026.07.21

# Latest nightly
docker pull ghcr.io/juspay/decision-engine:nightly-latest
```

### Manual Trigger
1. Go to Actions → Nightly Build and Release
2. Click "Run workflow"
3. Optionally provide a tag suffix

## Benefits

1. **Automated Daily Builds**: No manual intervention needed
2. **Version Tracking**: Easy to identify and rollback to specific dates
3. **Pre-release Testing**: Teams can test nightly builds before stable releases
4. **Multi-Platform**: Supports both x86 and ARM architectures
5. **Consistent Schedule**: Always available at the same time daily

## Testing

The workflow can be tested immediately by:
1. Merging this PR
2. Manually triggering the workflow from Actions tab
3. Verifying tags and images are created successfully

## Notes

- Builds take approximately 30-45 minutes to complete
- All images are pushed to GitHub Container Registry (ghcr.io)
- Requires `contents: write` and `packages: write` permissions (already configured)
- Nightly builds are marked as pre-release in GitHub

## Related

- Reuses existing Docker build infrastructure from `docker-publish.yml`
- Compatible with current CI/CD workflows


Closes #360
