### PR TITLE
feat(login): add support to reset password via email verification

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -622,6 +622,14 @@ where
         )
         .route("/auth/verify-email", get(routes::user_auth::verify_email))
         .route(
+            "/auth/forgot-password",
+            post(routes::user_auth::forgot_password),
+        )
+        .route(
+            "/auth/reset-password",
+            post(routes::user_auth::reset_password),
+        )
+        .route(
             "/auth/change-password",
             post(routes::user_auth::change_password),
         );

--- a/src/email/templates.rs
+++ b/src/email/templates.rs
@@ -127,7 +127,10 @@ impl MemberAddedTemplate {
             to: self.user_email,
             subject: format!("You now have access to {}", self.merchant_name),
             html_body: render_layout(
-                &format!("You now have access to {} on Juspay Decision Engine.", self.merchant_name),
+                &format!(
+                    "You now have access to {} on Juspay Decision Engine.",
+                    self.merchant_name
+                ),
                 &content,
             ),
         }
@@ -246,7 +249,10 @@ impl InviteUserTemplate {
             to: self.user_email,
             subject: format!("You've been invited to {}", self.merchant_name),
             html_body: render_layout(
-                &format!("You've been added to {} on Juspay Decision Engine.", self.merchant_name),
+                &format!(
+                    "You've been added to {} on Juspay Decision Engine.",
+                    self.merchant_name
+                ),
                 &content,
             ),
         }

--- a/src/email/templates.rs
+++ b/src/email/templates.rs
@@ -8,57 +8,36 @@ fn escape_html(s: &str) -> String {
         .replace('\'', "&#x27;")
 }
 
-pub struct MemberAddedTemplate {
-    pub user_email: String,
-    pub merchant_name: String,
-    pub base_url: String,
-}
-
-impl MemberAddedTemplate {
-    pub fn into_message(self) -> EmailMessage {
-        let merchant = escape_html(&self.merchant_name);
-        let base_url = escape_html(&self.base_url);
-        let html_body = format!(
-            r#"<!DOCTYPE html>
+/// Shared chrome for every transactional email: a plain wordmark, a white content
+/// card, and a neutral footer. `preheader` is the hidden inbox-preview line;
+/// `content` is the already-escaped inner HTML of the message body.
+fn render_layout(preheader: &str, content: &str) -> String {
+    format!(
+        r#"<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>You've been added to a merchant — Juspay Decision Engine</title>
+  <meta name="x-apple-disable-message-reformatting">
+  <title>Juspay Decision Engine</title>
 </head>
-<body style="margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-  <span style="display:none;max-height:0;overflow:hidden;mso-hide:all;">You now have access to {merchant} on Juspay Decision Engine.&#8202;&#65279;&#847;</span>
+<body style="margin:0;padding:0;background-color:#f4f5f7;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <span style="display:none;max-height:0;overflow:hidden;mso-hide:all;">{preheader}</span>
 
-  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#f1f5f9;">
+  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#f4f5f7;">
     <tr>
-      <td align="center" style="padding:40px 16px;">
+      <td align="center" style="padding:32px 16px;">
         <table width="600" cellpadding="0" cellspacing="0" role="presentation" style="max-width:600px;width:100%;">
 
           <tr>
-            <td style="background-color:#0b0e14;border-radius:16px 16px 0 0;padding:28px 40px;text-align:center;">
-              <span style="font-size:18px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">
-                <span style="color:#3b82f6;">&#9679;</span>&nbsp;Decision Engine
-              </span>
-            </td>
-          </tr>
-
-          <tr>
-            <td style="background-color:#ffffff;padding:48px 48px 44px;border-left:1px solid #e2e8f0;border-right:1px solid #e2e8f0;">
-              <h1 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#0f172a;letter-spacing:-0.02em;line-height:1.3;">
-                You&rsquo;ve been added to a merchant
-              </h1>
-              <p style="margin:0 0 32px;font-size:15px;line-height:1.75;color:#475569;">
-                An admin has granted you access to <strong style="color:#0f172a;">{merchant}</strong> on Juspay Decision Engine.
-                Sign in with your existing credentials to access this merchant&rsquo;s routing, analytics, and payment audits.
-              </p>
-
-              <table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 8px;">
+            <td style="padding:4px 4px 22px;">
+              <table cellpadding="0" cellspacing="0" role="presentation">
                 <tr>
-                  <td style="background-color:#4371ff;border-radius:12px;">
-                    <a href="{base_url}/login"
-                       style="display:inline-block;background-color:#4371ff;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:12px;letter-spacing:-0.01em;">
-                      Go to Decision Engine &rarr;
-                    </a>
+                  <td width="38" height="38" align="center" valign="middle" style="background-color:#0561E2;background-image:linear-gradient(135deg,#0099FF,#0561E2);border-radius:10px;">
+                    <span style="font-size:19px;font-weight:700;color:#ffffff;line-height:38px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">J</span>
+                  </td>
+                  <td style="padding-left:12px;" valign="middle">
+                    <span style="font-size:17px;font-weight:700;color:#0F172A;letter-spacing:-0.02em;">Juspay</span><span style="font-size:17px;font-weight:500;color:#475569;letter-spacing:-0.02em;">&nbsp;Decision Engine</span>
                   </td>
                 </tr>
               </table>
@@ -66,12 +45,15 @@ impl MemberAddedTemplate {
           </tr>
 
           <tr>
-            <td style="background-color:#f8fafc;border-radius:0 0 16px 16px;padding:24px 48px;border:1px solid #e2e8f0;border-top:none;">
-              <p style="margin:0 0 6px;font-size:12px;color:#94a3b8;line-height:1.65;">
-                If you weren&rsquo;t expecting this, contact your account administrator.
-              </p>
-              <p style="margin:10px 0 0;font-size:11px;color:#cbd5e1;">
-                Juspay Decision Engine &nbsp;&middot;&nbsp; Automated security email &mdash; please do not reply.
+            <td style="background-color:#ffffff;border:1px solid #e5e7eb;border-radius:10px;padding:40px 40px 36px;">
+{content}
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:20px 4px 4px;">
+              <p style="margin:0;font-size:12px;line-height:1.6;color:#9ca3af;">
+                This is an automated message from Juspay Decision Engine. Please do not reply to this email.
               </p>
             </td>
           </tr>
@@ -82,17 +64,72 @@ impl MemberAddedTemplate {
   </table>
 </body>
 </html>"#,
+        preheader = escape_html(preheader),
+        content = content,
+    )
+}
+
+/// A single primary call-to-action button. `href` is escaped; `label` is trusted
+/// static copy supplied by the caller.
+fn primary_button(href: &str, label: &str) -> String {
+    format!(
+        r#"              <table cellpadding="0" cellspacing="0" role="presentation" style="margin:0;">
+                <tr>
+                  <td style="background-color:#2563eb;border-radius:8px;">
+                    <a href="{href}" style="display:inline-block;background-color:#2563eb;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:13px 28px;border-radius:8px;">{label}</a>
+                  </td>
+                </tr>
+              </table>"#,
+        href = escape_html(href),
+        label = label,
+    )
+}
+
+/// The plain-text fallback shown under a CTA for clients that block buttons.
+fn fallback_link(url: &str) -> String {
+    let url = escape_html(url);
+    format!(
+        r#"              <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="margin:32px 0 0;">
+                <tr><td style="border-top:1px solid #e5e7eb;"></td></tr>
+              </table>
+              <p style="margin:24px 0 6px;font-size:13px;color:#6b7280;">Or paste this link into your browser:</p>
+              <p style="margin:0;font-size:13px;word-break:break-all;line-height:1.6;">
+                <a href="{url}" style="color:#2563eb;text-decoration:none;">{url}</a>
+              </p>"#,
+        url = url
+    )
+}
+
+pub struct MemberAddedTemplate {
+    pub user_email: String,
+    pub merchant_name: String,
+    pub base_url: String,
+}
+
+impl MemberAddedTemplate {
+    pub fn into_message(self) -> EmailMessage {
+        let merchant = escape_html(&self.merchant_name);
+        let login_url = format!("{}/login", self.base_url);
+        let content = format!(
+            r#"              <h1 style="margin:0 0 14px;font-size:20px;font-weight:600;color:#111827;line-height:1.3;">Access granted</h1>
+              <p style="margin:0 0 28px;font-size:15px;line-height:1.6;color:#374151;">
+                An administrator has granted your account access to <strong style="color:#111827;">{merchant}</strong> on Juspay Decision Engine. Sign in with your existing credentials to continue.
+              </p>
+{button}
+              <p style="margin:28px 0 0;font-size:13px;line-height:1.6;color:#6b7280;">
+                If you were not expecting this, please contact your account administrator.
+              </p>"#,
             merchant = merchant,
-            base_url = base_url,
+            button = primary_button(&login_url, "Sign in"),
         );
 
         EmailMessage {
             to: self.user_email,
-            subject: format!(
-                "You've been added to {} on Decision Engine",
-                self.merchant_name
+            subject: format!("You now have access to {}", self.merchant_name),
+            html_body: render_layout(
+                &format!("You now have access to {} on Juspay Decision Engine.", self.merchant_name),
+                &content,
             ),
-            html_body,
         }
     }
 }
@@ -104,96 +141,59 @@ pub struct EmailVerificationTemplate {
 
 impl EmailVerificationTemplate {
     pub fn into_message(self) -> EmailMessage {
-        let url = escape_html(&self.verification_url);
-        let html_body = format!(
-            r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Confirm your email — Juspay Decision Engine</title>
-</head>
-<body style="margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-  <!-- Preheader -->
-  <span style="display:none;max-height:0;overflow:hidden;mso-hide:all;">Confirm your email address to activate your Juspay Decision Engine account.&#8202;&#65279;&#847;</span>
-
-  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#f1f5f9;">
-    <tr>
-      <td align="center" style="padding:40px 16px;">
-        <table width="600" cellpadding="0" cellspacing="0" role="presentation" style="max-width:600px;width:100%;">
-
-          <!-- Header -->
-          <tr>
-            <td style="background-color:#0b0e14;border-radius:16px 16px 0 0;padding:28px 40px;text-align:center;">
-              <span style="font-size:18px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">
-                <span style="color:#3b82f6;">&#9679;</span>&nbsp;Decision Engine
-              </span>
-            </td>
-          </tr>
-
-          <!-- Body -->
-          <tr>
-            <td style="background-color:#ffffff;padding:48px 48px 44px;border-left:1px solid #e2e8f0;border-right:1px solid #e2e8f0;">
-
-              <h1 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#0f172a;letter-spacing:-0.02em;line-height:1.3;">
-                Confirm your email address
-              </h1>
-              <p style="margin:0 0 32px;font-size:15px;line-height:1.75;color:#475569;">
-                Thanks for signing up for Juspay Decision Engine. Click the button below to verify your email and activate your account. Once confirmed you'll have full access to gateway routing, analytics, and payment audits.
+        let content = format!(
+            r#"              <h1 style="margin:0 0 14px;font-size:20px;font-weight:600;color:#111827;line-height:1.3;">Confirm your email address</h1>
+              <p style="margin:0 0 28px;font-size:15px;line-height:1.6;color:#374151;">
+                Please confirm this email address to activate your Juspay Decision Engine account.
               </p>
-
-              <!-- CTA button -->
-              <table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 40px;">
-                <tr>
-                  <td style="background-color:#4371ff;border-radius:12px;">
-                    <a href="{url}"
-                       style="display:inline-block;background-color:#4371ff;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:12px;letter-spacing:-0.01em;">
-                      Verify email address &rarr;
-                    </a>
-                  </td>
-                </tr>
-              </table>
-
-              <!-- Divider -->
-              <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 28px;">
-                <tr><td style="border-top:1px solid #e2e8f0;"></td></tr>
-              </table>
-
-              <p style="margin:0 0 8px;font-size:13px;color:#94a3b8;">
-                Button not working? Copy and paste this link into your browser:
+{button}
+              <p style="margin:28px 0 0;font-size:13px;line-height:1.6;color:#6b7280;">
+                This link expires in 24 hours. If you did not create an account, you can ignore this email.
               </p>
-              <p style="margin:0;font-size:12px;word-break:break-all;line-height:1.6;">
-                <a href="{url}" style="color:#3b82f6;text-decoration:none;">{url}</a>
-              </p>
-            </td>
-          </tr>
-
-          <!-- Footer -->
-          <tr>
-            <td style="background-color:#f8fafc;border-radius:0 0 16px 16px;padding:24px 48px;border:1px solid #e2e8f0;border-top:none;">
-              <p style="margin:0 0 6px;font-size:12px;color:#94a3b8;line-height:1.65;">
-                This link expires in <strong style="color:#64748b;">24 hours</strong>.
-                If you didn&rsquo;t create an account, you can safely ignore this email &mdash; no action is needed and your address will not be used.
-              </p>
-              <p style="margin:10px 0 0;font-size:11px;color:#cbd5e1;">
-                Juspay Decision Engine &nbsp;&middot;&nbsp; Automated security email &mdash; please do not reply.
-              </p>
-            </td>
-          </tr>
-
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>"#,
-            url = url
+{fallback}"#,
+            button = primary_button(&self.verification_url, "Confirm email address"),
+            fallback = fallback_link(&self.verification_url),
         );
 
         EmailMessage {
             to: self.user_email,
-            subject: "Confirm your email — Juspay Decision Engine".to_string(),
-            html_body,
+            subject: "Confirm your email address".to_string(),
+            html_body: render_layout(
+                "Confirm your email address to activate your Juspay Decision Engine account.",
+                &content,
+            ),
+        }
+    }
+}
+
+pub struct PasswordResetTemplate {
+    pub user_email: String,
+    pub reset_url: String,
+}
+
+impl PasswordResetTemplate {
+    pub fn into_message(self) -> EmailMessage {
+        let content = format!(
+            r#"              <h1 style="margin:0 0 14px;font-size:20px;font-weight:600;color:#111827;line-height:1.3;">Reset your password</h1>
+              <p style="margin:0 0 28px;font-size:15px;line-height:1.6;color:#374151;">
+                We received a request to reset the password for your Juspay Decision Engine account. Use the button below to choose a new password.
+              </p>
+{button}
+              <p style="margin:28px 0 0;font-size:13px;line-height:1.6;color:#6b7280;">
+                This link expires in 1 hour. If you did not request a password reset, you can ignore this email and your password will remain unchanged.
+              </p>
+{fallback}"#,
+            button = primary_button(&self.reset_url, "Reset password"),
+            fallback = fallback_link(&self.reset_url),
+        );
+
+        EmailMessage {
+            to: self.user_email,
+            subject: "Reset your password".to_string(),
+            html_body: render_layout(
+                "Reset the password for your Juspay Decision Engine account.",
+                &content,
+            ),
         }
     }
 }
@@ -210,109 +210,45 @@ impl InviteUserTemplate {
         let merchant = escape_html(&self.merchant_name);
         let email = escape_html(&self.user_email);
         let password = escape_html(&self.temporary_password);
-        let base_url = escape_html(&self.base_url);
-        let html_body = format!(
-            r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>You're invited to Decision Engine</title>
-</head>
-<body style="margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-  <!-- Preheader -->
-  <span style="display:none;max-height:0;overflow:hidden;mso-hide:all;">You&rsquo;ve been added to {merchant} on Juspay Decision Engine. Your login details are inside.&#8202;&#65279;&#847;</span>
-
-  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#f1f5f9;">
-    <tr>
-      <td align="center" style="padding:40px 16px;">
-        <table width="600" cellpadding="0" cellspacing="0" role="presentation" style="max-width:600px;width:100%;">
-
-          <!-- Header -->
-          <tr>
-            <td style="background-color:#0b0e14;border-radius:16px 16px 0 0;padding:28px 40px;text-align:center;">
-              <span style="font-size:18px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">
-                <span style="color:#3b82f6;">&#9679;</span>&nbsp;Decision Engine
-              </span>
-            </td>
-          </tr>
-
-          <!-- Body -->
-          <tr>
-            <td style="background-color:#ffffff;padding:48px 48px 44px;border-left:1px solid #e2e8f0;border-right:1px solid #e2e8f0;">
-
-              <h1 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#0f172a;letter-spacing:-0.02em;line-height:1.3;">
-                You&rsquo;ve been invited
-              </h1>
-              <p style="margin:0 0 32px;font-size:15px;line-height:1.75;color:#475569;">
-                You&rsquo;ve been added to <strong style="color:#0f172a;">{merchant}</strong> on Juspay Decision Engine.
-                Use the credentials below to sign in, then change your password from your account settings.
+        let login_url = format!("{}/login", self.base_url);
+        let content = format!(
+            r#"              <h1 style="margin:0 0 14px;font-size:20px;font-weight:600;color:#111827;line-height:1.3;">You have been invited to {merchant}</h1>
+              <p style="margin:0 0 28px;font-size:15px;line-height:1.6;color:#374151;">
+                You have been added to <strong style="color:#111827;">{merchant}</strong> on Juspay Decision Engine. Sign in with the credentials below, then change your password from your account settings.
               </p>
 
-              <!-- Credentials card -->
-              <table width="100%" cellpadding="0" cellspacing="0" role="presentation"
-                     style="background-color:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;margin:0 0 36px;">
+              <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#f9fafb;border:1px solid #e5e7eb;border-radius:8px;margin:0 0 28px;">
                 <tr>
-                  <td style="padding:20px 24px 16px;">
-                    <p style="margin:0 0 4px;font-size:11px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.06em;">Email</p>
-                    <p style="margin:0;font-size:15px;color:#0f172a;">{email}</p>
+                  <td style="padding:16px 20px 12px;">
+                    <p style="margin:0 0 4px;font-size:11px;font-weight:600;color:#9ca3af;text-transform:uppercase;letter-spacing:0.05em;">Email</p>
+                    <p style="margin:0;font-size:14px;color:#111827;">{email}</p>
                   </td>
                 </tr>
                 <tr>
-                  <td style="border-top:1px solid #e2e8f0;padding:16px 24px 20px;">
-                    <p style="margin:0 0 4px;font-size:11px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.06em;">Temporary password</p>
-                    <p style="margin:0;font-size:15px;font-family:'Courier New',Courier,monospace;color:#0f172a;letter-spacing:0.04em;">{password}</p>
+                  <td style="border-top:1px solid #e5e7eb;padding:12px 20px 16px;">
+                    <p style="margin:0 0 4px;font-size:11px;font-weight:600;color:#9ca3af;text-transform:uppercase;letter-spacing:0.05em;">Temporary password</p>
+                    <p style="margin:0;font-size:14px;font-family:'Courier New',Courier,monospace;color:#111827;">{password}</p>
                   </td>
                 </tr>
               </table>
 
-              <!-- CTA button -->
-              <table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 8px;">
-                <tr>
-                  <td style="background-color:#4371ff;border-radius:12px;">
-                    <a href="{base_url}/login"
-                       style="display:inline-block;background-color:#4371ff;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:12px;letter-spacing:-0.01em;">
-                      Sign in to Decision Engine &rarr;
-                    </a>
-                  </td>
-                </tr>
-              </table>
-
-            </td>
-          </tr>
-
-          <!-- Footer -->
-          <tr>
-            <td style="background-color:#f8fafc;border-radius:0 0 16px 16px;padding:24px 48px;border:1px solid #e2e8f0;border-top:none;">
-              <p style="margin:0 0 6px;font-size:12px;color:#94a3b8;line-height:1.65;">
-                For your security, please <strong style="color:#64748b;">change your password</strong> after signing in.
-                If you weren&rsquo;t expecting this invitation, contact your account administrator.
-              </p>
-              <p style="margin:10px 0 0;font-size:11px;color:#cbd5e1;">
-                Juspay Decision Engine &nbsp;&middot;&nbsp; Automated security email &mdash; please do not reply.
-              </p>
-            </td>
-          </tr>
-
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>"#,
+{button}
+              <p style="margin:28px 0 0;font-size:13px;line-height:1.6;color:#6b7280;">
+                For security, change your password after your first sign-in. If you were not expecting this invitation, please contact your account administrator.
+              </p>"#,
             merchant = merchant,
             email = email,
             password = password,
-            base_url = base_url
+            button = primary_button(&login_url, "Sign in"),
         );
 
         EmailMessage {
             to: self.user_email,
-            subject: format!(
-                "You've been invited to join {} on Decision Engine",
-                self.merchant_name
+            subject: format!("You've been invited to {}", self.merchant_name),
+            html_body: render_layout(
+                &format!("You've been added to {} on Juspay Decision Engine.", self.merchant_name),
+                &content,
             ),
-            html_body,
         }
     }
 }

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -346,6 +346,8 @@ pub enum UserAuthError {
     EmailSendFailed,
     #[error("Invalid or expired verification token")]
     InvalidVerificationToken,
+    #[error("Invalid or expired password reset token")]
+    InvalidResetToken,
 }
 
 impl axum::response::IntoResponse for UserAuthError {
@@ -368,6 +370,7 @@ impl axum::response::IntoResponse for UserAuthError {
             }
             Self::EmailSendFailed => (hyper::StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             Self::InvalidVerificationToken => (hyper::StatusCode::BAD_REQUEST, self.to_string()),
+            Self::InvalidResetToken => (hyper::StatusCode::BAD_REQUEST, self.to_string()),
         };
         (
             status,

--- a/src/redis/commands.rs
+++ b/src/redis/commands.rs
@@ -423,6 +423,29 @@ impl RedisConnectionWrapper {
         self.get_key::<String>(key, "").await
     }
 
+    /// Atomically read and delete a string key (`GETDEL`), returning `None` when the key
+    /// did not exist. Use this for single-use tokens: a plain `get` followed by a later
+    /// `delete` lets two concurrent requests read the same token before either removes it.
+    pub async fn get_and_delete_key_string(
+        &self,
+        key: &str,
+    ) -> Result<Option<String>, errors::RedisError> {
+        let value: Vec<u8> = self
+            .conn
+            .pool
+            .getdel(self.conn.add_prefix(key))
+            .await
+            .change_context(errors::RedisError::GetFailed)?;
+
+        if value.is_empty() {
+            return Ok(None);
+        }
+
+        serde_json::from_slice(&value)
+            .change_context(errors::RedisError::JsonDeserializationFailed)
+            .map(Some)
+    }
+
     pub async fn get_list_length(&self, key: &str) -> Result<usize, errors::RedisError> {
         self.conn
             .pool

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -1134,7 +1134,10 @@ pub async fn forgot_password(
 
     let token = uuid::Uuid::new_v4().to_string();
     let redis_key = format!("{}{}", PASSWORD_RESET_PREFIX, token);
-    let reset_url = format!("{}/reset-password?token={}", global_config.email.base_url, token);
+    let reset_url = format!(
+        "{}/reset-password?token={}",
+        global_config.email.base_url, token
+    );
 
     app_state
         .redis_conn
@@ -1174,21 +1177,22 @@ pub async fn reset_password(
 
     let redis_key = format!("{}{}", PASSWORD_RESET_PREFIX, payload.token);
 
-    let user_id = app_state
-        .redis_conn
-        .get_key_string(&redis_key)
-        .await
-        .change_context(UserAuthError::StorageError)?;
-
-    if user_id.is_empty() {
-        return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
-    }
-
+    // Validate and hash before touching the token so a weak password doesn't consume it.
     auth::validate_password_strength(&payload.new_password)
         .change_context(UserAuthError::WeakPassword)?;
 
     let new_hash = auth::hash_password(&payload.new_password)
         .change_context(UserAuthError::PasswordHashingFailed)?;
+
+    // Single-use token: GETDEL consumes it atomically, so concurrent requests carrying the
+    // same token can't both read it and reset the password twice.
+    let user_id = app_state
+        .redis_conn
+        .get_and_delete_key_string(&redis_key)
+        .await
+        .change_context(UserAuthError::StorageError)?
+        .filter(|user_id| !user_id.is_empty())
+        .ok_or(UserAuthError::InvalidResetToken)?;
 
     let conn = app_state
         .db
@@ -1212,11 +1216,10 @@ pub async fn reset_password(
 
     if rows_updated == 0 {
         crate::logger::error!(user_id = %user_id, "Password reset matched 0 rows — user_id not found in DB");
-        return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
+        return Err(error::ContainerError::from(
+            UserAuthError::InvalidResetToken,
+        ));
     }
-
-    // Single-use token: consume it so the link can't be replayed.
-    let _ = app_state.redis_conn.delete_key(&redis_key).await;
 
     Ok(Json(MessageResponse {
         message: "Password reset successfully. You can now sign in with your new password."

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -88,6 +88,8 @@ const EMAIL_VERIFICATION_PREFIX: &str = "email_verification:";
 const EMAIL_VERIFICATION_TTL_SECONDS: i64 = 86400; // 24 hours
 const PENDING_SIGNUP_PREFIX: &str = "pending_signup:";
 const PENDING_SIGNUP_TTL_SECONDS: i64 = 300; // 5 minutes
+const PASSWORD_RESET_PREFIX: &str = "password_reset:";
+const PASSWORD_RESET_TTL_SECONDS: i64 = 3600; // 1 hour
 
 #[axum::debug_handler]
 pub async fn signup(
@@ -1054,6 +1056,172 @@ async fn fetch_user_merchants(
         });
     }
     Ok(result)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ForgotPasswordRequest {
+    pub email: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResetPasswordRequest {
+    pub token: String,
+    pub new_password: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MessageResponse {
+    pub message: String,
+}
+
+/// Generic message returned by `forgot_password` regardless of whether the email
+/// exists — this prevents attackers from using the endpoint to enumerate accounts.
+const FORGOT_PASSWORD_GENERIC_MESSAGE: &str =
+    "If an account exists for that email, a password reset link has been sent.";
+
+#[axum::debug_handler]
+pub async fn forgot_password(
+    Json(payload): Json<ForgotPasswordRequest>,
+) -> Result<Json<MessageResponse>, error::ContainerError<UserAuthError>> {
+    let generic_ok = || {
+        Ok(Json(MessageResponse {
+            message: FORGOT_PASSWORD_GENERIC_MESSAGE.to_string(),
+        }))
+    };
+
+    let global_config = APP_STATE
+        .get()
+        .map(|s| s.global_config.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    // Without a configured email backend there is no way to deliver the reset link,
+    // so short-circuit — but still return the generic response to avoid leaking that.
+    if !global_config.email.is_active() {
+        crate::logger::warn!(
+            "forgot_password requested but no email backend is configured; skipping send"
+        );
+        return generic_ok();
+    }
+
+    let app_state = get_tenant_app_state().await;
+
+    let mut users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+        &app_state.db,
+        dsl::email.eq(payload.email.clone()),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+
+    let user = match users.pop() {
+        Some(user) => user,
+        // Unknown email — respond as if it succeeded so callers can't probe for accounts.
+        None => return generic_ok(),
+    };
+
+    let is_active = {
+        #[cfg(feature = "mysql")]
+        {
+            user.is_active != 0
+        }
+        #[cfg(feature = "postgres")]
+        {
+            user.is_active
+        }
+    };
+    if !is_active {
+        return generic_ok();
+    }
+
+    let token = uuid::Uuid::new_v4().to_string();
+    let redis_key = format!("{}{}", PASSWORD_RESET_PREFIX, token);
+    let reset_url = format!("{}/reset-password?token={}", global_config.email.base_url, token);
+
+    app_state
+        .redis_conn
+        .set_key_with_ttl(&redis_key, &user.user_id, PASSWORD_RESET_TTL_SECONDS)
+        .await
+        .change_context(UserAuthError::StorageError)?;
+
+    let email_client = APP_STATE
+        .get()
+        .map(|s| s.email_client.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    let send_result = email_client
+        .send_email(
+            crate::email::templates::PasswordResetTemplate {
+                user_email: user.email.clone(),
+                reset_url,
+            }
+            .into_message(),
+        )
+        .await;
+
+    if send_result.is_err() {
+        // Drop the token so a failed send doesn't leave a dangling reset entry.
+        let _ = app_state.redis_conn.delete_key(&redis_key).await;
+        send_result.change_context(UserAuthError::EmailSendFailed)?;
+    }
+
+    generic_ok()
+}
+
+#[axum::debug_handler]
+pub async fn reset_password(
+    Json(payload): Json<ResetPasswordRequest>,
+) -> Result<Json<MessageResponse>, error::ContainerError<UserAuthError>> {
+    let app_state = get_tenant_app_state().await;
+
+    let redis_key = format!("{}{}", PASSWORD_RESET_PREFIX, payload.token);
+
+    let user_id = app_state
+        .redis_conn
+        .get_key_string(&redis_key)
+        .await
+        .change_context(UserAuthError::StorageError)?;
+
+    if user_id.is_empty() {
+        return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
+    }
+
+    auth::validate_password_strength(&payload.new_password)
+        .change_context(UserAuthError::WeakPassword)?;
+
+    let new_hash = auth::hash_password(&payload.new_password)
+        .change_context(UserAuthError::PasswordHashingFailed)?;
+
+    let conn = app_state
+        .db
+        .get_conn()
+        .await
+        .change_error(UserAuthError::StorageError)?;
+
+    let rows_updated = crate::generics::generic_update_if_present::<
+        <User as HasTable>::Table,
+        crate::storage::types::UserPasswordUpdate,
+        _,
+    >(
+        &conn,
+        dsl::user_id.eq(user_id.clone()),
+        crate::storage::types::UserPasswordUpdate {
+            password_hash: new_hash,
+        },
+    )
+    .await
+    .change_context(UserAuthError::StorageError)?;
+
+    if rows_updated == 0 {
+        crate::logger::error!(user_id = %user_id, "Password reset matched 0 rows — user_id not found in DB");
+        return Err(error::ContainerError::from(UserAuthError::InvalidResetToken));
+    }
+
+    // Single-use token: consume it so the link can't be replayed.
+    let _ = app_state.redis_conn.delete_key(&redis_key).await;
+
+    Ok(Json(MessageResponse {
+        message: "Password reset successfully. You can now sign in with your new password."
+            .to_string(),
+    }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -18,6 +18,8 @@ import { OnboardingPage } from './pages/OnboardingPage'
 import { MembersPage } from './pages/MembersPage'
 import { ApiKeysPage } from './pages/ApiKeysPage'
 import { VerifyEmailPage } from './pages/VerifyEmailPage'
+import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
+import { ResetPasswordPage } from './pages/ResetPasswordPage'
 import { AccountPage } from './pages/AccountPage'
 
 export default function App() {
@@ -26,6 +28,8 @@ export default function App() {
       <Route path="login" element={<AuthPage />} />
       <Route path="signup" element={<AuthPage />} />
       <Route path="verify-email" element={<VerifyEmailPage />} />
+      <Route path="forgot-password" element={<ForgotPasswordPage />} />
+      <Route path="reset-password" element={<ResetPasswordPage />} />
       <Route element={<AuthGuard />}>
         <Route path="onboarding" element={<OnboardingPage />} />
         <Route element={<AppShell />}>

--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -13,6 +13,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
+import { CheckCircle2, ChevronRight } from 'lucide-react'
 import { fetcher } from '../../lib/api'
 import { FEATURE_FLAGS } from '../../lib/featureFlags'
 import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
@@ -588,27 +589,45 @@ function RoutingAlignmentCard({
 
   return (
     <Card className="overflow-visible">
-      <CardHeader className={expanded ? 'px-5 py-4' : 'px-5 py-3 !border-b-0'}>
+      <CardHeader className={expanded ? 'px-5 py-4' : 'px-5 py-4 !border-b-0'}>
         <div className={`flex flex-wrap justify-between gap-3 ${expanded ? 'items-start' : 'items-center'}`}>
-          <div className={expanded ? 'min-w-0' : 'flex min-w-0 flex-wrap items-center gap-2'}>
-            <h2 className="text-sm font-semibold text-slate-800 dark:text-white">
-              Routing alignment
-            </h2>
-            {expanded ? (
+          {expanded ? (
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-slate-800 dark:text-white">
+                Routing alignment
+              </h2>
               <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
                 Traffic share: checks if the best-scoring connector is also getting the largest share.
               </p>
-            ) : (
-              <span className="min-w-0 truncate text-xs font-medium text-slate-500 dark:text-[#9aa7bb]">
+            </div>
+          ) : (
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <CheckCircle2 size={18} className="shrink-0 text-emerald-500" />
+              <span className="min-w-0 text-sm text-slate-600 dark:text-[#9aa7bb]">
+                <span className="font-semibold text-slate-800 dark:text-white">Routing alignment</span>
+                {' — '}
                 {collapsedReadout}
               </span>
-            )}
-          </div>
+            </div>
+          )}
           <div className="flex shrink-0 items-center gap-2">
-            <InfoButton content={CARD_INFO.alignment} />
-            <Button size="sm" variant="secondary" onClick={onToggle}>
-              {expanded ? 'Hide details' : 'Show details'}
-            </Button>
+            {expanded ? (
+              <>
+                <InfoButton content={CARD_INFO.alignment} />
+                <Button size="sm" variant="secondary" onClick={onToggle}>
+                  Hide details
+                </Button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={onToggle}
+                className="inline-flex items-center gap-1 text-sm font-semibold text-brand-600 transition hover:text-brand-700 dark:text-brand-300 dark:hover:text-brand-200"
+              >
+                Show details
+                <ChevronRight size={16} />
+              </button>
+            )}
           </div>
         </div>
       </CardHeader>
@@ -1712,14 +1731,36 @@ export function AnalyticsPage() {
 
   return (
     <div className="space-y-8 px-5 sm:px-6 lg:px-8 xl:px-10">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="space-y-2">
-          <div className="flex flex-wrap items-center gap-2">
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-1">
             <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Analytics</h1>
+            <p className="text-sm text-slate-500 dark:text-[#8a8a93]">
+              Real-time multi-gateway routing performance overview.
+            </p>
+          </div>
+
+          <div className="inline-flex max-w-full flex-wrap items-center gap-1 rounded-[18px] border border-slate-200 bg-white/70 p-1 dark:border-[#2a303a] dark:bg-[#11151d]">
+            <Button
+              size="sm"
+              variant="secondary"
+              className={sectionButtonClass(view === 'transactions')}
+              onClick={() => setView('transactions')}
+            >
+              {ANALYTICS_VIEW_LABELS.transactions}
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              className={sectionButtonClass(view === 'rule_based')}
+              onClick={() => setView('rule_based')}
+            >
+              {ANALYTICS_VIEW_LABELS.rule_based}
+            </Button>
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2 md:justify-end">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <Button size="sm" variant="ghost" onClick={refreshAll}>
             Refresh
           </Button>
@@ -1793,25 +1834,6 @@ export function AnalyticsPage() {
         </div>
       </div>
 
-      <div className="inline-flex max-w-full flex-wrap items-center gap-1 rounded-[18px] border border-slate-200 bg-white/70 p-1 dark:border-[#2a303a] dark:bg-[#11151d]">
-        <Button
-          size="sm"
-          variant="secondary"
-          className={sectionButtonClass(view === 'transactions')}
-          onClick={() => setView('transactions')}
-        >
-          {ANALYTICS_VIEW_LABELS.transactions}
-        </Button>
-        <Button
-          size="sm"
-          variant="secondary"
-          className={sectionButtonClass(view === 'rule_based')}
-          onClick={() => setView('rule_based')}
-        >
-          {ANALYTICS_VIEW_LABELS.rule_based}
-        </Button>
-      </div>
-
       <ErrorMessage error={error} />
 
       {loading ? (
@@ -1824,67 +1846,71 @@ export function AnalyticsPage() {
       <div className="relative">
       {view === 'transactions' ? (
         <div className="space-y-6">
-          <Card>
-            <CardBody>
-              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                <div>
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
-                    Overall auth rate
-                  </p>
-                  {overallAuthRate !== null ? (
-                    <>
-                      <p className={`mt-2 text-4xl font-semibold tabular-nums ${authRateColor(overallAuthRate)}`}>
-                        {formatPercent(overallAuthRate)}
-                      </p>
-                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                        Weighted across all gateways
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <p className="mt-2 text-4xl font-semibold text-slate-300 dark:text-slate-700">—</p>
-                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">No score data yet</p>
-                    </>
-                  )}
-                </div>
-                {transactionRouteHits.map((item) => (
-                  <div key={item.route}>
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
-                      {analyticsRouteLabel(item.route)}
-                    </p>
-                    <p className="mt-2 text-2xl font-semibold tabular-nums text-slate-950 dark:text-white">
-                      {formatNumber(item.count, 0)}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <Card>
+              <CardBody>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
+                  Overall auth rate
+                </p>
+                {overallAuthRate !== null ? (
+                  <>
+                    <p className={`mt-2 text-4xl font-semibold tabular-nums ${authRateColor(overallAuthRate)}`}>
+                      {formatPercent(overallAuthRate)}
                     </p>
                     <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                      {item.route === '/decide_gateway' ? 'routing decisions' : 'score feedback calls'}
+                      Weighted across all gateways
                     </p>
-                  </div>
-                ))}
-                <div>
+                  </>
+                ) : (
+                  <>
+                    <p className="mt-2 text-4xl font-semibold text-slate-300 dark:text-slate-700">—</p>
+                    <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">No score data yet</p>
+                  </>
+                )}
+              </CardBody>
+            </Card>
+
+            {transactionRouteHits.map((item) => (
+              <Card key={item.route}>
+                <CardBody>
                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
-                    Total cost saved
+                    {analyticsRouteLabel(item.route)}
                   </p>
-                  {costSavings.data && costSavings.data.currency && costSavings.data.totals.saved_value > 0 ? (
-                    <>
-                      <p className="mt-2 text-2xl font-semibold tabular-nums text-emerald-600 dark:text-emerald-400">
-                        {formatCurrencyValue(costSavings.data.totals.saved_value, costSavings.data.currency)}
-                      </p>
-                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                        {formatNumber(costSavings.data.totals.cost_won_count, 0)} of {formatNumber(costSavings.data.totals.total_decisions, 0)} cost decisions
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <p className="mt-2 text-2xl font-semibold text-slate-300 dark:text-slate-700">—</p>
-                      <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
-                        {costSavings.data ? 'No multi-objective wins yet' : 'Loading…'}
-                      </p>
-                    </>
-                  )}
-                </div>
-              </div>
-            </CardBody>
-          </Card>
+                  <p className="mt-2 text-4xl font-semibold tabular-nums text-slate-950 dark:text-white">
+                    {formatNumber(item.count, 0)}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                    {item.route === '/decide_gateway' ? 'routing decisions' : 'score feedback calls'}
+                  </p>
+                </CardBody>
+              </Card>
+            ))}
+
+            <Card>
+              <CardBody>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-[#8a8a93]">
+                  Total cost saved
+                </p>
+                {costSavings.data && costSavings.data.currency && costSavings.data.totals.saved_value > 0 ? (
+                  <>
+                    <p className="mt-2 text-4xl font-semibold tabular-nums text-emerald-600 dark:text-emerald-400">
+                      {formatCurrencyValue(costSavings.data.totals.saved_value, costSavings.data.currency)}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                      {formatNumber(costSavings.data.totals.cost_won_count, 0)} of {formatNumber(costSavings.data.totals.total_decisions, 0)} cost decisions
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="mt-2 text-4xl font-semibold text-slate-300 dark:text-slate-700">—</p>
+                    <p className="mt-1 text-xs text-slate-500 dark:text-[#8a8a93]">
+                      {costSavings.data ? 'No multi-objective wins yet' : 'Loading…'}
+                    </p>
+                  </>
+                )}
+              </CardBody>
+            </Card>
+          </div>
 
           <RoutingAlignmentCard
             summary={routingAlignmentSummary}

--- a/website/src/components/pages/PaymentAuditPage.tsx
+++ b/website/src/components/pages/PaymentAuditPage.tsx
@@ -330,6 +330,22 @@ function selectClassName() {
   return `${controlClassName()} appearance-none pr-7 bg-[url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")] bg-no-repeat bg-[right_8px_center]`
 }
 
+function fieldClassName() {
+  return 'h-11 w-full rounded-2xl border border-slate-200 bg-white px-4 text-sm text-slate-700 outline-none transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-[#e5ecf7] dark:placeholder:text-[#555f6e]'
+}
+
+function fieldSelectClassName() {
+  return `${fieldClassName()} appearance-none pr-9 bg-[url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")] bg-no-repeat bg-[right_12px_center]`
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <label className="mb-1.5 block text-xs font-medium text-slate-500 dark:text-[#8a8a93]">
+      {children}
+    </label>
+  )
+}
+
 function FilterField({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <label className="flex items-center gap-3">
@@ -368,20 +384,153 @@ function InspectorKeyValueGrid({ rows }: { rows: Array<{ label: string; value: s
   )
 }
 
-function InspectorJsonPanel({ title, value, emptyMessage }: { title: string; value: unknown; emptyMessage: string }) {
+function JsonBlock({ value }: { value: unknown }) {
+  return (
+    <pre className="overflow-x-auto rounded-[22px] border border-slate-200/80 bg-slate-50/90 px-4 py-4 font-mono text-xs leading-6 text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),0_16px_30px_-28px_rgba(15,23,42,0.18)] dark:border-[#2a303a] dark:bg-[#0b1017] dark:text-[#d8e1ef] dark:shadow-none">
+      {stringifyValue(value)}
+    </pre>
+  )
+}
+
+function PanelSection({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="space-y-3">
-      <div>
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-white">{title}</h3>
-      </div>
+      <h3 className="text-sm font-semibold text-slate-900 dark:text-white">{title}</h3>
+      {children}
+    </div>
+  )
+}
+
+function InspectorJsonPanel({ title, value, emptyMessage }: { title: string; value: unknown; emptyMessage: string }) {
+  return (
+    <PanelSection title={title}>
       {value ? (
-        <pre className="overflow-x-auto rounded-[22px] border border-slate-200/80 bg-slate-50/90 px-4 py-4 font-mono text-xs leading-6 text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),0_16px_30px_-28px_rgba(15,23,42,0.18)] dark:border-[#2a303a] dark:bg-[#0b1017] dark:text-[#d8e1ef] dark:shadow-none">
-          {stringifyValue(value)}
-        </pre>
+        <JsonBlock value={value} />
       ) : (
         <EmptyState title={`No ${title.toLowerCase()} captured`} body={emptyMessage} />
       )}
-    </div>
+    </PanelSection>
+  )
+}
+
+/** Entries of a flat record whose values are all finite numbers, else null. */
+function asNumberEntries(value: unknown): Array<[string, number]> | null {
+  if (!isRecord(value)) return null
+  const keys = Object.keys(value)
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1]),
+  )
+  return entries.length && entries.length === keys.length ? entries : null
+}
+
+/** Entries of a flat record whose values are all scalars (string/number/bool/null), else null. */
+function asScalarEntries(value: unknown): Array<[string, string | number | boolean | null]> | null {
+  if (!isRecord(value)) return null
+  const entries = Object.entries(value)
+  if (!entries.length) return null
+  const allScalar = entries.every(
+    ([, val]) => val === null || ['string', 'number', 'boolean'].includes(typeof val),
+  )
+  return allScalar ? (entries as Array<[string, string | number | boolean | null]>) : null
+}
+
+function formatScalar(value: string | number | boolean | null): string {
+  if (value === null) return '—'
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (typeof value === 'number') return value.toLocaleString(undefined, { maximumFractionDigits: 6 })
+  return value
+}
+
+function ConnectorScorePanel({
+  title,
+  value,
+  emptyMessage,
+  selectedGateway,
+}: {
+  title: string
+  value: unknown
+  emptyMessage: string
+  selectedGateway?: string | null
+}) {
+  const entries = asNumberEntries(value)
+
+  if (!entries) {
+    return (
+      <PanelSection title={title}>
+        {value ? <JsonBlock value={value} /> : <EmptyState title={`No ${title.toLowerCase()} captured`} body={emptyMessage} />}
+      </PanelSection>
+    )
+  }
+
+  const sorted = [...entries].sort((left, right) => right[1] - left[1])
+  const max = Math.max(...sorted.map(([, score]) => score))
+  const asFraction = max <= 1
+  const denom = asFraction ? 1 : max || 1
+  const winner = selectedGateway && sorted.some(([gateway]) => gateway === selectedGateway)
+    ? selectedGateway
+    : sorted[0][0]
+
+  return (
+    <PanelSection title={title}>
+      <div className="space-y-3 rounded-[22px] border border-slate-200/80 bg-slate-50/90 px-4 py-4 dark:border-[#2a303a] dark:bg-[#0b1017]">
+        {sorted.map(([gateway, score]) => {
+          const isWinner = gateway === winner
+          const width = Math.max(3, Math.min(100, (score / denom) * 100))
+          return (
+            <div key={gateway} className="space-y-1.5">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="truncate text-sm font-medium text-slate-900 dark:text-white">{gateway}</span>
+                  {isWinner ? (
+                    <span className="shrink-0 rounded-md bg-brand-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-600 dark:text-brand-300">
+                      Selected
+                    </span>
+                  ) : null}
+                </div>
+                <span className="shrink-0 text-sm font-semibold tabular-nums text-slate-700 dark:text-[#d8e1ef]">
+                  {asFraction ? `${(score * 100).toFixed(1)}%` : score.toLocaleString(undefined, { maximumFractionDigits: 4 })}
+                </span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-slate-200/70 dark:bg-[#1e2330]">
+                <div
+                  className="h-full rounded-full transition-all"
+                  style={{ width: `${width}%`, backgroundColor: isWinner ? '#0069ED' : '#94a3b8' }}
+                />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </PanelSection>
+  )
+}
+
+function StructuredRecordPanel({ title, value, emptyMessage }: { title: string; value: unknown; emptyMessage: string }) {
+  const entries = asScalarEntries(value)
+
+  if (!entries) {
+    return (
+      <PanelSection title={title}>
+        {value ? <JsonBlock value={value} /> : <EmptyState title={`No ${title.toLowerCase()} captured`} body={emptyMessage} />}
+      </PanelSection>
+    )
+  }
+
+  return (
+    <PanelSection title={title}>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 rounded-[22px] border border-slate-200/80 bg-slate-50/90 px-4 py-4 dark:border-[#2a303a] dark:bg-[#0b1017]">
+        {entries.map(([key, val]) => (
+          <div key={key} className="min-w-0">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-[#555f6e]">
+              {humanizeAuditValue(key)}
+            </p>
+            <p className={`mt-0.5 break-all text-sm ${val === null ? 'text-slate-400 dark:text-[#555f6e]' : 'text-slate-900 dark:text-white'}`}>
+              {formatScalar(val)}
+            </p>
+          </div>
+        ))}
+      </div>
+    </PanelSection>
   )
 }
 
@@ -902,47 +1051,56 @@ export function PaymentAuditPage() {
         </div>
 
         <form
-          className="flex flex-wrap items-center gap-3"
+          className="flex flex-wrap items-end gap-3"
           onSubmit={(e) => { e.preventDefault(); applyFilters() }}
         >
-          <input
-            className={`${controlClassName()} min-w-[320px] flex-[1.4]`}
-            value={filters.paymentId || filters.requestId}
-            onChange={(event) => updateFilter('paymentId', event.target.value)}
-            placeholder={mode === 'rule_based' ? 'Decision payment ID' : 'Payment ID'}
-          />
-          <input
-            className={`${controlClassName()} min-w-[180px] flex-1`}
-            value={filters.gateway}
-            onChange={(event) => updateFilter('gateway', event.target.value)}
-            placeholder="Any gateway"
-          />
-          <select
-            className={`${selectClassName()} min-w-[160px]`}
-            value={filters.status}
-            onChange={(event) => updateFilter('status', event.target.value)}
-          >
-            {STATUS_OPTIONS.map((option) => (
-              <option key={option.value || 'all'} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-          <Button type="submit" size="sm" className="min-w-[72px]">
+          <div className="min-w-[280px] flex-[1.4]">
+            <FieldLabel>{mode === 'rule_based' ? 'Decision payment ID' : 'Payment ID'}</FieldLabel>
+            <input
+              className={fieldClassName()}
+              value={filters.paymentId || filters.requestId}
+              onChange={(event) => updateFilter('paymentId', event.target.value)}
+              placeholder={mode === 'rule_based' ? 'Decision payment ID' : 'PaymentID'}
+            />
+          </div>
+          <div className="min-w-[180px] flex-1">
+            <FieldLabel>Gateway</FieldLabel>
+            <input
+              className={fieldClassName()}
+              value={filters.gateway}
+              onChange={(event) => updateFilter('gateway', event.target.value)}
+              placeholder="Any gateway"
+            />
+          </div>
+          <div className="min-w-[160px] flex-1">
+            <FieldLabel>Status</FieldLabel>
+            <select
+              className={fieldSelectClassName()}
+              value={filters.status}
+              onChange={(event) => updateFilter('status', event.target.value)}
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option.value || 'all'} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button type="submit" className="h-11 min-w-[88px]">
             Search
           </Button>
-          <Button size="sm" variant="ghost" onClick={clearFilters}>
+          <Button variant="ghost" onClick={clearFilters} className="h-11">
             Clear
           </Button>
           <Button
             type="button"
-            size="sm"
             variant="secondary"
             onClick={() => setShowAdvancedFilters((value) => !value)}
-            className={showAdvancedFilters ? 'text-brand-600 dark:text-brand-400' : ''}
+            aria-label="More filters"
+            title="More filters"
+            className={`h-11 !px-3 ${showAdvancedFilters ? '!text-brand-600 dark:!text-brand-400' : ''}`}
           >
-            <SlidersHorizontal className="h-3.5 w-3.5" />
-            Filters
+            <SlidersHorizontal className="h-4 w-4" />
           </Button>
         </form>
 
@@ -983,26 +1141,38 @@ export function PaymentAuditPage() {
       )}
 
       {auditSearch.data ? (
-        <div className="flex flex-wrap items-stretch gap-2">
-          <div className="flex items-center gap-1.5 rounded-[14px] border border-slate-200/80 bg-white/60 px-3.5 py-2 dark:border-[#23232a] dark:bg-[#0e1117]">
-            <span className="text-base font-bold tabular-nums text-slate-900 dark:text-white">{totalMatches}</span>
-            <span className="text-xs font-medium text-slate-500 dark:text-[#8a8a93]">Matches</span>
-          </div>
-          <div className="flex items-center gap-1.5 rounded-[14px] border border-emerald-200/60 bg-emerald-50/70 px-3.5 py-2 dark:border-emerald-500/20 dark:bg-emerald-500/[0.07]">
-            <span className="text-base font-bold tabular-nums text-emerald-700 dark:text-emerald-400">{successCount}</span>
-            <span className="text-xs font-medium text-emerald-600/80 dark:text-emerald-500/80">Success</span>
-          </div>
-          <div className="flex items-center gap-1.5 rounded-[14px] border border-red-200/60 bg-red-50/70 px-3.5 py-2 dark:border-red-500/20 dark:bg-red-500/[0.07]">
-            <span className="text-base font-bold tabular-nums text-red-600 dark:text-red-400">{failureCount}</span>
-            <span className="text-xs font-medium text-red-500/80 dark:text-red-400/80">Failure</span>
-          </div>
-          {activeGatewayList.length > 0 && (
-            <div className="flex items-center gap-1.5 rounded-[14px] border border-violet-200/60 bg-violet-50/70 px-3.5 py-2 dark:border-violet-500/20 dark:bg-violet-500/[0.07]">
-              <span className="text-base font-bold tabular-nums text-violet-700 dark:text-violet-400">{activeGateways}</span>
-              <span className="text-xs font-medium text-violet-600/80 dark:text-violet-400/80">Connectors</span>
-              <span className="text-[11px] text-violet-500/60 dark:text-violet-600/60">· {activeGatewayList.slice(0, 2).join(', ')}</span>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <GlassCard className="flex items-center gap-3 px-5 py-4">
+            <span className="text-2xl font-bold tabular-nums text-slate-900 dark:text-white">
+              {totalMatches.toLocaleString()}
+            </span>
+            <span className="text-sm font-medium text-slate-500 dark:text-[#8a8a93]">Matches</span>
+          </GlassCard>
+          <GlassCard className="flex items-center gap-3 px-5 py-4">
+            <span className="text-2xl font-bold tabular-nums text-emerald-600 dark:text-emerald-400">
+              {successCount.toLocaleString()}
+            </span>
+            <Badge variant="green">Success</Badge>
+          </GlassCard>
+          <GlassCard className="flex items-center gap-3 px-5 py-4">
+            <span className="text-2xl font-bold tabular-nums text-red-600 dark:text-red-400">
+              {failureCount.toLocaleString()}
+            </span>
+            <Badge variant="red">Failure</Badge>
+          </GlassCard>
+          <GlassCard className="flex items-center gap-3 px-5 py-4">
+            <span className="text-2xl font-bold tabular-nums text-slate-900 dark:text-white">
+              {activeGateways}
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-slate-500 dark:text-[#8a8a93]">Connectors</p>
+              {activeGatewayList.length > 0 ? (
+                <p className="truncate text-xs text-slate-400 dark:text-[#555f6e]">
+                  {activeGatewayList.slice(0, 3).join(', ')}
+                </p>
+              ) : null}
             </div>
-          )}
+          </GlassCard>
         </div>
       ) : null}
 
@@ -1016,7 +1186,7 @@ export function PaymentAuditPage() {
                   Back to results
                 </Button>
                 <div className="flex items-center justify-between gap-3">
-                  <h2 className="truncate text-sm font-semibold text-slate-900 dark:text-white">
+                  <h2 className="truncate text-base font-semibold text-slate-900 dark:text-white">
                     {selectedSummary?.payment_id || selectedSummary?.request_id || selectedSummary?.lookup_key || 'Selected payment'}
                   </h2>
                   <div className="flex shrink-0 items-center gap-2">
@@ -1036,7 +1206,7 @@ export function PaymentAuditPage() {
 
           {!trailFocused ? (
             <>
-            <div className="flex-1 overflow-y-auto p-2">
+            <div className="flex-1 space-y-2 overflow-y-auto p-3">
               {resultRows.length > 0 ? resultRows.map((row) => {
                 const isSelected = selectedSummary?.lookup_key === row.lookup_key
                 return (
@@ -1044,30 +1214,37 @@ export function PaymentAuditPage() {
                   key={row.lookup_key}
                   type="button"
                   onClick={() => selectSummary(row.lookup_key, row.event_count)}
-                  className={`relative w-full rounded-lg px-3 py-2.5 text-left transition-all ${
+                  className={`relative w-full overflow-hidden rounded-2xl border px-4 py-3 text-left transition-all ${
                     isSelected
-                      ? 'bg-brand-50 dark:bg-[#161b24]'
-                      : 'hover:bg-slate-50/80 dark:hover:bg-[#13131a]'
+                      ? 'border-brand-300 bg-brand-50 dark:border-brand-500/40 dark:bg-[#161b24]'
+                      : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/80 dark:border-[#23232a] dark:bg-[#0e1117] dark:hover:border-[#2a303a] dark:hover:bg-[#13131a]'
                   }`}
                 >
                   {isSelected && (
-                    <span className="absolute inset-y-1.5 left-0 w-[3px] rounded-full bg-brand-500" />
+                    <span className="absolute inset-y-2 left-0 w-[3px] rounded-full bg-brand-500" />
                   )}
-                  <div className="flex items-center gap-2.5">
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
-                        {row.payment_id || row.request_id || row.lookup_key}
-                      </p>
-                      <p className="mt-0.5 truncate text-xs text-slate-400 dark:text-[#555f6e]">
-                        {compactMeta([row.latest_gateway || null, `${row.event_count} event${row.event_count === 1 ? '' : 's'}`])}
-                      </p>
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
+                      {row.payment_id || row.request_id || row.lookup_key}
+                    </p>
+                    <span className="shrink-0 text-[11px] text-slate-400 dark:text-[#555f6e]">
+                      {formatRelative(row.last_seen_ms)}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex items-center justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-2">
+                      {row.latest_gateway ? (
+                        <span className="shrink-0 rounded-md bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:bg-[#1e2330] dark:text-[#a7b2c6]">
+                          {row.latest_gateway}
+                        </span>
+                      ) : null}
+                      <span className="truncate text-xs text-slate-400 dark:text-[#555f6e]">
+                        {row.event_count} event{row.event_count === 1 ? '' : 's'}
+                      </span>
                     </div>
-                    <div className="shrink-0 text-right">
-                      <p className="text-[11px] text-slate-400 dark:text-[#555f6e]">{formatRelative(row.last_seen_ms)}</p>
-                      <Badge variant={summaryBadgeVariant(row.latest_status)}>
-                        {humanizeAuditValue(row.latest_status) || 'Unknown'}
-                      </Badge>
-                    </div>
+                    <Badge variant={summaryBadgeVariant(row.latest_status)}>
+                      {humanizeAuditValue(row.latest_status) || 'Unknown'}
+                    </Badge>
                   </div>
                 </button>
               )}) : (
@@ -1108,9 +1285,9 @@ export function PaymentAuditPage() {
             </div>
             </>
           ) : (
-            <div className="flex-1 overflow-y-auto p-2">
+            <div className="flex-1 space-y-1.5 overflow-y-auto p-3">
               {timeline.length ? (
-                <div>
+                <>
                   {timeline.map((event, index) => {
                     const selected = selectedEvent?.id === event.id
                     return (
@@ -1121,17 +1298,17 @@ export function PaymentAuditPage() {
                           setSelectedEventId(event.id)
                           setInspectorTab('summary')
                         }}
-                        className={`relative w-full rounded-lg px-3 py-2.5 text-left transition-all ${
+                        className={`relative w-full overflow-hidden rounded-2xl px-4 py-3 text-left transition-all ${
                           selected
                             ? 'bg-brand-50 dark:bg-[#161b24]'
                             : 'hover:bg-slate-50/80 dark:hover:bg-[#13131a]'
                         }`}
                       >
                         {selected && (
-                          <span className="absolute inset-y-1.5 left-0 w-[3px] rounded-full bg-brand-500" />
+                          <span className="absolute inset-y-2.5 left-0 w-[3px] rounded-full bg-brand-500" />
                         )}
-                        <div className="flex items-center gap-2.5">
-                          <div className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold ${
+                        <div className="flex items-start gap-3">
+                          <div className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold ${
                             selected
                               ? 'bg-brand-500/15 text-brand-500 dark:text-brand-400'
                               : 'bg-slate-100 text-slate-500 dark:bg-[#1e2330] dark:text-[#8a8a93]'
@@ -1155,7 +1332,7 @@ export function PaymentAuditPage() {
                               </p>
                             ) : null}
                           </div>
-                          <div className="shrink-0 text-right">
+                          <div className="shrink-0 space-y-1 text-right">
                             <p className="text-[11px] text-slate-400 dark:text-[#555f6e]">{formatRelative(event.created_at_ms)}</p>
                             {event.status ? (
                               <Badge variant={summaryBadgeVariant(event.status)}>
@@ -1167,7 +1344,7 @@ export function PaymentAuditPage() {
                       </button>
                     )
                   })}
-                </div>
+                </>
               ) : (
                 <EmptyState
                   title="No timeline selected yet"
@@ -1216,31 +1393,40 @@ export function PaymentAuditPage() {
                   </InsetPanel>
                 </div>
 
-                <div className="flex flex-wrap gap-2">
+                <div className="inline-flex max-w-full flex-wrap items-center gap-1 rounded-full border border-slate-200 bg-slate-100/70 p-1 dark:border-[#2a303a] dark:bg-[#11151d]">
                   {INSPECTOR_TABS.map((tab) => (
-                    <Button
+                    <button
                       key={tab}
-                      size="sm"
-                      variant="secondary"
-                      className={sectionButtonClass(inspectorTab === tab)}
+                      type="button"
                       onClick={() => setInspectorTab(tab)}
+                      className={`rounded-full px-4 py-1.5 text-xs font-semibold transition ${
+                        inspectorTab === tab
+                          ? 'bg-white text-slate-900 shadow-sm dark:bg-[#161b24] dark:text-white'
+                          : 'text-slate-500 hover:text-slate-900 dark:text-[#a7b2c6] dark:hover:text-white'
+                      }`}
                     >
                       {tab === 'summary' ? 'Summary' : tab === 'input' ? 'Input' : tab === 'response' ? 'Response' : 'Raw JSON'}
-                    </Button>
+                    </button>
                   ))}
                 </div>
 
                 {inspectorTab === 'summary' ? (
                   <div className="space-y-4">
                     {selectedEventIsDecision ? (
-                      <InspectorJsonPanel
+                      <ConnectorScorePanel
                         title="Connector scores"
                         value={inspectorModel.scoreContext}
+                        selectedGateway={selectedEvent.gateway}
                         emptyMessage="No connector score map was captured for this event."
                       />
                     ) : null}
-                    <InspectorKeyValueGrid rows={inspectorModel.summaryRows} />
-                    <InspectorJsonPanel
+                    {inspectorModel.summaryRows.length ? (
+                      <div className="space-y-3">
+                        <h3 className="text-sm font-semibold text-slate-900 dark:text-white">Decision metadata</h3>
+                        <InspectorKeyValueGrid rows={inspectorModel.summaryRows} />
+                      </div>
+                    ) : null}
+                    <StructuredRecordPanel
                       title="Selection reason"
                       value={inspectorModel.selectionReason}
                       emptyMessage="No explicit selection reason was captured for this event."

--- a/website/src/pages/AuthPage.tsx
+++ b/website/src/pages/AuthPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import {
   ArrowRight,
   Building2,
@@ -360,7 +360,7 @@ export function AuthPage() {
                     label="Password"
                     footer={
                       tab === 'login'
-                        ? 'Password reset is managed by your account admin.'
+                        ? undefined
                         : 'Use at least 10 characters with uppercase, lowercase, number, and special character.'
                     }
                   >
@@ -385,6 +385,18 @@ export function AuthPage() {
                       </button>
                     </div>
                   </Field>
+
+                  {tab === 'login' ? (
+                    <div className="-mt-1 flex justify-end">
+                      <Link
+                        to="/forgot-password"
+                        state={{ email }}
+                        className="text-sm font-medium text-brand-600 transition-colors hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-100"
+                      >
+                        Forgot password?
+                      </Link>
+                    </div>
+                  ) : null}
 
                   {tab === 'signup' ? (
                     <p className="text-xs leading-5 text-slate-500 dark:text-[#7b8496]">

--- a/website/src/pages/ForgotPasswordPage.tsx
+++ b/website/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { ArrowLeft, ArrowRight, CheckCircle, Loader2, Mail, Moon, Sun } from 'lucide-react'
+import { apiFetch } from '../lib/api'
+import { getResolvedThemePreference, persistThemePreference } from '../lib/theme'
+import { ErrorMessage } from '../components/ui/ErrorMessage'
+
+interface ForgotPasswordResponse {
+  message: string
+}
+
+function getApiErrorMessage(err: unknown): string {
+  const msg = err instanceof Error ? err.message : 'Something went wrong'
+  const match = msg.match(/API error \d+: (.+)/)
+  if (!match) return msg
+  try {
+    const parsed = JSON.parse(match[1])
+    return parsed.message ?? msg
+  } catch {
+    return match[1]
+  }
+}
+
+export function ForgotPasswordPage() {
+  const assetBaseUrl = import.meta.env.BASE_URL
+  const location = useLocation()
+  const prefillEmail = (location.state as { email?: string } | null)?.email ?? ''
+  const [isDark, setIsDark] = useState(() => getResolvedThemePreference() === 'dark')
+  const [email, setEmail] = useState(prefillEmail)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [sentMessage, setSentMessage] = useState<string | null>(null)
+
+  function handleThemeToggle() {
+    const next = isDark ? 'light' : 'dark'
+    setIsDark(next === 'dark')
+    persistThemePreference(next)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    try {
+      const res = await apiFetch<ForgotPasswordResponse>('/auth/forgot-password', {
+        method: 'POST',
+        body: JSON.stringify({ email }),
+      })
+      setSentMessage(
+        res.message ??
+          'If an account exists for that email, a password reset link has been sent.',
+      )
+    } catch (err) {
+      setError(getApiErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-white text-slate-900 dark:bg-[#030507] dark:text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,_rgba(59,130,246,0.06),_transparent_24%),radial-gradient(circle_at_78%_20%,_rgba(14,165,233,0.04),_transparent_18%),radial-gradient(circle_at_50%_100%,_rgba(14,165,233,0.03),_transparent_24%)] dark:bg-[radial-gradient(circle_at_18%_18%,_rgba(56,189,248,0.05),_transparent_24%),radial-gradient(circle_at_78%_20%,_rgba(59,130,246,0.04),_transparent_18%),radial-gradient(circle_at_50%_100%,_rgba(14,165,233,0.035),_transparent_24%)]" />
+      <div className="pointer-events-none absolute inset-0 opacity-[0.05] dark:opacity-[0.08] [background-image:linear-gradient(rgba(148,163,184,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,0.08)_1px,transparent_1px)] [background-size:56px_56px]" />
+
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <header className="flex items-center justify-between px-6 py-5 sm:px-10">
+          <div>
+            <img
+              src={`${assetBaseUrl}logo/decision-engine-light.svg`}
+              alt="Juspay Decision Engine"
+              className="h-10 w-auto dark:hidden sm:h-11"
+            />
+            <img
+              src={`${assetBaseUrl}logo/decision-engine-dark.svg`}
+              alt="Juspay Decision Engine"
+              className="hidden h-10 w-auto dark:block sm:h-11"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handleThemeToggle}
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-white/8 dark:hover:text-white"
+            aria-label="Toggle theme"
+            title="Toggle theme"
+          >
+            {isDark ? <Sun size={18} /> : <Moon size={18} />}
+          </button>
+        </header>
+
+        <div className="flex flex-1 items-center justify-center px-6 py-12">
+          <div className="w-full max-w-[440px] rounded-3xl border border-slate-200 bg-white px-8 py-10 shadow-[0_20px_60px_-20px_rgba(15,23,42,0.08)] dark:border-[#1d1d23] dark:bg-[#0b0e14] dark:shadow-none sm:px-10">
+            {sentMessage ? (
+              <div className="space-y-6 text-center">
+                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-500/10">
+                  <CheckCircle size={28} className="text-emerald-500" />
+                </div>
+                <div className="space-y-2">
+                  <h1 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">
+                    Check your inbox
+                  </h1>
+                  <p className="text-sm leading-6 text-slate-500 dark:text-[#8a94a7]">{sentMessage}</p>
+                </div>
+                <Link
+                  to="/login"
+                  className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(90deg,#4371ff_0%,#3a63f4_100%)] px-6 text-sm font-semibold text-white transition-all hover:brightness-110"
+                >
+                  Back to sign in
+                </Link>
+              </div>
+            ) : (
+              <>
+                <div className="text-center">
+                  <h1 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white sm:text-[1.75rem]">
+                    Forgot your password?
+                  </h1>
+                  <p className="mt-3 text-sm leading-6 text-slate-500 dark:text-[#8a94a7]">
+                    Enter the email tied to your account and we&rsquo;ll send you a link to reset your
+                    password.
+                  </p>
+                </div>
+
+                <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+                  <label className="block">
+                    <span className="mb-2 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-[#8a94a7]">
+                      Email
+                    </span>
+                    <div className="relative">
+                      <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 dark:text-[#667085]">
+                        <Mail size={16} />
+                      </span>
+                      <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="name@company.com"
+                        required
+                        autoFocus
+                        className="h-14 w-full rounded-2xl border border-slate-200 bg-white pl-12 pr-4 text-sm text-slate-950 shadow-[0_12px_30px_-24px_rgba(15,23,42,0.12)] outline-none transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-white dark:shadow-none"
+                      />
+                    </div>
+                  </label>
+
+                  <ErrorMessage error={error} />
+
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    className="group inline-flex h-14 w-full items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(90deg,#4371ff_0%,#3a63f4_100%)] px-5 text-sm font-semibold text-white transition-all duration-200 hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {loading ? (
+                      <>
+                        <Loader2 size={16} className="animate-spin" />
+                        Sending link
+                      </>
+                    ) : (
+                      <>
+                        Send reset link
+                        <ArrowRight
+                          size={16}
+                          className="transition-transform duration-200 group-hover:translate-x-0.5"
+                        />
+                      </>
+                    )}
+                  </button>
+                </form>
+
+                <div className="mt-8 border-t border-slate-200 pt-6 text-center dark:border-[#1d1d23]">
+                  <Link
+                    to="/login"
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-950 dark:text-[#8a94a7] dark:hover:text-white"
+                  >
+                    <ArrowLeft size={15} />
+                    Back to sign in
+                  </Link>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <footer className="px-6 py-5 text-center text-xs text-slate-400 dark:text-[#525866]">
+          Juspay Decision Engine
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/website/src/pages/ResetPasswordPage.tsx
+++ b/website/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import {
+  ArrowRight,
+  Eye,
+  EyeOff,
+  Loader2,
+  LockKeyhole,
+  Moon,
+  Sun,
+  XCircle,
+} from 'lucide-react'
+import { apiFetch } from '../lib/api'
+import { getResolvedThemePreference, persistThemePreference } from '../lib/theme'
+import { ErrorMessage } from '../components/ui/ErrorMessage'
+
+interface ResetPasswordResponse {
+  message: string
+}
+
+function getPasswordPolicyError(password: string): string | null {
+  if (password.length < 10) return 'Use at least 10 characters.'
+  if (!/[A-Z]/.test(password)) return 'Add at least one uppercase letter.'
+  if (!/[a-z]/.test(password)) return 'Add at least one lowercase letter.'
+  if (!/[0-9]/.test(password)) return 'Add at least one number.'
+  if (!/[^A-Za-z0-9]/.test(password)) return 'Add at least one special character.'
+  return null
+}
+
+function getApiErrorMessage(err: unknown): string {
+  const msg = err instanceof Error ? err.message : 'Something went wrong'
+  const match = msg.match(/API error \d+: (.+)/)
+  if (!match) return msg
+  try {
+    const parsed = JSON.parse(match[1])
+    return parsed.message ?? msg
+  } catch {
+    return match[1]
+  }
+}
+
+export function ResetPasswordPage() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')
+  const assetBaseUrl = import.meta.env.BASE_URL
+
+  const [isDark, setIsDark] = useState(() => getResolvedThemePreference() === 'dark')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function handleThemeToggle() {
+    const next = isDark ? 'light' : 'dark'
+    setIsDark(next === 'dark')
+    persistThemePreference(next)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    const policyError = getPasswordPolicyError(password)
+    if (policyError) {
+      setError(policyError)
+      return
+    }
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      await apiFetch<ResetPasswordResponse>('/auth/reset-password', {
+        method: 'POST',
+        body: JSON.stringify({ token, new_password: password }),
+      })
+      navigate('/login', {
+        replace: true,
+        state: { notice: 'Password reset! Sign in with your new password.' },
+      })
+    } catch (err) {
+      setError(getApiErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const themeToggle = (
+    <button
+      type="button"
+      onClick={handleThemeToggle}
+      className="flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-white/8 dark:hover:text-white"
+      aria-label="Toggle theme"
+      title="Toggle theme"
+    >
+      {isDark ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  )
+
+  const shell = (children: React.ReactNode) => (
+    <div className="relative min-h-screen overflow-hidden bg-white text-slate-900 dark:bg-[#030507] dark:text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,_rgba(59,130,246,0.06),_transparent_24%),radial-gradient(circle_at_78%_20%,_rgba(14,165,233,0.04),_transparent_18%),radial-gradient(circle_at_50%_100%,_rgba(14,165,233,0.03),_transparent_24%)] dark:bg-[radial-gradient(circle_at_18%_18%,_rgba(56,189,248,0.05),_transparent_24%),radial-gradient(circle_at_78%_20%,_rgba(59,130,246,0.04),_transparent_18%),radial-gradient(circle_at_50%_100%,_rgba(14,165,233,0.035),_transparent_24%)]" />
+      <div className="pointer-events-none absolute inset-0 opacity-[0.05] dark:opacity-[0.08] [background-image:linear-gradient(rgba(148,163,184,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,0.08)_1px,transparent_1px)] [background-size:56px_56px]" />
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <header className="flex items-center justify-between px-6 py-5 sm:px-10">
+          <div>
+            <img
+              src={`${assetBaseUrl}logo/decision-engine-light.svg`}
+              alt="Juspay Decision Engine"
+              className="h-10 w-auto dark:hidden sm:h-11"
+            />
+            <img
+              src={`${assetBaseUrl}logo/decision-engine-dark.svg`}
+              alt="Juspay Decision Engine"
+              className="hidden h-10 w-auto dark:block sm:h-11"
+            />
+          </div>
+          {themeToggle}
+        </header>
+        <div className="flex flex-1 items-center justify-center px-6 py-12">{children}</div>
+        <footer className="px-6 py-5 text-center text-xs text-slate-400 dark:text-[#525866]">
+          Juspay Decision Engine
+        </footer>
+      </div>
+    </div>
+  )
+
+  if (!token) {
+    return shell(
+      <div className="w-full max-w-[420px] rounded-3xl border border-slate-200 bg-white px-10 py-12 text-center shadow-[0_20px_60px_-20px_rgba(15,23,42,0.08)] dark:border-[#1d1d23] dark:bg-[#0b0e14] dark:shadow-none">
+        <div className="space-y-5">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10">
+            <XCircle size={28} className="text-red-500" />
+          </div>
+          <div className="space-y-2">
+            <p className="text-xl font-semibold tracking-tight text-slate-950 dark:text-white">
+              Invalid reset link
+            </p>
+            <p className="text-sm text-slate-500 dark:text-[#8a94a7]">
+              This link is missing a token. Request a new password reset link to continue.
+            </p>
+          </div>
+          <Link
+            to="/forgot-password"
+            className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(90deg,#4371ff_0%,#3a63f4_100%)] px-6 text-sm font-semibold text-white transition-all hover:brightness-110"
+          >
+            Request a new link
+          </Link>
+        </div>
+      </div>,
+    )
+  }
+
+  return shell(
+    <div className="w-full max-w-[440px] rounded-3xl border border-slate-200 bg-white px-8 py-10 shadow-[0_20px_60px_-20px_rgba(15,23,42,0.08)] dark:border-[#1d1d23] dark:bg-[#0b0e14] dark:shadow-none sm:px-10">
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white sm:text-[1.75rem]">
+          Set a new password
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-slate-500 dark:text-[#8a94a7]">
+          Choose a strong password you don&rsquo;t use anywhere else.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+        <label className="block">
+          <span className="mb-2 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-[#8a94a7]">
+            New password
+          </span>
+          <div className="relative">
+            <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 dark:text-[#667085]">
+              <LockKeyhole size={16} />
+            </span>
+            <input
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Enter new password"
+              required
+              autoFocus
+              className="h-14 w-full rounded-2xl border border-slate-200 bg-white pl-12 pr-12 text-sm text-slate-950 shadow-[0_12px_30px_-24px_rgba(15,23,42,0.12)] outline-none transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-white dark:shadow-none"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((value) => !value)}
+              className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 transition-colors hover:text-slate-700 dark:text-slate-500 dark:hover:text-slate-200"
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+            >
+              {showPassword ? <Eye size={18} /> : <EyeOff size={18} />}
+            </button>
+          </div>
+        </label>
+
+        <label className="block">
+          <span className="mb-2 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-[#8a94a7]">
+            Confirm password
+          </span>
+          <div className="relative">
+            <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 dark:text-[#667085]">
+              <LockKeyhole size={16} />
+            </span>
+            <input
+              type={showPassword ? 'text' : 'password'}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="Re-enter new password"
+              required
+              className="h-14 w-full rounded-2xl border border-slate-200 bg-white pl-12 pr-4 text-sm text-slate-950 shadow-[0_12px_30px_-24px_rgba(15,23,42,0.12)] outline-none transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-[#2a303a] dark:bg-[#161b24] dark:text-white dark:shadow-none"
+            />
+          </div>
+        </label>
+
+        <p className="text-xs leading-5 text-slate-500 dark:text-[#7b8496]">
+          Minimum 10 characters, including 1 uppercase letter, 1 lowercase letter, 1 number, and 1
+          special character.
+        </p>
+
+        <ErrorMessage error={error} />
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="group inline-flex h-14 w-full items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(90deg,#4371ff_0%,#3a63f4_100%)] px-5 text-sm font-semibold text-white transition-all duration-200 hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {loading ? (
+            <>
+              <Loader2 size={16} className="animate-spin" />
+              Resetting
+            </>
+          ) : (
+            <>
+              Reset password
+              <ArrowRight
+                size={16}
+                className="transition-transform duration-200 group-hover:translate-x-0.5"
+              />
+            </>
+          )}
+        </button>
+      </form>
+
+      <div className="mt-8 border-t border-slate-200 pt-6 text-center dark:border-[#1d1d23]">
+        <Link
+          to="/login"
+          className="text-sm font-medium text-slate-500 transition-colors hover:text-slate-950 dark:text-[#8a94a7] dark:hover:text-white"
+        >
+          Back to sign in
+        </Link>
+      </div>
+    </div>,
+  )
+}


### PR DESCRIPTION
This pull request introduces a comprehensive set of improvements to the authentication flows and transactional email templates, focusing on user experience, maintainability, and support for password reset functionality. The main changes include adding password reset endpoints and templates, refactoring and modernizing all transactional email templates for consistency, and improving error handling for authentication-related actions.

**Authentication and Routing Enhancements:**
- Added new API endpoints: `/auth/forgot-password` and `/auth/reset-password` to support password reset flows.
- Introduced constants for password reset token prefix and TTL.

**Email Template Refactoring and Features:**
- Refactored all transactional email templates to use a shared `render_layout` for consistent branding and structure, and extracted reusable helpers for call-to-action buttons and fallback links. 
- Updated `MemberAddedTemplate`, `InviteUserTemplate`, and `EmailVerificationTemplate` to use the new layout and style, improving clarity and accessibility. 
- Added a new `PasswordResetTemplate` for password reset emails, following the new design system.

**Error Handling Improvements:**
- Added a new `InvalidResetToken` variant to `UserAuthError` and mapped it to a `400 Bad Request` response. 