### PR TITLE
fix(workflow): Add smart tag naming and force-push support to nightly builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -47,36 +47,51 @@ jobs:
               echo "Provided: $TAG_SUFFIX"
               exit 1
             fi
-            TAG_NAME="nightly-${DATE_TAG}-${TAG_SUFFIX}"
+            BASE_TAG="nightly-${DATE_TAG}-${TAG_SUFFIX}"
           else
-            TAG_NAME="nightly-${DATE_TAG}"
+            BASE_TAG="nightly-${DATE_TAG}"
           fi
           
           SHORT_SHA="${GITHUB_SHA::7}"
           BUILT_AT=$(TZ=Asia/Kolkata date '+%Y-%m-%d %H:%M:%S IST')
           
+          # Check if base tag exists remotely and points to different commit
+          # If so, append run number to make it unique
+          TAG_NAME="${BASE_TAG}"
+          if git ls-remote --tags origin | grep -q "refs/tags/${BASE_TAG}$"; then
+            # Tag exists remotely, check if it points to current commit
+            git fetch origin "refs/tags/${BASE_TAG}:refs/tags/${BASE_TAG}" 2>/dev/null || true
+            EXISTING_SHA=$(git rev-parse "refs/tags/${BASE_TAG}^{commit}" 2>/dev/null || echo "")
+            
+            if [[ "$EXISTING_SHA" == "$GITHUB_SHA" ]]; then
+              echo "✓ Tag ${BASE_TAG} already exists and points to current commit ${SHORT_SHA}"
+              echo "  Reusing existing tag. Builds will update images."
+            else
+              # Tag exists but points to different commit, append run number
+              TAG_NAME="${BASE_TAG}-run${GITHUB_RUN_NUMBER}"
+              echo "⚠ Tag ${BASE_TAG} exists but points to different commit"
+              echo "  Creating unique tag: ${TAG_NAME}"
+            fi
+          else
+            echo "✓ Tag ${BASE_TAG} does not exist remotely. Will create new tag."
+          fi
+          
+          # Output the final tag name
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
           echo "built_at=${BUILT_AT}" >> $GITHUB_OUTPUT
-          echo "Creating tag: ${TAG_NAME} at commit ${SHORT_SHA}"
-          
-          # Check if tag already exists
-          if git show-ref --tags --verify --quiet "refs/tags/${TAG_NAME}"; then
-            EXISTING_SHA=$(git rev-parse "refs/tags/${TAG_NAME}^{commit}")
-            if [[ "$EXISTING_SHA" == "$GITHUB_SHA" ]]; then
-              echo "Tag ${TAG_NAME} already exists and points to current commit. Reusing."
-              exit 0
-            else
-              echo "Error: Tag ${TAG_NAME} already exists but points to different commit (${EXISTING_SHA})"
-              echo "Current commit: ${GITHUB_SHA}"
-              exit 1
-            fi
-          fi
+          echo "final_tag=${TAG_NAME}" >> $GITHUB_OUTPUT
           
           # Create tag locally (will be pushed after successful builds)
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG_NAME}" -m "Nightly build ${TAG_NAME} (${SHORT_SHA})"
+          
+          # Remove local tag if it exists
+          git tag -d "${TAG_NAME}" 2>/dev/null || true
+          
+          # Create the tag pointing to current commit
+          echo "Creating tag: ${TAG_NAME} → ${GITHUB_SHA}"
+          git tag -a "${TAG_NAME}" "${GITHUB_SHA}" -m "Nightly build ${TAG_NAME} (${SHORT_SHA})"
 
   build-postgres-image:
     needs: create-tag
@@ -357,17 +372,24 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
           # Re-create the tag (it was created locally in create-tag job but not pushed)
-          echo "Creating tag ${TAG_NAME} at commit ${GITHUB_SHA::7}..."
-          if git show-ref --tags --verify --quiet "refs/tags/${TAG_NAME}"; then
-            echo "Tag ${TAG_NAME} already exists locally. Skipping create."
-          else
-            git tag -a "${TAG_NAME}" "${GITHUB_SHA}" -m "Nightly build ${TAG_NAME} (${SHORT_SHA})"
-          fi
+          echo "Creating tag ${TAG_NAME} at commit ${GITHUB_SHA}..."
           
-          # Push tag to remote
+          # Remove local tag if it exists
+          git tag -d "${TAG_NAME}" 2>/dev/null || true
+          
+          # Create annotated tag pointing to current commit
+          git tag -a "${TAG_NAME}" "${GITHUB_SHA}" -m "Nightly build ${TAG_NAME} (${SHORT_SHA})"
+          
+          # Push tag to remote (force push to handle updates)
           echo "Pushing tag ${TAG_NAME} to remote..."
-          git push origin "${TAG_NAME}"
-          echo "Tag pushed successfully!"
+          if git ls-remote --tags origin | grep -q "refs/tags/${TAG_NAME}$"; then
+            echo "⚠ Tag exists remotely. Force-pushing to update..."
+            git push --force origin "${TAG_NAME}"
+          else
+            echo "✓ Pushing new tag..."
+            git push origin "${TAG_NAME}"
+          fi
+          echo "✓ Tag pushed successfully!"
 
   notify-completion:
     needs: [create-tag, push-tag]


### PR DESCRIPTION
## 🎯 Problem

Building on #327 (already merged), the nightly build workflow still has issues:

### 1. Tag Already Exists on Different Commit
```
Error: Tag nightly-2026.07.22 already exists but points to different commit
```
**Impact:** Cannot rerun workflow on same day with new commits

### 2. No Idempotency
**Impact:** Manual tag deletion required between runs

---

## ✅ Solution (Builds on #327)

#327 fixed the "missing tag in push-tag job" issue. This PR adds:

### 1. Smart Tag Naming

**Logic:**
1. Check if base tag exists remotely (`nightly-YYYY.MM.DD`)
2. If exists + same commit → reuse (idempotent ✅)
3. If exists + different commit → append `-run{N}` for uniqueness  
4. If doesn't exist → use base tag

**Examples:**
```bash
# First run of the day
Tag: nightly-2026.07.22

# Rerun on same commit
Tag: nightly-2026.07.22 (reuses)

# Rerun after new commits  
Tag: nightly-2026.07.22-run124
```

### 2. Force-Push Support

```bash
if git ls-remote --tags origin | grep -q "refs/tags/${TAG_NAME}$"; then
  git push --force origin "${TAG_NAME}"  # Update
else
  git push origin "${TAG_NAME}"  # New
fi
```

### 3. Explicit Commit Targeting

```bash
git tag -d "${TAG_NAME}" 2>/dev/null || true  # Remove conflicts
git tag -a "${TAG_NAME}" "${GITHUB_SHA}" -m "..."  # Explicit SHA
```

---

## 🧪 Testing

**Tested successfully in:** https://github.com/juspay/decision-engine/actions/runs/29897358092

All jobs passed:
- ✅ create-tag (smart naming worked - created `nightly-2026.07.22-run3`)
- ✅ All build jobs  
- ✅ push-tag (force-push worked)
- ✅ Release created

**Tag created:** `nightly-2026.07.22-run3`  
**Release:** https://github.com/juspay/decision-engine/releases/tag/nightly-2026.07.22-run3

---

## ✨ Benefits

- ✅ **Fully idempotent:** Safe to rerun multiple times
- ✅ **No manual intervention:** Workflow handles all edge cases
- ✅ **Clear diagnostics:** Status messages for debugging  
- ✅ **Production-ready:** Tested end-to-end successfully

---

## 📝 Changes

**Files Modified:** `.github/workflows/nightly-build.yml`

**Lines:** +47 / -25

**Key Changes:**
1. `create-tag`: Smart tag naming with remote check + run number
2. `push-tag`: Force-push support + explicit SHA targeting

---

## Related

- Builds on: #327 (merged - fixed tag transfer issue)
- Fixes: #325 (original nightly build feature)
- Supersedes: #328 (had merge conflicts, this is clean version)

## Checklist

- [x] Tested end-to-end successfully
- [x] All edge cases handled
- [x] Based on current main (no conflicts)
- [x] Production-ready


Closes #361
