### PR TITLE
feat(auth): replace invite temp passwords with emailed set-password links

### DIFF
--- a/docs/api-refs/auth-and-onboarding.mdx
+++ b/docs/api-refs/auth-and-onboarding.mdx
@@ -181,9 +181,8 @@ curl --location "$BASE_URL/merchant/members/invite" \
 {
   "email": "teammate@example.com",
   "is_new_user": true,
-  "password": "TempPass#8821",
   "role": "member"
 }
 ```
 
-`password` is only present when the invite creates a brand-new user account — share it out of band so they can log in and change it. Inviting an email that's already a user omits `password` and just adds the membership.
+No credentials are ever returned or emailed. When the invite creates a brand-new user (`is_new_user: true`), the invitee receives an email with a single-use **set-password link** (valid for 7 days) that opens the dashboard's reset-password page; the account is unusable until they set a password. If the invite email cannot be delivered, the request fails with `500` and nothing is created — just retry. Because the emailed link is the new account's only credential, inviting new users in a release deployment requires an active email client (`[email] active_email_client = "smtp"` or `"aws_ses"`); with `no_email_client` the request fails rather than creating an unreachable account. Inviting an email that's already a user simply adds the membership and sends a notification email.

--- a/src/email/no_email.rs
+++ b/src/email/no_email.rs
@@ -6,13 +6,18 @@ pub struct NoEmailClient;
 impl EmailClient for NoEmailClient {
     async fn send_email(&self, message: EmailMessage) -> error_stack::Result<(), EmailError> {
         // Extract the action URL from the body so developers can complete email
-        // verification or password reset manually. Avoid logging the full HTML body
-        // for other email types (e.g. invite emails) because it would expose
-        // temporary passwords. Reset URLs carry a live single-use credential, so they
-        // are only logged in debug builds — never from a release binary.
+        // verification, password reset, or an invite manually. Avoid logging the full
+        // HTML body for other email types. Reset and invite URLs carry a live single-use
+        // credential, so they are only logged in debug builds — never from a release
+        // binary.
+        // `starts_with` (not `contains`) for the release-logged verification branch: invite
+        // subjects embed an admin-chosen merchant name, so a substring match could let a
+        // crafted merchant name route a live set-password link into release logs.
         let subject_lower = message.subject.to_lowercase();
-        let action_url = if subject_lower.contains("confirm your email")
-            || (cfg!(debug_assertions) && subject_lower.contains("reset your password"))
+        let action_url = if subject_lower.starts_with("confirm your email")
+            || (cfg!(debug_assertions)
+                && (subject_lower.contains("reset your password")
+                    || subject_lower.contains("invited")))
         {
             extract_href_from_cta(&message.html_body)
         } else {

--- a/src/email/templates.rs
+++ b/src/email/templates.rs
@@ -299,19 +299,16 @@ impl PasswordResetTemplate {
     }
 }
 
-pub struct InviteUserTemplate {
+pub struct InviteSetPasswordTemplate {
     pub user_email: String,
     pub merchant_name: String,
-    pub temporary_password: String,
-    pub base_url: String,
+    pub set_password_url: String,
 }
 
-impl InviteUserTemplate {
+impl InviteSetPasswordTemplate {
     pub fn into_message(self) -> EmailMessage {
         let merchant = escape_html(&self.merchant_name);
-        let email = escape_html(&self.user_email);
-        let password = escape_html(&self.temporary_password);
-        let base_url = escape_html(&self.base_url);
+        let url = escape_html(&self.set_password_url);
         let html_body = format!(
             r#"<!DOCTYPE html>
 <html lang="en">
@@ -322,7 +319,7 @@ impl InviteUserTemplate {
 </head>
 <body style="margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
   <!-- Preheader -->
-  <span style="display:none;max-height:0;overflow:hidden;mso-hide:all;">You&rsquo;ve been added to {merchant} on Juspay Decision Engine. Your login details are inside.&#8202;&#65279;&#847;</span>
+  <span style="display:none;max-height:0;overflow:hidden;mso-hide:all;">You&rsquo;ve been invited to {merchant} on Juspay Decision Engine. Set your password to get started.&#8202;&#65279;&#847;</span>
 
   <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#f1f5f9;">
     <tr>
@@ -346,39 +343,33 @@ impl InviteUserTemplate {
                 You&rsquo;ve been invited
               </h1>
               <p style="margin:0 0 32px;font-size:15px;line-height:1.75;color:#475569;">
-                You&rsquo;ve been added to <strong style="color:#0f172a;">{merchant}</strong> on Juspay Decision Engine.
-                Use the credentials below to sign in, then change your password from your account settings.
+                You&rsquo;ve been invited to <strong style="color:#0f172a;">{merchant}</strong> on Juspay Decision Engine.
+                Click the button below to choose your password and activate your account.
               </p>
 
-              <!-- Credentials card -->
-              <table width="100%" cellpadding="0" cellspacing="0" role="presentation"
-                     style="background-color:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;margin:0 0 36px;">
-                <tr>
-                  <td style="padding:20px 24px 16px;">
-                    <p style="margin:0 0 4px;font-size:11px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.06em;">Email</p>
-                    <p style="margin:0;font-size:15px;color:#0f172a;">{email}</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td style="border-top:1px solid #e2e8f0;padding:16px 24px 20px;">
-                    <p style="margin:0 0 4px;font-size:11px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.06em;">Temporary password</p>
-                    <p style="margin:0;font-size:15px;font-family:'Courier New',Courier,monospace;color:#0f172a;letter-spacing:0.04em;">{password}</p>
-                  </td>
-                </tr>
-              </table>
-
               <!-- CTA button -->
-              <table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 8px;">
+              <table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 40px;">
                 <tr>
                   <td style="background-color:#4371ff;border-radius:12px;">
-                    <a href="{base_url}/login"
+                    <a href="{url}"
                        style="display:inline-block;background-color:#4371ff;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:12px;letter-spacing:-0.01em;">
-                      Sign in to Decision Engine &rarr;
+                      Set your password &rarr;
                     </a>
                   </td>
                 </tr>
               </table>
 
+              <!-- Divider -->
+              <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 28px;">
+                <tr><td style="border-top:1px solid #e2e8f0;"></td></tr>
+              </table>
+
+              <p style="margin:0 0 8px;font-size:13px;color:#94a3b8;">
+                Button not working? Copy and paste this link into your browser:
+              </p>
+              <p style="margin:0;font-size:12px;word-break:break-all;line-height:1.6;">
+                <a href="{url}" style="color:#3b82f6;text-decoration:none;">{url}</a>
+              </p>
             </td>
           </tr>
 
@@ -386,8 +377,8 @@ impl InviteUserTemplate {
           <tr>
             <td style="background-color:#f8fafc;border-radius:0 0 16px 16px;padding:24px 48px;border:1px solid #e2e8f0;border-top:none;">
               <p style="margin:0 0 6px;font-size:12px;color:#94a3b8;line-height:1.65;">
-                For your security, please <strong style="color:#64748b;">change your password</strong> after signing in.
-                If you weren&rsquo;t expecting this invitation, contact your account administrator.
+                This link expires in <strong style="color:#64748b;">7 days</strong> and can be used only once.
+                If you weren&rsquo;t expecting this invitation, you can safely ignore this email &mdash; the account cannot be used until a password is set.
               </p>
               <p style="margin:10px 0 0;font-size:11px;color:#cbd5e1;">
                 Juspay Decision Engine &nbsp;&middot;&nbsp; Automated security email &mdash; please do not reply.
@@ -402,15 +393,13 @@ impl InviteUserTemplate {
 </body>
 </html>"#,
             merchant = merchant,
-            email = email,
-            password = password,
-            base_url = base_url
+            url = url
         );
 
         EmailMessage {
             to: self.user_email,
             subject: format!(
-                "You've been invited to join {} on Decision Engine",
+                "You're invited to {} on Decision Engine",
                 self.merchant_name
             ),
             html_body,

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -104,6 +104,11 @@ const FORGOT_PASSWORD_RATE_WINDOW_SECONDS: i64 = 3600;
 const FORGOT_PASSWORD_RATE_MAX_PER_EMAIL: i64 = 3;
 const FORGOT_PASSWORD_RATE_MAX_PER_IP: i64 = 30;
 
+/// Set-password links for invited users reuse the reset-code machinery (same Redis prefix,
+/// same redemption endpoint) but live longer — an invitee may not open the email the same
+/// day the admin sends it.
+const INVITE_SET_PASSWORD_TTL_SECONDS: i64 = 7 * 86400; // 7 days
+
 #[axum::debug_handler]
 pub async fn signup(
     Json(payload): Json<SignupRequest>,
@@ -368,6 +373,16 @@ pub async fn login(
         return Err(error::ContainerError::from(UserAuthError::AccountInactive));
     }
 
+    if !auth::verify_password(&payload.password, &user.password_hash)
+        .change_context(UserAuthError::StorageError)?
+    {
+        return Err(error::ContainerError::from(UserAuthError::InvalidPassword));
+    }
+
+    // Only after the password checks out: revealing EmailNotVerified to a caller who
+    // doesn't hold the credential would turn login into an account-existence /
+    // verification-status oracle (invited accounts sit unverified until they set a
+    // password via their emailed link).
     let email_verified = {
         #[cfg(feature = "mysql")]
         {
@@ -380,12 +395,6 @@ pub async fn login(
     };
     if global_config.user_auth.email_verification_enabled && !email_verified {
         return Err(error::ContainerError::from(UserAuthError::EmailNotVerified));
-    }
-
-    if !auth::verify_password(&payload.password, &user.password_hash)
-        .change_context(UserAuthError::StorageError)?
-    {
-        return Err(error::ContainerError::from(UserAuthError::InvalidPassword));
     }
 
     let merchants = fetch_user_merchants(&app_state, &user.user_id).await?;
@@ -693,7 +702,7 @@ async fn record_password_reset_timestamp(
     let reset_at_key = format!("{}{}", PASSWORD_RESET_AT_PREFIX, user_id);
     let ttl = std::cmp::max(
         global_config.user_auth.jwt_expiry_seconds as i64,
-        PASSWORD_RESET_CODE_TTL_SECONDS,
+        std::cmp::max(PASSWORD_RESET_CODE_TTL_SECONDS, INVITE_SET_PASSWORD_TTL_SECONDS),
     );
     if let Err(err) = app_state
         .redis_conn
@@ -1015,8 +1024,6 @@ pub struct InviteMemberRequest {
 pub struct InviteMemberResponse {
     pub email: String,
     pub is_new_user: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub password: Option<String>,
     pub role: String,
 }
 
@@ -1155,17 +1162,67 @@ pub async fn invite_member(
         Ok(Json(InviteMemberResponse {
             email: existing_user.email,
             is_new_user: false,
-            password: None,
             role,
         }))
     } else {
-        // Create new user with generated password
-        let generated_password = generate_random_password();
-
-        let password_hash = auth::hash_password(&generated_password)
-            .change_context(UserAuthError::PasswordHashingFailed)?;
+        // New users never receive a password — not in the email, not in the API response.
+        // The account is created with an unusable random hash and the invitee sets their
+        // own password through a single-use emailed link (the reset-password machinery).
+        //
+        // That emailed link is the account's only credential, so an email backend that
+        // delivers nothing (NoEmailClient logs the URL in debug builds only) must fail
+        // the invite instead of reporting false success and leaving a dead account.
+        if !global_config.email.is_active() && !cfg!(debug_assertions) {
+            return Err(error::ContainerError::from(UserAuthError::EmailSendFailed));
+        }
 
         let user_id = uuid::Uuid::new_v4().to_string();
+
+        // Unusable placeholder: a random secret hashed and immediately discarded. Login is
+        // impossible until the invitee sets a real password via the link (or, if the email
+        // is lost, via the forgot-password flow). Computed before the Redis write so no
+        // failure after the code is stored lacks a compensating delete.
+        let password_hash = auth::hash_password(&auth::generate_api_key())
+            .change_context(UserAuthError::PasswordHashingFailed)?;
+
+        let code = auth::generate_api_key();
+        let code_key = format!("{}{}", PASSWORD_RESET_CODE_PREFIX, auth::hash_api_key(&code));
+        let issued_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let code_value = format!("{}:{}", user_id, issued_at);
+        app_state
+            .redis_conn
+            .set_key_with_ttl(&code_key, &code_value, INVITE_SET_PASSWORD_TTL_SECONDS)
+            .await
+            .change_context(UserAuthError::StorageError)?;
+
+        // Send before any DB writes (same ordering as signup): the emailed link is the
+        // invitee's only way into the account, so a delivery failure must fail the invite
+        // cleanly — nothing persisted, the admin simply retries.
+        let email_client = APP_STATE
+            .get()
+            .map(|s| s.email_client.clone())
+            .ok_or(UserAuthError::StorageError)?;
+        let set_password_url = format!(
+            "{}/reset-password?token={}",
+            global_config.email.base_url, code
+        );
+        let send_result = email_client
+            .send_email(
+                crate::email::templates::InviteSetPasswordTemplate {
+                    user_email: payload.email.clone(),
+                    merchant_name: merchant_name.clone(),
+                    set_password_url,
+                }
+                .into_message(),
+            )
+            .await;
+        if send_result.is_err() {
+            let _ = app_state.redis_conn.delete_key(&code_key).await;
+        }
+        send_result.change_context(UserAuthError::EmailSendFailed)?;
 
         let new_user = NewUser {
             user_id: user_id.clone(),
@@ -1177,16 +1234,22 @@ pub async fn invite_member(
             is_active: 1,
             #[cfg(feature = "postgres")]
             is_active: true,
+            // Mailbox control is proven when the set-password link is redeemed — the
+            // reset flow flips this to true.
             #[cfg(feature = "mysql")]
-            email_verified: 1,
+            email_verified: 0,
             #[cfg(feature = "postgres")]
-            email_verified: true,
+            email_verified: false,
             created_at: now,
         };
 
-        crate::generics::generic_insert(&app_state.db, new_user)
+        if crate::generics::generic_insert(&app_state.db, new_user)
             .await
-            .change_context(UserAuthError::StorageError)?;
+            .is_err()
+        {
+            let _ = app_state.redis_conn.delete_key(&code_key).await;
+            return Err(error::ContainerError::from(UserAuthError::StorageError));
+        }
 
         let new_user_merchant = NewUserMerchant {
             user_id: user_id.clone(),
@@ -1199,7 +1262,8 @@ pub async fn invite_member(
             .await
             .is_err()
         {
-            // Compensating delete: remove orphaned user if membership insert fails
+            // Compensating deletes: remove the orphaned user and the now-dangling link
+            // if the membership insert fails.
             let conn = app_state.db.get_conn().await.ok();
             if let Some(conn) = conn {
                 let _ = crate::generics::generic_delete::<
@@ -1208,37 +1272,13 @@ pub async fn invite_member(
                 >(&conn, dsl::user_id.eq(user_id.clone()))
                 .await;
             }
+            let _ = app_state.redis_conn.delete_key(&code_key).await;
             return Err(error::ContainerError::from(UserAuthError::StorageError));
-        }
-
-        let email_config = &global_config.email;
-        if email_config.is_active() {
-            let email_client = APP_STATE
-                .get()
-                .map(|s| s.email_client.clone())
-                .ok_or(UserAuthError::StorageError)?;
-
-            let email_msg = crate::email::templates::InviteUserTemplate {
-                user_email: payload.email.clone(),
-                merchant_name: merchant_name.clone(),
-                temporary_password: generated_password.clone(),
-                base_url: email_config.base_url.clone(),
-            }
-            .into_message();
-
-            if let Err(err) = email_client.send_email(email_msg).await {
-                crate::logger::warn!(
-                    to = %payload.email,
-                    error = ?err,
-                    "Failed to send invite email; invite still succeeded"
-                );
-            }
         }
 
         Ok(Json(InviteMemberResponse {
             email: payload.email,
             is_new_user: true,
-            password: Some(generated_password),
             role,
         }))
     }
@@ -1293,37 +1333,6 @@ pub async fn list_members(
         .collect();
 
     Ok(Json(members))
-}
-
-fn generate_random_password() -> String {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    let uppercase = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    let lowercase = b"abcdefghijklmnopqrstuvwxyz";
-    let digits = b"0123456789";
-    let special = b"!@#$%^&*";
-
-    let mut password = vec![
-        uppercase[rng.gen_range(0..uppercase.len())] as char,
-        lowercase[rng.gen_range(0..lowercase.len())] as char,
-        digits[rng.gen_range(0..digits.len())] as char,
-        special[rng.gen_range(0..special.len())] as char,
-    ];
-
-    let all: Vec<u8> = [
-        uppercase.as_ref(),
-        lowercase.as_ref(),
-        digits.as_ref(),
-        special.as_ref(),
-    ]
-    .concat();
-    for _ in 0..12 {
-        password.push(all[rng.gen_range(0..all.len())] as char);
-    }
-
-    use rand::seq::SliceRandom;
-    password.shuffle(&mut rng);
-    password.into_iter().collect()
 }
 
 #[axum::debug_handler]

--- a/website/src/pages/MembersPage.tsx
+++ b/website/src/pages/MembersPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { UserPlus, Users, Copy, Check, Loader2, Eye, EyeOff } from 'lucide-react'
+import { UserPlus, Users, Loader2 } from 'lucide-react'
 import { apiFetch } from '../lib/api'
 import { ErrorMessage } from '../components/ui/ErrorMessage'
 
@@ -12,7 +12,6 @@ interface MemberInfo {
 interface InviteResponse {
   email: string
   is_new_user: boolean
-  password?: string
   role: string
 }
 
@@ -28,30 +27,6 @@ function RoleBadge({ role }: { role: string }) {
   )
 }
 
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false)
-  async function copy() {
-    if (!navigator.clipboard) return
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1800)
-    } catch {
-      // clipboard unavailable or denied — fail silently
-    }
-  }
-  return (
-    <button
-      onClick={copy}
-      className="ml-1.5 inline-flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
-      title={copied ? 'Copied' : 'Copy'}
-      aria-label={copied ? 'Copied' : 'Copy'}
-    >
-      {copied ? <Check size={13} className="text-green-500" /> : <Copy size={13} />}
-    </button>
-  )
-}
-
 export function MembersPage() {
   const [members, setMembers] = useState<MemberInfo[]>([])
   const [loadingMembers, setLoadingMembers] = useState(true)
@@ -62,7 +37,6 @@ export function MembersPage() {
   const [inviting, setInviting] = useState(false)
   const [inviteError, setInviteError] = useState<string | null>(null)
   const [inviteResult, setInviteResult] = useState<InviteResponse | null>(null)
-  const [showPassword, setShowPassword] = useState(false)
 
   async function loadMembers() {
     setLoadingMembers(true)
@@ -159,35 +133,13 @@ export function MembersPage() {
         </form>
 
         {inviteResult && (
-          <div className={`mt-4 rounded-xl border p-4 ${inviteResult.is_new_user ? 'border-amber-200 bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/20' : 'border-green-200 bg-green-50 dark:border-green-900/40 dark:bg-green-950/20'}`}>
+          <div className="mt-4 rounded-xl border border-green-200 bg-green-50 p-4 dark:border-green-900/40 dark:bg-green-950/20">
             {inviteResult.is_new_user ? (
-              <>
-                <p className="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-2">
-                  New account created — share these credentials
-                </p>
-                <div className="space-y-1.5 text-sm">
-                  <div className="flex items-center">
-                    <span className="w-20 text-amber-700 dark:text-amber-400 font-medium">Email</span>
-                    <code className="text-amber-900 dark:text-amber-200">{inviteResult.email}</code>
-                    <CopyButton text={inviteResult.email} />
-                  </div>
-                  <div className="flex items-center">
-                    <span className="w-20 text-amber-700 dark:text-amber-400 font-medium">Password</span>
-                    <code className="text-amber-900 dark:text-amber-200">
-                      {showPassword ? inviteResult.password : '••••••••••••••••'}
-                    </code>
-                    <button
-                      onClick={() => setShowPassword((v) => !v)}
-                      className="ml-1.5 inline-flex items-center justify-center w-6 h-6 rounded text-amber-600 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200 transition-colors"
-                      title={showPassword ? 'Hide password' : 'Show password'}
-                      aria-label={showPassword ? 'Hide password' : 'Show password'}
-                    >
-                      {showPassword ? <EyeOff size={13} /> : <Eye size={13} />}
-                    </button>
-                    {inviteResult.password && <CopyButton text={inviteResult.password} />}
-                  </div>
-                </div>
-              </>
+              <p className="text-sm text-green-800 dark:text-green-300">
+                Invitation sent to <span className="font-semibold">{inviteResult.email}</span> —
+                they&rsquo;ll receive an email with a link to set their password (valid for 7
+                days).
+              </p>
             ) : (
               <p className="text-sm text-green-800 dark:text-green-300">
                 <span className="font-semibold">{inviteResult.email}</span> has been added to this merchant.


### PR DESCRIPTION
## Summary

`invite_member` previously generated a temporary password for new users and both **returned it in the HTTP response body** (`InviteMemberResponse.password`) and **emailed it in plaintext**. This was flagged during the forgot-password security review as a pre-existing weakness to fix once a reset flow existed — which #333 provides. This PR removes passwords from the invite flow entirely: invitees now receive a single-use **set-password link**.

> **Stacked on #333** (`feat/forgot-password-reset`) — it reuses the reset-code machinery and redemption endpoint introduced there. Merge #333 first; GitHub will retarget this PR to `main` automatically.

## How the new flow works

- New users are created with an **unusable random bcrypt hash** (a discarded 244-bit secret) and `email_verified = false` — the account cannot be logged into until the invitee sets a password.
- The invite email carries a single-use set-password link built on the reset machinery: same SHA-256-keyed Redis entry and the same `POST /auth/reset-password` redemption (which also marks the mailbox verified), but with a **7-day TTL** since invitees may not open the email same-day.
- **Ordering / rollback:** the email is sent before any DB write — a delivery failure fails the invite with `500` and persists nothing (admin just retries). A membership-insert failure compensates by deleting both the user row and the code. A lost invite email is recoverable via the normal forgot-password flow.
- `InviteMemberResponse.password` is gone; the Members page shows an "invitation sent" banner instead of a credentials card. `InviteUserTemplate` (credentials email) is replaced by `InviteSetPasswordTemplate` (CTA link + 7-day/single-use footer). Existing-user invites (membership add + notification email) are unchanged.

## Hardenings from the review pass

This PR was reviewed by a multi-agent adversarial pass (3 reviewer dimensions, every finding independently verified); all confirmed findings are fixed here:

- **7-day codes vs revocation:** `user_pwreset_at`'s TTL now covers the invite-code lifetime, so a password change/reset still invalidates every previously emailed link — without this, a stale invite link could regain takeover power after the revocation key expired.
- **No silent dead accounts:** release deployments without an active email client (`no_email_client`) now fail the invite instead of "succeeding" while delivering no link (debug builds keep the dev flow, where the stub logs the URL).
- **Log-leak hardening:** the `no_email` stub's release-logged branch now matches `starts_with("confirm your email")`, closing a path where an admin-chosen merchant name could steer a live set-password link into release logs.
- **Oracle removal:** `login` now verifies the password before disclosing `EmailNotVerified`, so probing an invited-but-unredeemed account returns the same generic `401` as a nonexistent one.
- The unusable placeholder hash is computed before the Redis write so every post-write failure path has a compensating delete.

## Testing

- `cargo check` clean on both `mysql` and `postgres` feature paths; `tsc` clean.
- Live end-to-end on an isolated instance: admin signup → merchant → invite → response contains **no password field** → login before redemption fails → set-password link from the (debug) log redeems with `200` → invitee logs in with their chosen password, `email_verified = true`, membership present → link replay `400` → re-invite `409 AlreadyMember` → wrong-password probes against an unverified invited account and a nonexistent account return **byte-identical** responses.

## Docs

`docs/api-refs/auth-and-onboarding.mdx` — invite section rewritten: new response shape, link semantics, and the active-email-client requirement for release deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #364
