### PR TITLE
feat(auth): self-serve forgot/reset password flow with session revocation

### DIFF
--- a/cypress/e2e/ui/forgot-password.cy.js
+++ b/cypress/e2e/ui/forgot-password.cy.js
@@ -1,0 +1,99 @@
+describe('Forgot password UI', () => {
+  const clearAuthStorage = {
+    onBeforeLoad(win) {
+      win.localStorage.removeItem('auth-store')
+      win.localStorage.removeItem('merchant-store')
+    },
+  }
+
+  beforeEach(() => {
+    cy.waitForService()
+  })
+
+  it('links from the login page to the forgot-password form', () => {
+    cy.visitAppPath('/login', clearAuthStorage)
+
+    cy.contains('a', 'Forgot password?').should('be.visible').click()
+    cy.location('pathname').should('include', '/forgot-password')
+    cy.contains('Forgot your password?').should('be.visible')
+    cy.contains('button', 'Send reset link').should('be.visible')
+  })
+
+  it('shows the generic confirmation after requesting a reset link', () => {
+    cy.intercept('POST', '**/decision-engine-api/auth/forgot-password', {
+      statusCode: 200,
+      body: { message: 'If an account exists for that email, a password reset link has been sent.' },
+    }).as('forgotPassword')
+
+    cy.visitAppPath('/forgot-password', clearAuthStorage)
+
+    cy.get('input[type="email"]').type('someone@example.com')
+    cy.contains('button', 'Send reset link').click()
+
+    cy.wait('@forgotPassword')
+    cy.contains('Check your inbox').should('be.visible')
+    cy.contains('someone@example.com').should('be.visible')
+    cy.contains('expires in 30 minutes').should('be.visible')
+  })
+
+  it('shows the missing-token card when opened without a token', () => {
+    cy.visitAppPath('/reset-password', clearAuthStorage)
+
+    cy.contains('Reset link is incomplete').should('be.visible')
+    cy.contains('button', 'Request a new link').click()
+    cy.location('pathname').should('include', '/forgot-password')
+  })
+
+  it('strips the token from the URL and blocks mismatched passwords without a request', () => {
+    cy.intercept('POST', '**/decision-engine-api/auth/reset-password', cy.spy().as('resetCall'))
+
+    cy.visitAppPath('/reset-password?token=test-token-123', clearAuthStorage)
+
+    cy.contains('Choose a new password').should('be.visible')
+    cy.location('search').should('not.contain', 'token')
+
+    cy.get('input[type="password"]').first().type('ValidPass1!')
+    cy.get('input[type="password"]').eq(1).type('DifferentPass1!')
+    cy.contains('button', 'Reset password').click()
+
+    cy.contains('Passwords do not match.').should('be.visible')
+    cy.get('@resetCall').should('not.have.been.called')
+  })
+
+  it('redirects to login with a success notice after resetting', () => {
+    cy.intercept('POST', '**/decision-engine-api/auth/reset-password', {
+      statusCode: 200,
+      body: { message: 'Password reset successfully. You can now sign in with your new password.' },
+    }).as('resetPassword')
+
+    cy.visitAppPath('/reset-password?token=test-token-123', clearAuthStorage)
+
+    cy.get('input[type="password"]').first().type('ValidPass1!')
+    cy.get('input[type="password"]').eq(1).type('ValidPass1!')
+    cy.contains('button', 'Reset password').click()
+
+    cy.wait('@resetPassword')
+      .its('request.body')
+      .should('deep.include', { token: 'test-token-123', new_password: 'ValidPass1!' })
+    cy.location('pathname').should('include', '/login')
+    cy.contains('Password reset successfully. Sign in with your new password.').should('be.visible')
+  })
+
+  it('offers a fresh link when the token is invalid or expired', () => {
+    cy.intercept('POST', '**/decision-engine-api/auth/reset-password', {
+      statusCode: 400,
+      body: { message: 'Invalid or expired password reset link' },
+    }).as('resetPassword')
+
+    cy.visitAppPath('/reset-password?token=used-token', clearAuthStorage)
+
+    cy.get('input[type="password"]').first().type('ValidPass1!')
+    cy.get('input[type="password"]').eq(1).type('ValidPass1!')
+    cy.contains('button', 'Reset password').click()
+
+    cy.wait('@resetPassword')
+    cy.contains('Invalid or expired password reset link').should('be.visible')
+    cy.contains('button', 'Request a new link').should('be.visible').click()
+    cy.location('pathname').should('include', '/forgot-password')
+  })
+})

--- a/docs/api-refs/auth-and-onboarding.mdx
+++ b/docs/api-refs/auth-and-onboarding.mdx
@@ -83,15 +83,19 @@ curl --location "$BASE_URL/auth/logout" \
 
 ## Verify Email
 
-Public route — the link sent by the signup email-verification flow calls this with the token from the email.
+Public route — the emailed verification link opens the dashboard's `/verify-email` page, which submits the single-use token here in the request body (never in the URL, so it cannot leak into request logs).
 
 ```bash
-curl "$BASE_URL/auth/verify-email?token=vf_9f21a6c0..."
+curl --location "$BASE_URL/auth/verify-email" \
+  --header "Content-Type: application/json" \
+  --data '{ "token": "vf_9f21a6c0..." }'
 ```
 
 ```json
-{ "message": "Email verified successfully." }
+{ "message": "Email verified successfully. You can now log in." }
 ```
+
+The token is single-use: a second submission returns `400` with `"Invalid or expired verification token"`. `GET /auth/verify-email?token=...` is still accepted as a deprecated compatibility shim for one release and will be removed.
 
 ## Change Password
 
@@ -106,8 +110,43 @@ curl --location "$BASE_URL/auth/change-password" \
 ```
 
 ```json
-{ "message": "Password updated successfully." }
+{ "message": "Password updated successfully.", "token": "eyJhbGciOi..." }
 ```
+
+Changing the password invalidates **all** previously issued JWTs for the user, including the one this request was made with — replace `$AUTH_HEADER` with the fresh `token` from the response.
+
+## Forgot Password
+
+Public route — requests a password-reset email. Always returns the same generic `200` regardless of whether the address has an account (no account enumeration). The emailed link is single-use and expires in 30 minutes. Rate limited per email address and per client IP; over-limit requests still receive the generic `200` but no email is sent.
+
+```bash
+curl --location "$BASE_URL/auth/forgot-password" \
+  --header "Content-Type: application/json" \
+  --data '{ "email": "operator@example.com" }'
+```
+
+```json
+{ "message": "If an account exists for that email, a password reset link has been sent." }
+```
+
+## Reset Password
+
+Public route — the link from the reset email opens the dashboard's `/reset-password` page, which submits the single-use token here. A successful reset also marks the email verified (mailbox control is proven) and invalidates all previously issued JWTs and any other outstanding reset links for the user.
+
+```bash
+curl --location "$BASE_URL/auth/reset-password" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "token": "DE_9f21a6c0...",
+    "new_password": "EvenStrongerPass#456"
+  }'
+```
+
+```json
+{ "message": "Password reset successfully. You can now sign in with your new password." }
+```
+
+An invalid, expired, or already-used token returns `400` with `"Invalid or expired password reset link"`.
 
 ## Team Management
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -620,7 +620,18 @@ where
             "/merchant/members/invite",
             post(routes::user_auth::invite_member),
         )
-        .route("/auth/verify-email", get(routes::user_auth::verify_email))
+        .route(
+            "/auth/verify-email",
+            get(routes::user_auth::verify_email_get).post(routes::user_auth::verify_email),
+        )
+        .route(
+            "/auth/forgot-password",
+            post(routes::user_auth::forgot_password),
+        )
+        .route(
+            "/auth/reset-password",
+            post(routes::user_auth::reset_password),
+        )
         .route(
             "/auth/change-password",
             post(routes::user_auth::change_password),

--- a/src/email/no_email.rs
+++ b/src/email/no_email.rs
@@ -5,25 +5,26 @@ pub struct NoEmailClient;
 #[async_trait::async_trait]
 impl EmailClient for NoEmailClient {
     async fn send_email(&self, message: EmailMessage) -> error_stack::Result<(), EmailError> {
-        // Extract the verification URL from the body so developers can complete
-        // email verification manually. Avoid logging the full HTML body for other
-        // email types (e.g. invite emails) because it would expose temporary passwords.
-        let verification_url = if message
-            .subject
-            .to_lowercase()
-            .contains("confirm your email")
+        // Extract the action URL from the body so developers can complete email
+        // verification or password reset manually. Avoid logging the full HTML body
+        // for other email types (e.g. invite emails) because it would expose
+        // temporary passwords. Reset URLs carry a live single-use credential, so they
+        // are only logged in debug builds — never from a release binary.
+        let subject_lower = message.subject.to_lowercase();
+        let action_url = if subject_lower.contains("confirm your email")
+            || (cfg!(debug_assertions) && subject_lower.contains("reset your password"))
         {
             extract_href_from_cta(&message.html_body)
         } else {
             None
         };
 
-        match verification_url {
+        match action_url {
             Some(url) => crate::logger::info!(
                 to = %message.to,
                 subject = %message.subject,
-                verification_url = %url,
-                "Email sending skipped (no_email_client) — use the verification_url to verify manually"
+                action_url = %url,
+                "Email sending skipped (no_email_client) — use the action_url to complete the flow manually"
             ),
             None => crate::logger::info!(
                 to = %message.to,

--- a/src/email/templates.rs
+++ b/src/email/templates.rs
@@ -198,6 +198,107 @@ impl EmailVerificationTemplate {
     }
 }
 
+pub struct PasswordResetTemplate {
+    pub user_email: String,
+    pub reset_url: String,
+}
+
+impl PasswordResetTemplate {
+    pub fn into_message(self) -> EmailMessage {
+        let url = escape_html(&self.reset_url);
+        let html_body = format!(
+            r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Reset your password — Juspay Decision Engine</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <!-- Preheader -->
+  <span style="display:none;max-height:0;overflow:hidden;mso-hide:all;">Reset your Juspay Decision Engine password. This link expires in 30 minutes.&#8202;&#65279;&#847;</span>
+
+  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#f1f5f9;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+        <table width="600" cellpadding="0" cellspacing="0" role="presentation" style="max-width:600px;width:100%;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background-color:#0b0e14;border-radius:16px 16px 0 0;padding:28px 40px;text-align:center;">
+              <span style="font-size:18px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">
+                <span style="color:#3b82f6;">&#9679;</span>&nbsp;Decision Engine
+              </span>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="background-color:#ffffff;padding:48px 48px 44px;border-left:1px solid #e2e8f0;border-right:1px solid #e2e8f0;">
+
+              <h1 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#0f172a;letter-spacing:-0.02em;line-height:1.3;">
+                Reset your password
+              </h1>
+              <p style="margin:0 0 32px;font-size:15px;line-height:1.75;color:#475569;">
+                We received a request to reset the password for your Juspay Decision Engine account. Click the button below to choose a new password.
+              </p>
+
+              <!-- CTA button -->
+              <table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 40px;">
+                <tr>
+                  <td style="background-color:#4371ff;border-radius:12px;">
+                    <a href="{url}"
+                       style="display:inline-block;background-color:#4371ff;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:12px;letter-spacing:-0.01em;">
+                      Reset password &rarr;
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Divider -->
+              <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 28px;">
+                <tr><td style="border-top:1px solid #e2e8f0;"></td></tr>
+              </table>
+
+              <p style="margin:0 0 8px;font-size:13px;color:#94a3b8;">
+                Button not working? Copy and paste this link into your browser:
+              </p>
+              <p style="margin:0;font-size:12px;word-break:break-all;line-height:1.6;">
+                <a href="{url}" style="color:#3b82f6;text-decoration:none;">{url}</a>
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background-color:#f8fafc;border-radius:0 0 16px 16px;padding:24px 48px;border:1px solid #e2e8f0;border-top:none;">
+              <p style="margin:0 0 6px;font-size:12px;color:#94a3b8;line-height:1.65;">
+                This link expires in <strong style="color:#64748b;">30 minutes</strong> and can be used only once.
+                If you didn&rsquo;t request a password reset, you can safely ignore this email &mdash; your password will not change.
+              </p>
+              <p style="margin:10px 0 0;font-size:11px;color:#cbd5e1;">
+                Juspay Decision Engine &nbsp;&middot;&nbsp; Automated security email &mdash; please do not reply.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"#,
+            url = url
+        );
+
+        EmailMessage {
+            to: self.user_email,
+            subject: "Reset your password — Juspay Decision Engine".to_string(),
+            html_body,
+        }
+    }
+}
+
 pub struct InviteUserTemplate {
     pub user_email: String,
     pub merchant_name: String,

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -346,6 +346,8 @@ pub enum UserAuthError {
     EmailSendFailed,
     #[error("Invalid or expired verification token")]
     InvalidVerificationToken,
+    #[error("Invalid or expired password reset link")]
+    InvalidResetToken,
 }
 
 impl axum::response::IntoResponse for UserAuthError {
@@ -368,6 +370,7 @@ impl axum::response::IntoResponse for UserAuthError {
             }
             Self::EmailSendFailed => (hyper::StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             Self::InvalidVerificationToken => (hyper::StatusCode::BAD_REQUEST, self.to_string()),
+            Self::InvalidResetToken => (hyper::StatusCode::BAD_REQUEST, self.to_string()),
         };
         (
             status,

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -89,6 +89,21 @@ const EMAIL_VERIFICATION_TTL_SECONDS: i64 = 86400; // 24 hours
 const PENDING_SIGNUP_PREFIX: &str = "pending_signup:";
 const PENDING_SIGNUP_TTL_SECONDS: i64 = 300; // 5 minutes
 
+/// One-time password-reset codes. Stored by SHA-256 of the code (never the code itself),
+/// so a leaked Redis snapshot cannot yield live reset links. Single-use via atomic DEL.
+const PASSWORD_RESET_CODE_PREFIX: &str = "password_reset_code:";
+const PASSWORD_RESET_CODE_TTL_SECONDS: i64 = 1800; // 30 minutes
+
+/// Unix timestamp of the user's last password change/reset. Any JWT minted before it is
+/// rejected in `verify_jwt_not_revoked`; the key self-expires once all such tokens would
+/// have expired anyway.
+const PASSWORD_RESET_AT_PREFIX: &str = "user_pwreset_at:";
+
+const FORGOT_PASSWORD_RATE_PREFIX: &str = "forgot_password_rate:";
+const FORGOT_PASSWORD_RATE_WINDOW_SECONDS: i64 = 3600;
+const FORGOT_PASSWORD_RATE_MAX_PER_EMAIL: i64 = 3;
+const FORGOT_PASSWORD_RATE_MAX_PER_IP: i64 = 30;
+
 #[axum::debug_handler]
 pub async fn signup(
     Json(payload): Json<SignupRequest>,
@@ -559,6 +574,28 @@ pub struct ChangePasswordRequest {
 #[derive(Debug, Serialize)]
 pub struct ChangePasswordResponse {
     pub message: String,
+    pub token: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ForgotPasswordRequest {
+    pub email: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ForgotPasswordResponse {
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResetPasswordRequest {
+    pub token: String,
+    pub new_password: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResetPasswordResponse {
+    pub message: String,
 }
 
 #[axum::debug_handler]
@@ -597,6 +634,12 @@ pub async fn change_password(
     let new_hash = auth::hash_password(&payload.new_password)
         .change_context(UserAuthError::PasswordHashingFailed)?;
 
+    // Revoke every session minted before this change — fail-closed and BEFORE the DB
+    // update: if Redis is down nothing has changed and the user retries; if the DB update
+    // below fails, sessions were revoked but the password is unchanged, which is safe.
+    // The fresh token is minted after, so its iat never precedes the cutoff.
+    record_password_reset_timestamp(&app_state, &claims.user_id, &global_config).await?;
+
     let conn = app_state
         .db
         .get_conn()
@@ -617,8 +660,348 @@ pub async fn change_password(
     .await
     .change_context(UserAuthError::StorageError)?;
 
+    let new_token = auth::generate_jwt(
+        &claims.user_id,
+        &claims.email,
+        &claims.merchant_id,
+        &claims.role,
+        &global_config.user_auth.jwt_secret,
+        global_config.user_auth.jwt_expiry_seconds,
+    )
+    .change_context(UserAuthError::TokenGenerationFailed)?;
+
     Ok(Json(ChangePasswordResponse {
         message: "Password updated successfully.".to_string(),
+        token: new_token,
+    }))
+}
+
+/// Record "passwords changed at" so `verify_jwt_not_revoked` rejects all JWTs minted
+/// earlier and `reset_password` rejects reset codes issued earlier. Fail-closed: a
+/// password change must not report success while old sessions remain revocable-in-name-
+/// only, so a Redis write failure is surfaced as an error (the read side stays fail-open,
+/// matching the jti denylist). The key outlives both every pre-change JWT and every
+/// outstanding reset code.
+async fn record_password_reset_timestamp(
+    app_state: &crate::app::TenantAppState,
+    user_id: &str,
+    global_config: &crate::config::GlobalConfig,
+) -> Result<(), error::ContainerError<UserAuthError>> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|_| error::ContainerError::from(UserAuthError::StorageError))?;
+    let reset_at_key = format!("{}{}", PASSWORD_RESET_AT_PREFIX, user_id);
+    let ttl = std::cmp::max(
+        global_config.user_auth.jwt_expiry_seconds as i64,
+        PASSWORD_RESET_CODE_TTL_SECONDS,
+    );
+    if let Err(err) = app_state
+        .redis_conn
+        .set_key_with_ttl(&reset_at_key, &now.as_secs().to_string(), ttl)
+        .await
+    {
+        crate::logger::warn!(
+            error = ?err,
+            "Failed to record password change timestamp; refusing to complete the change"
+        );
+        return Err(error::ContainerError::from(UserAuthError::StorageError));
+    }
+    Ok(())
+}
+
+/// INCR-first fixed-window counter; returns true when the bucket is over `max`. The
+/// window TTL is attached when this INCR created the key (count == 1); if attaching it
+/// fails the counter is deleted so a TTL-less key can never lock a bucket out
+/// permanently. Redis errors fail open (never throttle).
+async fn is_forgot_password_rate_limited(
+    app_state: &crate::app::TenantAppState,
+    key: &str,
+    max: i64,
+) -> bool {
+    let Ok(count) = app_state.redis_conn.increment_key(key).await else {
+        return false;
+    };
+    if count == 1 {
+        if let Err(err) = app_state
+            .redis_conn
+            .expire_key(key, FORGOT_PASSWORD_RATE_WINDOW_SECONDS)
+            .await
+        {
+            let _ = app_state.redis_conn.delete_key(key).await;
+            crate::logger::warn!(error = ?err, "Failed to set forgot-password rate-limit TTL");
+        }
+    }
+    count > max
+}
+
+#[axum::debug_handler]
+pub async fn forgot_password(
+    headers: HeaderMap,
+    Json(payload): Json<ForgotPasswordRequest>,
+) -> Result<Json<ForgotPasswordResponse>, error::ContainerError<UserAuthError>> {
+    let app_state = get_tenant_app_state().await;
+    let global_config = APP_STATE
+        .get()
+        .map(|s| s.global_config.clone())
+        .ok_or(UserAuthError::StorageError)?;
+    let email_client = APP_STATE
+        .get()
+        .map(|s| s.email_client.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    // Every path below returns this same body — the response must never reveal whether
+    // the address has an account.
+    let generic_response = || {
+        Json(ForgotPasswordResponse {
+            message: "If an account exists for that email, a password reset link has been sent."
+                .to_string(),
+        })
+    };
+
+    let email = payload.email.trim().to_string();
+    if email.is_empty()
+        || email.len() > 254
+        || !email.contains('@')
+        || email.contains(char::is_whitespace)
+    {
+        return Ok(generic_response());
+    }
+
+    // Rate limit per email and per client IP. Counters advance for existing and
+    // unknown emails alike so limiter behavior leaks nothing about account existence.
+    let email_rate_key = format!(
+        "{}email:{}",
+        FORGOT_PASSWORD_RATE_PREFIX,
+        auth::hash_api_key(&email.to_lowercase())
+    );
+    if is_forgot_password_rate_limited(&app_state, &email_rate_key, FORGOT_PASSWORD_RATE_MAX_PER_EMAIL)
+        .await
+    {
+        return Ok(generic_response());
+    }
+
+    // Only the RIGHTMOST x-forwarded-for entry is trustworthy — it is the hop appended by
+    // our own reverse proxy; everything left of it is client-supplied. Parsing as an IP
+    // rejects forged free-text so arbitrary header bytes can't become Redis keys.
+    let client_ip = headers
+        .get("x-forwarded-for")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.rsplit(',').next())
+        .and_then(|value| value.trim().parse::<std::net::IpAddr>().ok())
+        .or_else(|| {
+            headers
+                .get("x-real-ip")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.trim().parse::<std::net::IpAddr>().ok())
+        });
+    if let Some(ip) = client_ip {
+        let ip_rate_key = format!("{}ip:{}", FORGOT_PASSWORD_RATE_PREFIX, ip);
+        if is_forgot_password_rate_limited(&app_state, &ip_rate_key, FORGOT_PASSWORD_RATE_MAX_PER_IP)
+            .await
+        {
+            return Ok(generic_response());
+        }
+    }
+
+    let mut users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+        &app_state.db,
+        dsl::email.eq(email.clone()),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+
+    let Some(user) = users.pop() else {
+        return Ok(generic_response());
+    };
+
+    let is_active = {
+        #[cfg(feature = "mysql")]
+        {
+            user.is_active != 0
+        }
+        #[cfg(feature = "postgres")]
+        {
+            user.is_active
+        }
+    };
+    if !is_active {
+        return Ok(generic_response());
+    }
+    // Unverified-but-active users DO get the email: completing a reset proves mailbox
+    // control (it sets email_verified), so this is also the escape hatch for users who
+    // lost their verification email.
+
+    // Issue the code and send the email off the request path: the SES round trip and any
+    // failure it produces must not be observable in the response, or they become an
+    // account-existence oracle (latency, or a 500 only the user-exists branch can hit).
+    let base_url = global_config.email.base_url.clone();
+    let bg_state = app_state.clone();
+    tokio::spawn(async move {
+        let code = auth::generate_api_key();
+        let code_key = format!("{}{}", PASSWORD_RESET_CODE_PREFIX, auth::hash_api_key(&code));
+        // The value carries the issue time so redemption can reject codes issued before
+        // the user's last password change/reset (see `reset_password`).
+        let issued_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let code_value = format!("{}:{}", user.user_id, issued_at);
+        if let Err(err) = bg_state
+            .redis_conn
+            .set_key_with_ttl(&code_key, &code_value, PASSWORD_RESET_CODE_TTL_SECONDS)
+            .await
+        {
+            crate::logger::warn!(error = ?err, "Failed to store password reset code");
+            return;
+        }
+
+        let reset_url = format!("{}/reset-password?token={}", base_url, code);
+        if let Err(err) = email_client
+            .send_email(
+                crate::email::templates::PasswordResetTemplate {
+                    user_email: user.email.clone(),
+                    reset_url,
+                }
+                .into_message(),
+            )
+            .await
+        {
+            crate::logger::warn!(
+                to = %user.email,
+                error = ?err,
+                "Failed to send password reset email"
+            );
+            let _ = bg_state.redis_conn.delete_key(&code_key).await;
+        }
+    });
+
+    Ok(generic_response())
+}
+
+#[axum::debug_handler]
+pub async fn reset_password(
+    Json(payload): Json<ResetPasswordRequest>,
+) -> Result<Json<ResetPasswordResponse>, error::ContainerError<UserAuthError>> {
+    let app_state = get_tenant_app_state().await;
+    let global_config = APP_STATE
+        .get()
+        .map(|s| s.global_config.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    // Validate strength before touching the code — a weak password must not burn the
+    // single-use link.
+    auth::validate_password_strength(&payload.new_password)
+        .change_context(UserAuthError::WeakPassword)?;
+
+    let code_key = format!(
+        "{}{}",
+        PASSWORD_RESET_CODE_PREFIX,
+        auth::hash_api_key(&payload.token)
+    );
+    // A missing/expired/unknown code reads as a failure — treat any failure to read it as
+    // an invalid code, not a server error.
+    let stored_value = match app_state.redis_conn.get_key_string(&code_key).await {
+        Ok(value) if !value.is_empty() => value,
+        _ => return Err(error::ContainerError::from(UserAuthError::InvalidResetToken)),
+    };
+
+    // Atomically claim the code by deleting it. `DEL` reports whether *this* call removed
+    // the key, so with two concurrent redemptions exactly one sees KeyDeleted — the other
+    // (already consumed, expired, or replayed) is rejected.
+    let claimed = app_state
+        .redis_conn
+        .delete_key(&code_key)
+        .await
+        .change_context(UserAuthError::StorageError)?;
+    if !matches!(claimed, redis_interface::types::DelReply::KeyDeleted) {
+        return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
+    }
+
+    // Value format: "<user_id>:<issued_at_unix>" (user_ids are UUIDs, so the last colon
+    // is unambiguous).
+    let Some((user_id, issued_at)) = stored_value
+        .rsplit_once(':')
+        .and_then(|(id, ts)| ts.parse::<u64>().ok().map(|ts| (id.to_string(), ts)))
+    else {
+        return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
+    };
+
+    // Reject codes issued before the user's last password change/reset — once the
+    // password changes, every previously emailed link must die with it. Strict `<`
+    // mirrors the JWT iat check; fail-open on Redis read errors, like that check.
+    let reset_at_key = format!("{}{}", PASSWORD_RESET_AT_PREFIX, user_id);
+    if let Ok(val) = app_state.redis_conn.get_key_string(&reset_at_key).await {
+        if let Ok(reset_at) = val.parse::<u64>() {
+            if issued_at < reset_at {
+                return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
+            }
+        }
+    }
+
+    // Re-check the account at redemption time — it may have been deactivated during the
+    // code's 30-minute lifetime. Report inactive/missing identically to a bad code.
+    let mut users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+        &app_state.db,
+        dsl::user_id.eq(user_id.clone()),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+    let Some(user) = users.pop() else {
+        return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
+    };
+    let is_active = {
+        #[cfg(feature = "mysql")]
+        {
+            user.is_active != 0
+        }
+        #[cfg(feature = "postgres")]
+        {
+            user.is_active
+        }
+    };
+    if !is_active {
+        return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
+    }
+
+    // No same-as-old-password check here, deliberately: the requester has proven mailbox
+    // control, and rejecting reuse after the atomic claim would burn the single-use code
+    // on a recoverable error while confirming the current password to whoever holds the
+    // link. Checking before the claim would be worse — a non-consuming password oracle.
+    let new_hash = auth::hash_password(&payload.new_password)
+        .change_context(UserAuthError::PasswordHashingFailed)?;
+
+    let conn = app_state
+        .db
+        .get_conn()
+        .await
+        .change_error(UserAuthError::StorageError)?;
+
+    // Completing a reset proves control of the mailbox, so mark the email verified in
+    // the same statement — this also unsticks users who never received the signup
+    // verification email.
+    crate::generics::generic_update_if_present::<
+        <User as HasTable>::Table,
+        crate::storage::types::UserPasswordResetUpdate,
+        _,
+    >(
+        &conn,
+        dsl::user_id.eq(user_id.clone()),
+        crate::storage::types::UserPasswordResetUpdate {
+            password_hash: new_hash,
+            #[cfg(feature = "mysql")]
+            email_verified: 1,
+            #[cfg(feature = "postgres")]
+            email_verified: true,
+        },
+    )
+    .await
+    .change_context(UserAuthError::StorageError)?;
+
+    record_password_reset_timestamp(&app_state, &user_id, &global_config).await?;
+
+    Ok(Json(ResetPasswordResponse {
+        message: "Password reset successfully. You can now sign in with your new password."
+            .to_string(),
     }))
 }
 
@@ -1061,21 +1444,59 @@ pub struct VerifyEmailQuery {
     pub token: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct VerifyEmailRequest {
+    pub token: String,
+}
+
+/// POST /auth/verify-email — the SPA submits the token from the emailed link in the JSON
+/// body, so the live token never appears in a backend URL (the request tracing span
+/// records full URIs, query string included).
 #[axum::debug_handler]
 pub async fn verify_email(
+    Json(payload): Json<VerifyEmailRequest>,
+) -> Result<Json<VerifyEmailResponse>, error::ContainerError<UserAuthError>> {
+    consume_verification_token(&payload.token).await
+}
+
+/// GET /auth/verify-email?token= — deprecated compatibility shim for SPA bundles cached
+/// from before the POST variant existed; remove after one release. This path puts the
+/// token in a logged URL, which is exactly what the POST variant exists to avoid.
+#[axum::debug_handler]
+pub async fn verify_email_get(
     Query(query): Query<VerifyEmailQuery>,
+) -> Result<Json<VerifyEmailResponse>, error::ContainerError<UserAuthError>> {
+    consume_verification_token(&query.token).await
+}
+
+async fn consume_verification_token(
+    token: &str,
 ) -> Result<Json<VerifyEmailResponse>, error::ContainerError<UserAuthError>> {
     let app_state = get_tenant_app_state().await;
 
-    let redis_key = format!("{}{}", EMAIL_VERIFICATION_PREFIX, query.token);
+    let redis_key = format!("{}{}", EMAIL_VERIFICATION_PREFIX, token);
 
-    let user_id = app_state
+    // A missing/expired/unknown token reads as a failure — treat any failure to read it
+    // as an invalid token, not a server error (same mapping as `reset_password`).
+    let user_id = match app_state.redis_conn.get_key_string(&redis_key).await {
+        Ok(user_id) if !user_id.is_empty() => user_id,
+        _ => {
+            return Err(error::ContainerError::from(
+                UserAuthError::InvalidVerificationToken,
+            ))
+        }
+    };
+
+    // Atomically claim the token by deleting it BEFORE the DB write — with two concurrent
+    // submissions exactly one sees KeyDeleted (same single-use pattern as
+    // `reset_password`). If the DB update below then fails the token is burned; the user
+    // is not stranded — completing a password reset also marks the email verified.
+    let claimed = app_state
         .redis_conn
-        .get_key_string(&redis_key)
+        .delete_key(&redis_key)
         .await
         .change_context(UserAuthError::StorageError)?;
-
-    if user_id.is_empty() {
+    if !matches!(claimed, redis_interface::types::DelReply::KeyDeleted) {
         return Err(error::ContainerError::from(
             UserAuthError::InvalidVerificationToken,
         ));
@@ -1111,8 +1532,6 @@ pub async fn verify_email(
         ));
     }
 
-    let _ = app_state.redis_conn.delete_key(&redis_key).await;
-
     Ok(Json(VerifyEmailResponse {
         message: "Email verified successfully. You can now log in.".to_string(),
     }))
@@ -1137,6 +1556,18 @@ pub async fn verify_jwt_not_revoked(
     if let Ok(val) = app_state.redis_conn.get_key_string(&deny_key).await {
         if !val.is_empty() {
             return Err(ContainerError::from(UserAuthError::InvalidToken));
+        }
+    }
+
+    // Reject tokens minted before the user's last password change/reset. Strict `<`
+    // keeps a token minted in the same second as the change (e.g. the fresh token
+    // change-password returns) valid. Fail-open on Redis errors, like the denylist.
+    let reset_key = format!("{}{}", PASSWORD_RESET_AT_PREFIX, claims.user_id);
+    if let Ok(val) = app_state.redis_conn.get_key_string(&reset_key).await {
+        if let Ok(reset_at) = val.parse::<u64>() {
+            if claims.iat < reset_at {
+                return Err(ContainerError::from(UserAuthError::InvalidToken));
+            }
         }
     }
 

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -913,3 +913,14 @@ pub struct UserEmailVerifiedUpdate {
 pub struct UserPasswordUpdate {
     pub password_hash: String,
 }
+
+#[derive(AsChangeset, Debug)]
+#[cfg_attr(feature = "mysql", diesel(table_name = schema::users))]
+#[cfg_attr(feature = "postgres", diesel(table_name = schema_pg::users))]
+pub struct UserPasswordResetUpdate {
+    pub password_hash: String,
+    #[cfg(feature = "mysql")]
+    pub email_verified: i8,
+    #[cfg(feature = "postgres")]
+    pub email_verified: bool,
+}

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -18,6 +18,8 @@ import { OnboardingPage } from './pages/OnboardingPage'
 import { MembersPage } from './pages/MembersPage'
 import { ApiKeysPage } from './pages/ApiKeysPage'
 import { VerifyEmailPage } from './pages/VerifyEmailPage'
+import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
+import { ResetPasswordPage } from './pages/ResetPasswordPage'
 import { AccountPage } from './pages/AccountPage'
 
 export default function App() {
@@ -26,6 +28,8 @@ export default function App() {
       <Route path="login" element={<AuthPage />} />
       <Route path="signup" element={<AuthPage />} />
       <Route path="verify-email" element={<VerifyEmailPage />} />
+      <Route path="forgot-password" element={<ForgotPasswordPage />} />
+      <Route path="reset-password" element={<ResetPasswordPage />} />
       <Route element={<AuthGuard />}>
         <Route path="onboarding" element={<OnboardingPage />} />
         <Route element={<AppShell />}>

--- a/website/src/lib/apiError.ts
+++ b/website/src/lib/apiError.ts
@@ -1,0 +1,14 @@
+/** Extract the human-readable message from an `API error <status>: <json>` error. */
+export function getApiErrorMessage(err: unknown): string {
+  const msg = err instanceof Error ? err.message : 'Something went wrong'
+  const match = msg.match(/API error \d+: (.+)/)
+
+  if (!match) return msg
+
+  try {
+    const parsed = JSON.parse(match[1])
+    return parsed.message ?? msg
+  } catch {
+    return match[1]
+  }
+}

--- a/website/src/lib/passwordPolicy.ts
+++ b/website/src/lib/passwordPolicy.ts
@@ -1,0 +1,8 @@
+export function getPasswordPolicyError(password: string): string | null {
+  if (password.length < 10) return 'Use at least 10 characters.'
+  if (!/[A-Z]/.test(password)) return 'Add at least one uppercase letter.'
+  if (!/[a-z]/.test(password)) return 'Add at least one lowercase letter.'
+  if (!/[0-9]/.test(password)) return 'Add at least one number.'
+  if (!/[^A-Za-z0-9]/.test(password)) return 'Add at least one special character.'
+  return null
+}

--- a/website/src/pages/AccountPage.tsx
+++ b/website/src/pages/AccountPage.tsx
@@ -1,20 +1,20 @@
 import { useState } from 'react'
 import { Eye, EyeOff, KeyRound } from 'lucide-react'
 import { apiFetch } from '../lib/api'
+import { getApiErrorMessage } from '../lib/apiError'
+import { getPasswordPolicyError } from '../lib/passwordPolicy'
+import { useAuthStore } from '../store/authStore'
 import { Card, CardBody, CardHeader } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { ErrorMessage } from '../components/ui/ErrorMessage'
 
-function getPasswordPolicyError(password: string): string | null {
-  if (password.length < 10) return 'Use at least 10 characters.'
-  if (!/[A-Z]/.test(password)) return 'Add at least one uppercase letter.'
-  if (!/[a-z]/.test(password)) return 'Add at least one lowercase letter.'
-  if (!/[0-9]/.test(password)) return 'Add at least one number.'
-  if (!/[^A-Za-z0-9]/.test(password)) return 'Add at least one special character.'
-  return null
+interface ChangePasswordResponse {
+  message: string
+  token: string
 }
 
 export function AccountPage() {
+  const setToken = useAuthStore((s) => s.setToken)
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -36,23 +36,19 @@ export function AccountPage() {
 
     setLoading(true)
     try {
-      await apiFetch('/auth/change-password', {
+      const res = await apiFetch<ChangePasswordResponse>('/auth/change-password', {
         method: 'POST',
         body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
       })
+      // Changing the password revokes every previously issued session token, including
+      // the one this request was made with — swap in the fresh one from the response.
+      if (res.token) setToken(res.token)
       setSuccess(true)
       setCurrentPassword('')
       setNewPassword('')
       setConfirmPassword('')
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Something went wrong'
-      const match = msg.match(/API error \d+: (.+)/)
-      if (match) {
-        try { setError(JSON.parse(match[1]).message ?? match[1]) }
-        catch { setError(match[1]) }
-      } else {
-        setError(msg)
-      }
+      setError(getApiErrorMessage(err))
     } finally {
       setLoading(false)
     }

--- a/website/src/pages/AuthPage.tsx
+++ b/website/src/pages/AuthPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import {
   ArrowRight,
   Building2,
@@ -14,6 +14,8 @@ import {
 import { useAuthStore, MerchantInfo } from '../store/authStore'
 import { useMerchantStore } from '../store/merchantStore'
 import { apiFetch } from '../lib/api'
+import { getApiErrorMessage } from '../lib/apiError'
+import { getPasswordPolicyError } from '../lib/passwordPolicy'
 import { getResolvedThemePreference, persistThemePreference } from '../lib/theme'
 import { SurfaceLabel } from '../components/ui/Card'
 import { ErrorMessage } from '../components/ui/ErrorMessage'
@@ -51,44 +53,6 @@ interface AuthLocationState {
 
 function getTabFromPath(pathname: string): Tab {
   return pathname.endsWith('/signup') ? 'signup' : 'login'
-}
-
-function getPasswordPolicyError(password: string): string | null {
-  if (password.length < 10) {
-    return 'Use at least 10 characters.'
-  }
-
-  if (!/[A-Z]/.test(password)) {
-    return 'Add at least one uppercase letter.'
-  }
-
-  if (!/[a-z]/.test(password)) {
-    return 'Add at least one lowercase letter.'
-  }
-
-  if (!/[0-9]/.test(password)) {
-    return 'Add at least one number.'
-  }
-
-  if (!/[^A-Za-z0-9]/.test(password)) {
-    return 'Add at least one special character.'
-  }
-
-  return null
-}
-
-function getApiErrorMessage(err: unknown): string {
-  const msg = err instanceof Error ? err.message : 'Something went wrong'
-  const match = msg.match(/API error \d+: (.+)/)
-
-  if (!match) return msg
-
-  try {
-    const parsed = JSON.parse(match[1])
-    return parsed.message ?? msg
-  } catch {
-    return match[1]
-  }
 }
 
 function isDuplicateEmailError(message: string): boolean {
@@ -359,9 +323,16 @@ export function AuthPage() {
                   <Field
                     label="Password"
                     footer={
-                      tab === 'login'
-                        ? 'Password reset is managed by your account admin.'
-                        : 'Use at least 10 characters with uppercase, lowercase, number, and special character.'
+                      tab === 'login' ? (
+                        <Link
+                          to="/forgot-password"
+                          className="font-medium text-brand-500 hover:underline"
+                        >
+                          Forgot password?
+                        </Link>
+                      ) : (
+                        'Use at least 10 characters with uppercase, lowercase, number, and special character.'
+                      )
                     }
                   >
                     <div className="relative">
@@ -466,14 +437,18 @@ function Field({
 }: {
   label: string
   children: React.ReactNode
-  footer?: string
+  footer?: React.ReactNode
 }) {
+  // The footer renders outside the <label>: it may contain interactive content (e.g. the
+  // "Forgot password?" link), which must not be part of the input's label subtree.
   return (
-    <label className="block">
-      <SurfaceLabel className="mb-2 block text-slate-500 dark:text-[#8a94a7]">{label}</SurfaceLabel>
-      {children}
+    <div>
+      <label className="block">
+        <SurfaceLabel className="mb-2 block text-slate-500 dark:text-[#8a94a7]">{label}</SurfaceLabel>
+        {children}
+      </label>
       {footer ? <p className="mt-2 text-xs leading-5 text-slate-500 dark:text-[#7b8496]">{footer}</p> : null}
-    </label>
+    </div>
   )
 }
 

--- a/website/src/pages/ForgotPasswordPage.tsx
+++ b/website/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { KeyRound, Loader2, Mail, MailCheck, Moon, Sun } from 'lucide-react'
+import { apiPost } from '../lib/api'
+import { getApiErrorMessage } from '../lib/apiError'
+import { getResolvedThemePreference, persistThemePreference } from '../lib/theme'
+import { ErrorMessage } from '../components/ui/ErrorMessage'
+
+export function ForgotPasswordPage() {
+  const navigate = useNavigate()
+  const [isDark, setIsDark] = useState(() => getResolvedThemePreference() === 'dark')
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const assetBaseUrl = import.meta.env.BASE_URL
+
+  function handleThemeToggle() {
+    const next = isDark ? 'light' : 'dark'
+    setIsDark(next === 'dark')
+    persistThemePreference(next)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await apiPost('/auth/forgot-password', { email })
+      setSubmitted(true)
+    } catch (err) {
+      setError(getApiErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-white text-slate-900 dark:bg-[#030507] dark:text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,_rgba(59,130,246,0.06),_transparent_24%),radial-gradient(circle_at_78%_20%,_rgba(14,165,233,0.04),_transparent_18%),radial-gradient(circle_at_50%_100%,_rgba(14,165,233,0.03),_transparent_24%)] dark:bg-[radial-gradient(circle_at_18%_18%,_rgba(56,189,248,0.05),_transparent_24%),radial-gradient(circle_at_78%_20%,_rgba(59,130,246,0.04),_transparent_18%),radial-gradient(circle_at_50%_100%,_rgba(14,165,233,0.035),_transparent_24%)]" />
+      <div className="pointer-events-none absolute inset-0 opacity-[0.05] dark:opacity-[0.08] [background-image:linear-gradient(rgba(148,163,184,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,0.08)_1px,transparent_1px)] [background-size:56px_56px]" />
+
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <header className="flex items-center justify-between px-6 py-5 sm:px-10">
+          <div>
+            <img
+              src={`${assetBaseUrl}logo/decision-engine-light.svg`}
+              alt="Juspay Decision Engine"
+              className="h-10 w-auto dark:hidden sm:h-11"
+            />
+            <img
+              src={`${assetBaseUrl}logo/decision-engine-dark.svg`}
+              alt="Juspay Decision Engine"
+              className="hidden h-10 w-auto dark:block sm:h-11"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handleThemeToggle}
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-white/8 dark:hover:text-white"
+            aria-label="Toggle theme"
+            title="Toggle theme"
+          >
+            {isDark ? <Sun size={18} /> : <Moon size={18} />}
+          </button>
+        </header>
+
+        <div className="flex flex-1 items-center justify-center px-6 py-12">
+          <div className="w-full max-w-[420px] rounded-3xl border border-slate-200 bg-white px-10 py-12 shadow-[0_20px_60px_-20px_rgba(15,23,42,0.08)] dark:border-[#1d1d23] dark:bg-[#0b0e14] dark:shadow-none">
+            {submitted ? (
+              <div className="space-y-5 text-center">
+                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-500/10">
+                  <MailCheck size={28} className="text-emerald-500" />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xl font-semibold tracking-tight text-slate-950 dark:text-white">
+                    Check your inbox
+                  </p>
+                  <p className="text-sm leading-6 text-slate-500 dark:text-[#8a94a7]">
+                    If an account exists for{' '}
+                    <span className="font-medium text-slate-700 dark:text-slate-300">{email}</span>,
+                    a reset link is on its way. The link expires in 30 minutes.
+                  </p>
+                </div>
+                <div className="pt-2">
+                  <button
+                    onClick={() => navigate('/login')}
+                    className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(90deg,#4371ff_0%,#3a63f4_100%)] px-6 text-sm font-semibold text-white transition-all hover:brightness-110"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                <div className="space-y-3 text-center">
+                  <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-brand-500/10">
+                    <KeyRound size={28} className="text-brand-500" />
+                  </div>
+                  <p className="text-xl font-semibold tracking-tight text-slate-950 dark:text-white">
+                    Forgot your password?
+                  </p>
+                  <p className="text-sm leading-6 text-slate-500 dark:text-[#8a94a7]">
+                    Enter your account email and we&rsquo;ll send you a link to reset it.
+                  </p>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  <label className="block">
+                    <span className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-[#8a94a7]">
+                      Email
+                    </span>
+                    <div className="relative">
+                      <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 dark:text-[#667085]">
+                        <Mail size={16} />
+                      </span>
+                      <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="name@company.com"
+                        required
+                        autoFocus
+                        className="h-12 w-full rounded-xl border border-slate-200 bg-white pl-11 pr-4 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-white"
+                      />
+                    </div>
+                  </label>
+
+                  <ErrorMessage error={error} />
+
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(90deg,#4371ff_0%,#3a63f4_100%)] px-6 text-sm font-semibold text-white transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {loading ? (
+                      <>
+                        <Loader2 size={16} className="animate-spin" />
+                        Sending link
+                      </>
+                    ) : (
+                      'Send reset link'
+                    )}
+                  </button>
+                </form>
+
+                <p className="text-center text-sm text-slate-500 dark:text-[#8a94a7]">
+                  Remembered it?{' '}
+                  <button
+                    type="button"
+                    onClick={() => navigate('/login')}
+                    className="font-medium text-brand-500 hover:underline"
+                  >
+                    Back to sign in
+                  </button>
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <footer className="px-6 py-5 text-center text-xs text-slate-400 dark:text-[#525866]">
+          Juspay Decision Engine
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/website/src/pages/ResetPasswordPage.tsx
+++ b/website/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Eye, EyeOff, Loader2, LockKeyhole, Moon, Sun, XCircle } from 'lucide-react'
+import { apiPost } from '../lib/api'
+import { getApiErrorMessage } from '../lib/apiError'
+import { getPasswordPolicyError } from '../lib/passwordPolicy'
+import { getResolvedThemePreference, persistThemePreference } from '../lib/theme'
+import { useAuthStore } from '../store/authStore'
+import { ErrorMessage } from '../components/ui/ErrorMessage'
+
+export function ResetPasswordPage() {
+  const navigate = useNavigate()
+  const [isDark, setIsDark] = useState(() => getResolvedThemePreference() === 'dark')
+  // Capture the token before it is stripped from the URL below.
+  const [token] = useState(() => new URLSearchParams(window.location.search).get('token'))
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const assetBaseUrl = import.meta.env.BASE_URL
+
+  useEffect(() => {
+    // The one-time code shouldn't linger in the address bar, browser history, or leak
+    // via the Referer header — strip it immediately and suppress referrers on this page.
+    const params = new URLSearchParams(window.location.search)
+    if (params.has('token')) {
+      params.delete('token')
+      const newSearch = params.toString()
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + (newSearch ? `?${newSearch}` : ''),
+      )
+    }
+
+    const meta = document.createElement('meta')
+    meta.name = 'referrer'
+    meta.content = 'no-referrer'
+    document.head.appendChild(meta)
+    return () => {
+      document.head.removeChild(meta)
+    }
+  }, [])
+
+  function handleThemeToggle() {
+    const next = isDark ? 'light' : 'dark'
+    setIsDark(next === 'dark')
+    persistThemePreference(next)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    const policyError = getPasswordPolicyError(newPassword)
+    if (policyError) {
+      setError(policyError)
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      await apiPost('/auth/reset-password', { token, new_password: newPassword })
+      // Any session persisted in this browser now holds a revoked JWT; clear it so the
+      // login page shows the success notice instead of bouncing through the dashboard.
+      useAuthStore.getState().clearAuth()
+      navigate('/login', {
+        replace: true,
+        state: { notice: 'Password reset successfully. Sign in with your new password.' },
+      })
+    } catch (err) {
+      setError(getApiErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const isExpiredLinkError = error != null && /invalid or expired/i.test(error)
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-white text-slate-900 dark:bg-[#030507] dark:text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,_rgba(59,130,246,0.06),_transparent_24%),radial-gradient(circle_at_78%_20%,_rgba(14,165,233,0.04),_transparent_18%),radial-gradient(circle_at_50%_100%,_rgba(14,165,233,0.03),_transparent_24%)] dark:bg-[radial-gradient(circle_at_18%_18%,_rgba(56,189,248,0.05),_transparent_24%),radial-gradient(circle_at_78%_20%,_rgba(59,130,246,0.04),_transparent_18%),radial-gradient(circle_at_50%_100%,_rgba(14,165,233,0.035),_transparent_24%)]" />
+      <div className="pointer-events-none absolute inset-0 opacity-[0.05] dark:opacity-[0.08] [background-image:linear-gradient(rgba(148,163,184,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,0.08)_1px,transparent_1px)] [background-size:56px_56px]" />
+
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <header className="flex items-center justify-between px-6 py-5 sm:px-10">
+          <div>
+            <img
+              src={`${assetBaseUrl}logo/decision-engine-light.svg`}
+              alt="Juspay Decision Engine"
+              className="h-10 w-auto dark:hidden sm:h-11"
+            />
+            <img
+              src={`${assetBaseUrl}logo/decision-engine-dark.svg`}
+              alt="Juspay Decision Engine"
+              className="hidden h-10 w-auto dark:block sm:h-11"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handleThemeToggle}
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-white/8 dark:hover:text-white"
+            aria-label="Toggle theme"
+            title="Toggle theme"
+          >
+            {isDark ? <Sun size={18} /> : <Moon size={18} />}
+          </button>
+        </header>
+
+        <div className="flex flex-1 items-center justify-center px-6 py-12">
+          <div className="w-full max-w-[420px] rounded-3xl border border-slate-200 bg-white px-10 py-12 shadow-[0_20px_60px_-20px_rgba(15,23,42,0.08)] dark:border-[#1d1d23] dark:bg-[#0b0e14] dark:shadow-none">
+            {!token ? (
+              <div className="space-y-5 text-center">
+                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10">
+                  <XCircle size={28} className="text-red-500" />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xl font-semibold tracking-tight text-slate-950 dark:text-white">
+                    Reset link is incomplete
+                  </p>
+                  <p className="text-sm leading-6 text-slate-500 dark:text-[#8a94a7]">
+                    This page needs the link from your password reset email. Open the link
+                    directly, or request a new one.
+                  </p>
+                </div>
+                <div className="pt-2">
+                  <button
+                    onClick={() => navigate('/forgot-password', { replace: true })}
+                    className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(90deg,#4371ff_0%,#3a63f4_100%)] px-6 text-sm font-semibold text-white transition-all hover:brightness-110"
+                  >
+                    Request a new link
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                <div className="space-y-3 text-center">
+                  <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-brand-500/10">
+                    <LockKeyhole size={28} className="text-brand-500" />
+                  </div>
+                  <p className="text-xl font-semibold tracking-tight text-slate-950 dark:text-white">
+                    Choose a new password
+                  </p>
+                  <p className="text-sm leading-6 text-slate-500 dark:text-[#8a94a7]">
+                    Minimum 10 characters with uppercase, lowercase, number, and special
+                    character.
+                  </p>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  <PasswordField
+                    label="New password"
+                    value={newPassword}
+                    onChange={setNewPassword}
+                    show={showPassword}
+                    onToggleShow={() => setShowPassword((v) => !v)}
+                    autoFocus
+                  />
+                  <PasswordField
+                    label="Confirm new password"
+                    value={confirmPassword}
+                    onChange={setConfirmPassword}
+                    show={showPassword}
+                    onToggleShow={() => setShowPassword((v) => !v)}
+                  />
+
+                  <ErrorMessage error={error} />
+
+                  {isExpiredLinkError ? (
+                    <button
+                      type="button"
+                      onClick={() => navigate('/forgot-password')}
+                      className="inline-flex h-12 w-full items-center justify-center rounded-2xl border border-slate-200 px-6 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 dark:border-[#2a303a] dark:text-slate-200 dark:hover:bg-white/5"
+                    >
+                      Request a new link
+                    </button>
+                  ) : null}
+
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(90deg,#4371ff_0%,#3a63f4_100%)] px-6 text-sm font-semibold text-white transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {loading ? (
+                      <>
+                        <Loader2 size={16} className="animate-spin" />
+                        Resetting password
+                      </>
+                    ) : (
+                      'Reset password'
+                    )}
+                  </button>
+                </form>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <footer className="px-6 py-5 text-center text-xs text-slate-400 dark:text-[#525866]">
+          Juspay Decision Engine
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+function PasswordField({
+  label,
+  value,
+  onChange,
+  show,
+  onToggleShow,
+  autoFocus,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  show: boolean
+  onToggleShow: () => void
+  autoFocus?: boolean
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-[#8a94a7]">
+        {label}
+      </span>
+      <div className="relative">
+        <input
+          type={show ? 'text' : 'password'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          required
+          autoFocus={autoFocus}
+          className="h-12 w-full rounded-xl border border-slate-200 bg-white px-4 pr-11 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-white"
+        />
+        <button
+          type="button"
+          onClick={onToggleShow}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 transition-colors hover:text-slate-700 dark:hover:text-slate-200"
+          aria-label={show ? 'Hide password' : 'Show password'}
+        >
+          {show ? <Eye size={17} /> : <EyeOff size={17} />}
+        </button>
+      </div>
+    </label>
+  )
+}

--- a/website/src/pages/VerifyEmailPage.tsx
+++ b/website/src/pages/VerifyEmailPage.tsx
@@ -26,7 +26,22 @@ export function VerifyEmailPage() {
       return
     }
 
-    apiFetch(`/auth/verify-email?token=${encodeURIComponent(token)}`, { method: 'GET' })
+    // Strip the token from the address bar/history once captured. Plain replaceState
+    // bypasses the router, so `searchParams` (and the guard above) are unaffected.
+    const params = new URLSearchParams(window.location.search)
+    if (params.has('token')) {
+      params.delete('token')
+      const newSearch = params.toString()
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + (newSearch ? `?${newSearch}` : ''),
+      )
+    }
+
+    // POST with the token in the body — it must never ride in a backend URL, where
+    // request tracing would log it.
+    apiFetch('/auth/verify-email', { method: 'POST', body: JSON.stringify({ token }) })
       .then(() => {
         setStatus('success')
         setTimeout(() => {

--- a/website/src/store/authStore.ts
+++ b/website/src/store/authStore.ts
@@ -21,6 +21,7 @@ interface AuthStore {
   merchants: MerchantInfo[]
   hasHydrated: boolean
   setAuth: (token: string, user: AuthUser, merchants?: MerchantInfo[]) => void
+  setToken: (token: string) => void
   updateMerchant: (token: string, merchantId: string, merchants: MerchantInfo[]) => void
   clearAuth: () => void
   setHasHydrated: (hasHydrated: boolean) => void
@@ -36,6 +37,10 @@ export const useAuthStore = create<AuthStore>()(
       setAuth: (token, user, merchants = []) => {
         tokenRef.set(token)
         set({ token, user, merchants })
+      },
+      setToken: (token) => {
+        tokenRef.set(token)
+        set({ token })
       },
       updateMerchant: (token, merchantId, merchants) => {
         tokenRef.set(token)


### PR DESCRIPTION
## Summary

The dashboard previously had no way to recover a forgotten password — the login page said *"Password reset is managed by your account admin."* This PR adds a full self-serve forgot/reset password flow on top of the existing email infrastructure (AWS SES / SMTP / dev stub), plus two security hardenings that fell out of its review: session revocation on password change, and a safer verify-email flow.

## Forgot / reset password

- **`POST /auth/forgot-password`** — public. Always returns the same generic `200` (no account enumeration via status, body, or timing: code issuance + email send run in `tokio::spawn` off the request path, and send failures are swallowed and logged). Rate limited per email (3/h) and per client IP (30/h, rightmost `X-Forwarded-For` hop validated as an IP); over-limit requests still get the generic `200`.
- Reset codes: ~244-bit random codes, stored in Redis **as SHA-256** (a leaked snapshot yields no live links), 30-minute TTL, single-use.
- **`POST /auth/reset-password`** — public. Password-strength check *before* the claim (a weak password can't burn the link) → atomic single-use claim (`DEL` + `KeyDeleted`, so concurrent redemptions can't both succeed) → re-checks the account is active at redemption → updates the bcrypt hash and marks `email_verified = true` (mailbox control proven — also unsticks users who lost their verification email).
- Emails use a new `PasswordResetTemplate` matching the existing template family; the emailed link points at the SPA (`{base_url}/reset-password?token=…`), and the token only ever travels to the backend in a POST body.

## Session revocation

- A successful reset writes a per-user `user_pwreset_at` timestamp to Redis (fail-closed — the reset does not report success if this write fails). `verify_jwt_not_revoked()` — the chokepoint for every authenticated route — rejects any JWT with `iat` before it, and older outstanding reset codes are rejected at redemption the same way.
- **`/auth/change-password`** had the identical stale-session gap and gets the same treatment; it now returns a fresh `token` in its response (the SPA swaps it in) so the caller's own session survives.

## Verify-email hardening

- The SPA now **POSTs** the verification token in the JSON body — previously it rode in a `GET` query string, which the request-tracing span records, putting live tokens in backend logs. The `GET` form remains as a deprecated one-release compatibility shim.
- Token consumption is now an **atomic single-use claim** (was GET → update → best-effort DEL, so concurrent submissions could both succeed).

## Frontend

- New `/forgot-password` and `/reset-password` pages (outside `AuthGuard`), styled after the existing verify-email card; the login page's password field now links **"Forgot password?"**.
- The reset and verify pages strip the token from the address bar on load; the reset page also sets `referrer: no-referrer`. On success the reset page clears any persisted session (its JWT is revoked anyway) and lands on `/login` with a success notice.
- Duplicated `getPasswordPolicyError` / API-error parsing extracted to shared `lib/passwordPolicy.ts` / `lib/apiError.ts`.

## Docs & tests

- `docs/api-refs/auth-and-onboarding.mdx`: new Forgot/Reset Password sections, updated Change Password and Verify Email.
- New stub-based Cypress spec `cypress/e2e/ui/forgot-password.cy.js` following `auth-page.cy.js` conventions.

## Testing

- `cargo check` clean on both `mysql` and `postgres` feature paths; `tsc` clean.
- Live end-to-end against the dev stack: signup → forgot → reset link from logs → weak password 400 without burning the code → reset → **old JWT 401s, old password rejected, new login works** → replaying the link 400s → an older outstanding link is rejected after a successful reset → 4th request in the window silently drops (generic 200, no email) → unknown emails get byte-identical responses. Verify-email: concurrent double-submit of one token yields exactly one 200 and one 400.
- Full browser walkthrough of both flows through the Vite proxy (token stripped from URL, inline validation, success notices).
- Reviewed by a multi-agent adversarial pass (4 reviewer dimensions, every finding independently verified); all confirmed findings are fixed in this PR.

## Rollout notes

- Deployed envs need `[email] active_email_client = "aws_ses"` and a verified sender identity (startup health-check validates it); confirm SPF/DKIM/DMARC on the sender domain.
- `config/docker-configuration.toml` `email.base_url` points at the backend rather than the SPA (pre-existing) — verify/reset links are wrong in that setup until fixed.
- Do **not** add `/auth/*` routes to analytics `classify_request` — `capture_api_event` persists raw request bodies (passwords, tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #363
