### PR TITLE
refractor: Update documentation links to point to the new GitHub repository structure

### DIFF
--- a/docs/analytics.mdx
+++ b/docs/analytics.mdx
@@ -91,6 +91,6 @@ COMPOSE_PROFILES= docker compose --profile analytics-clickhouse up -d
 
 ## Related Docs
 
-- [Payment Audit](/payment-audit) — single-payment timeline lookups.
-- [ClickHouse Analytics](/clickhouse-analytics) — the underlying ingestion pipeline and schema.
-- [Dashboard](/dashboard-guide) — where these views are surfaced.
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/payment-audit.mdx) — single-payment timeline lookups.
+- [ClickHouse Analytics](https://github.com/juspay/decision-engine/blob/main/docs/clickhouse-analytics.mdx) — the underlying ingestion pipeline and schema.
+- [Dashboard](https://github.com/juspay/decision-engine/blob/main/docs/dashboard-guide.mdx) — where these views are surfaced.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -7,16 +7,16 @@ description: "Schema-backed reference for every Decision Engine endpoint, with r
 
 This is the schema-backed reference for every Decision Engine endpoint. Each page below shows the full request and response model and includes an interactive playground, generated from the OpenAPI contract.
 
-Looking for copy-paste examples and end-to-end flows instead? Start with the [API Guide](/api-refs/api-ref).
+Looking for copy-paste examples and end-to-end flows instead? Start with the [API Guide](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx).
 
 ## Two ways to read the API
 
 | Surface | Best for |
 | --- | --- |
-| [API Guide](/api-refs/api-ref) | Task-oriented `curl` examples, complete flows, and request variants. |
+| [API Guide](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx) | Task-oriented `curl` examples, complete flows, and request variants. |
 | API Reference (this section) | Exact request/response schemas and an interactive playground, one page per endpoint. |
 
-For advanced rule examples — AND, OR, nested AND+OR, `volume_split_priority`, enum arrays, and number-array matching — see the [Advanced Routing Example](/api-refs/routing-advanced-example). For the exact `POST /routing/create` schema, use [Create Routing Rule](/api-reference/endpoint/createRoutingRule).
+For advanced rule examples — AND, OR, nested AND+OR, `volume_split_priority`, enum arrays, and number-array matching — see the [Advanced Routing Example](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-advanced-example.mdx). For the exact `POST /routing/create` schema, use [Create Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRoutingRule.mdx).
 
 ## Access classes
 
@@ -31,77 +31,77 @@ For advanced rule examples — AND, OR, nested AND+OR, `volume_split_priority`, 
 
 ### Health
 
-- [Health Check](/api-reference/endpoint/healthCheck)
-- [Health Ready](/api-reference/endpoint/healthReady)
-- [Health Diagnostics](/api-reference/endpoint/healthDiagnostics)
+- [Health Check](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthCheck.mdx)
+- [Health Ready](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthReady.mdx)
+- [Health Diagnostics](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthDiagnostics.mdx)
 
 ### Auth And Onboarding
 
-- [Signup](/api-reference/endpoint/signup)
-- [Login](/api-reference/endpoint/login)
-- [Logout](/api-reference/endpoint/logout)
-- [Current User](/api-reference/endpoint/me)
-- [List User Merchants](/api-reference/endpoint/listUserMerchants)
-- [Switch Merchant](/api-reference/endpoint/switchMerchant)
-- [Onboard Merchant](/api-reference/endpoint/onboardMerchant)
+- [Signup](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/signup.mdx)
+- [Login](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/login.mdx)
+- [Logout](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/logout.mdx)
+- [Current User](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/me.mdx)
+- [List User Merchants](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listUserMerchants.mdx)
+- [Switch Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/switchMerchant.mdx)
+- [Onboard Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/onboardMerchant.mdx)
 
 ### API Keys
 
-- [Create API Key](/api-reference/endpoint/createApiKey)
-- [List API Keys](/api-reference/endpoint/listApiKeys)
-- [Revoke API Key](/api-reference/endpoint/revokeApiKey)
+- [Create API Key](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createApiKey.mdx)
+- [List API Keys](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listApiKeys.mdx)
+- [Revoke API Key](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/revokeApiKey.mdx)
 
 ### Merchant Account
 
-- [Create Merchant](/api-reference/endpoint/createMerchant)
-- [Get Merchant](/api-reference/endpoint/getMerchant)
-- [Delete Merchant](/api-reference/endpoint/deleteMerchant)
-- [Get Merchant Debit Routing](/api-reference/endpoint/getMerchantDebitRouting)
-- [Update Merchant Debit Routing](/api-reference/endpoint/updateMerchantDebitRouting)
+- [Create Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createMerchant.mdx)
+- [Get Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getMerchant.mdx)
+- [Delete Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/deleteMerchant.mdx)
+- [Get Merchant Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getMerchantDebitRouting.mdx)
+- [Update Merchant Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateMerchantDebitRouting.mdx)
 
 ### Gateway Decision
 
-- [Decide Gateway](/api-reference/endpoint/decideGateway)
-- [Legacy Decision Gateway](/api-reference/endpoint/legacyDecisionGateway)
-- [Update Gateway Score](/api-reference/endpoint/updateGatewayScore)
-- [Legacy Update Score](/api-reference/endpoint/legacyUpdateScore)
+- [Decide Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/decideGateway.mdx)
+- [Legacy Decision Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/legacyDecisionGateway.mdx)
+- [Update Gateway Score](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateGatewayScore.mdx)
+- [Legacy Update Score](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/legacyUpdateScore.mdx)
 
 ### Routing Rules
 
-- [Create Routing Rule](/api-reference/endpoint/createRoutingRule)
-- [Activate Routing Rule](/api-reference/endpoint/activateRoutingRule)
-- [Deactivate Routing Rule](/api-reference/endpoint/deactivateRoutingRule)
-- [List Routing Rules](/api-reference/endpoint/listRoutingRules)
-- [Get Active Routing Rule](/api-reference/endpoint/getActiveRoutingRule)
-- [Evaluate Routing Rule](/api-reference/endpoint/evaluateRoutingRule)
-- [Hybrid Routing](/api-reference/endpoint/hybridRouting)
+- [Create Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRoutingRule.mdx)
+- [Activate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/activateRoutingRule.mdx)
+- [Deactivate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/deactivateRoutingRule.mdx)
+- [List Routing Rules](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listRoutingRules.mdx)
+- [Get Active Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getActiveRoutingRule.mdx)
+- [Evaluate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/evaluateRoutingRule.mdx)
+- [Hybrid Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/hybridRouting.mdx)
 
 ### Rule Configuration
 
-- [Create Rule Config](/api-reference/endpoint/createRuleConfig)
-- [Get Rule Config](/api-reference/endpoint/getRuleConfig)
-- [Update Rule Config](/api-reference/endpoint/updateRuleConfig)
-- [Delete Rule Config](/api-reference/endpoint/deleteRuleConfig)
+- [Create Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRuleConfig.mdx)
+- [Get Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getRuleConfig.mdx)
+- [Update Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateRuleConfig.mdx)
+- [Delete Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/deleteRuleConfig.mdx)
 
 ### Config
 
-- [Get Routing Config](/api-reference/endpoint/getRoutingConfig)
-- [Configure SR Dimensions](/api-reference/endpoint/configSrDimension)
+- [Get Routing Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getRoutingConfig.mdx)
+- [Configure SR Dimensions](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/configSrDimension.mdx)
 
 ### Analytics
 
-- [Overview](/api-reference/endpoint/analyticsOverview)
-- [Gateway Scores](/api-reference/endpoint/analyticsGatewayScores)
-- [Decisions](/api-reference/endpoint/analyticsDecisions)
-- [Routing Stats](/api-reference/endpoint/analyticsRoutingStats)
-- [Log Summaries](/api-reference/endpoint/analyticsLogSummaries)
-- [Payment Audit](/api-reference/endpoint/analyticsPaymentAudit)
-- [Preview Trace](/api-reference/endpoint/analyticsPreviewTrace)
-- [Cost Savings](/api-reference/endpoint/analyticsCostSavings)
-- [Routing Events](/api-reference/endpoint/analyticsRoutingEvents)
-- [A/B Test Experiment Results](/api-reference/endpoint/analyticsExperimentResults)
-- [A/B Test Experiment Transactions](/api-reference/endpoint/analyticsExperimentTransactions)
+- [Overview](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsOverview.mdx)
+- [Gateway Scores](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsGatewayScores.mdx)
+- [Decisions](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsDecisions.mdx)
+- [Routing Stats](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsRoutingStats.mdx)
+- [Log Summaries](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsLogSummaries.mdx)
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsPaymentAudit.mdx)
+- [Preview Trace](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsPreviewTrace.mdx)
+- [Cost Savings](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsCostSavings.mdx)
+- [Routing Events](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsRoutingEvents.mdx)
+- [A/B Test Experiment Results](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsExperimentResults.mdx)
+- [A/B Test Experiment Transactions](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsExperimentTransactions.mdx)
 
 ## Curl Examples
 
-For local and sandbox smoke-test examples, use [API Examples](/api-refs/api-ref).
+For local and sandbox smoke-test examples, use [API Examples](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx).

--- a/docs/api-reference/endpoint/activateRoutingRule.mdx
+++ b/docs/api-reference/endpoint/activateRoutingRule.mdx
@@ -55,7 +55,7 @@ Success returns HTTP `200` with an empty response body.
 
 ## Related
 
-- [Create Routing Rule](/api-reference/endpoint/createRoutingRule)
-- [Deactivate Routing Rule](/api-reference/endpoint/deactivateRoutingRule)
-- [Get Active Routing Rule](/api-reference/endpoint/getActiveRoutingRule)
-- [Activate Routing Algorithm](/api-refs/routing-algorithm-activate)
+- [Create Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRoutingRule.mdx)
+- [Deactivate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/deactivateRoutingRule.mdx)
+- [Get Active Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getActiveRoutingRule.mdx)
+- [Activate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-activate.mdx)

--- a/docs/api-reference/endpoint/analyticsCostSavings.mdx
+++ b/docs/api-reference/endpoint/analyticsCostSavings.mdx
@@ -8,7 +8,7 @@ openapi: "openapi.json GET /analytics/cost-savings"
 
 ## Use case
 
-Returns a rollup of savings attributed to [multi-objective (cost-aware) routing](/api-refs/decide-gateway-multi-objective) — how much cheaper the chosen gateway was versus the plain success-rate head, trended over the window.
+Returns a rollup of savings attributed to [multi-objective (cost-aware) routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx) — how much cheaper the chosen gateway was versus the plain success-rate head, trended over the window.
 
 ## Authentication
 
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/cost-savings`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -88,11 +88,11 @@ curl "$BASE_URL/analytics/cost-savings?range=1w&currency=USD" \
 - Analytics reads are ClickHouse-backed and merchant-scoped by the authenticated context.
 - Use `range=15m|1h|12h|1d|1w` or `start_ms` plus `end_ms` for a custom window.
 - `saved_value` is money saved versus the SR head's cost, in the requested (or aggregated) currency.
-- Requires [cost data ingestion](/api-refs/cost-ingestion-setup) to have fitted a cost model — otherwise `cost_won_count` stays at zero.
+- Requires [cost data ingestion](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx) to have fitted a cost model — otherwise `cost_won_count` stays at zero.
 
 ## Related
 
-- [Multi-Objective Routing](/api-refs/decide-gateway-multi-objective)
-- [Cost Ingestion: Fees & Coverage](/api-refs/cost-ingestion-fees)
-- [Analytics Overview](/api-reference/endpoint/analyticsOverview)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx)
+- [Cost Ingestion: Fees & Coverage](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-fees.mdx)
+- [Analytics Overview](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsOverview.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsDecisions.mdx
+++ b/docs/api-reference/endpoint/analyticsDecisions.mdx
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/decisions`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -101,6 +101,6 @@ curl "$BASE_URL/analytics/decisions?range=1d&exclude_routing_approach=NTW_BASED_
 
 ## Related
 
-- [Analytics Routing Stats](/api-reference/endpoint/analyticsRoutingStats)
-- [Payment Audit](/api-reference/endpoint/analyticsPaymentAudit)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Analytics Routing Stats](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsRoutingStats.mdx)
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsPaymentAudit.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsExperimentResults.mdx
+++ b/docs/api-reference/endpoint/analyticsExperimentResults.mdx
@@ -8,7 +8,7 @@ openapi: "openapi.json GET /analytics/experiment/{experiment_id}/results"
 
 ## Use case
 
-Runs a statistical significance test between the control and variant arms of a routing [A/B test experiment](/api-refs/ab-testing-create): a two-sample z-test on expected value, collapsing to a plain auth-rate z-test for auth-only experiments. A guardrail check short-circuits to `guardrail_breached` before significance is computed.
+Runs a statistical significance test between the control and variant arms of a routing [A/B test experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx): a two-sample z-test on expected value, collapsing to a plain auth-rate z-test for auth-only experiments. A guardrail check short-circuits to `guardrail_breached` before significance is computed.
 
 ## Authentication
 
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/experiment/{experiment_id}/results`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `experiment_id` (path, required, string) — the `rule_id` returned by `/routing/create` for the `ab_test` algorithm.
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -92,10 +92,10 @@ curl "$BASE_URL/analytics/experiment/routing_a1b2c3d4-1111-2222-3333-44445555666
 
 - `verdict` is one of `collecting_data`, `not_significant`, `variant_wins`, `variant_loses`, or `guardrail_breached`.
 - For an auth-only experiment (no cost data involved on either arm), the cost-related fields (`total_cost_saved`, `avg_cost_saved_bps`, `net_ev_bps`, `net_delta_bps`) are `null`.
-- Full field-by-field reference: [A/B Testing: Results](/api-refs/ab-testing-results).
+- Full field-by-field reference: [A/B Testing: Results](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-results.mdx).
 
 ## Related
 
-- [A/B Test Experiment Transactions](/api-reference/endpoint/analyticsExperimentTransactions)
-- [A/B Testing: Create An Experiment](/api-refs/ab-testing-create)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [A/B Test Experiment Transactions](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsExperimentTransactions.mdx)
+- [A/B Testing: Create An Experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsExperimentTransactions.mdx
+++ b/docs/api-reference/endpoint/analyticsExperimentTransactions.mdx
@@ -8,7 +8,7 @@ openapi: "openapi.json GET /analytics/experiment/{experiment_id}/transactions"
 
 ## Use case
 
-Returns a paginated per-transaction log for a routing [A/B test experiment](/api-refs/ab-testing-create) — which arm each payment landed in, the gateway chosen, and the outcome. Useful for spot-checking arm assignment or debugging a specific payment.
+Returns a paginated per-transaction log for a routing [A/B test experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx) — which arm each payment landed in, the gateway chosen, and the outcome. Useful for spot-checking arm assignment or debugging a specific payment.
 
 ## Authentication
 
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/experiment/{experiment_id}/transactions`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `experiment_id` (path, required, string) — the `rule_id` returned by `/routing/create` for the `ab_test` algorithm.
   - `start_ms` (query, optional, integer)
   - `page` (query, optional, integer) — defaults to `1`.
@@ -69,6 +69,6 @@ curl "$BASE_URL/analytics/experiment/routing_a1b2c3d4-1111-2222-3333-44445555666
 
 ## Related
 
-- [A/B Test Experiment Results](/api-reference/endpoint/analyticsExperimentResults)
-- [A/B Testing: Results](/api-refs/ab-testing-results)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [A/B Test Experiment Results](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsExperimentResults.mdx)
+- [A/B Testing: Results](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-results.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsGatewayScores.mdx
+++ b/docs/api-reference/endpoint/analyticsGatewayScores.mdx
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/gateway-scores`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -96,6 +96,6 @@ curl "$BASE_URL/analytics/gateway-scores?range=1d&gateway=stripe,adyen" \
 
 ## Related
 
-- [Update Gateway Score](/api-reference/endpoint/updateGatewayScore)
-- [Analytics Overview](/api-reference/endpoint/analyticsOverview)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Update Gateway Score](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateGatewayScore.mdx)
+- [Analytics Overview](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsOverview.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsLogSummaries.mdx
+++ b/docs/api-reference/endpoint/analyticsLogSummaries.mdx
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/log-summaries`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -92,6 +92,6 @@ curl "$BASE_URL/analytics/log-summaries?range=1d&status=failure" \
 
 ## Related
 
-- [Payment Audit](/api-reference/endpoint/analyticsPaymentAudit)
-- [Analytics Overview](/api-reference/endpoint/analyticsOverview)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsPaymentAudit.mdx)
+- [Analytics Overview](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsOverview.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsOverview.mdx
+++ b/docs/api-reference/endpoint/analyticsOverview.mdx
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/overview`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -88,6 +88,6 @@ curl "$BASE_URL/analytics/overview?range=1d" \
 
 ## Related
 
-- [Analytics Routing Stats](/api-reference/endpoint/analyticsRoutingStats)
-- [Payment Audit](/api-reference/endpoint/analyticsPaymentAudit)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Analytics Routing Stats](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsRoutingStats.mdx)
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsPaymentAudit.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsPaymentAudit.mdx
+++ b/docs/api-reference/endpoint/analyticsPaymentAudit.mdx
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/payment-audit`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -120,6 +120,6 @@ curl "$BASE_URL/analytics/payment-audit?range=1d&routing_approach=NTW_BASED_ROUT
 
 ## Related
 
-- [Preview Trace](/api-reference/endpoint/analyticsPreviewTrace)
-- [Analytics Log Summaries](/api-reference/endpoint/analyticsLogSummaries)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Preview Trace](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsPreviewTrace.mdx)
+- [Analytics Log Summaries](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsLogSummaries.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsPreviewTrace.mdx
+++ b/docs/api-reference/endpoint/analyticsPreviewTrace.mdx
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/preview-trace`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -103,6 +103,6 @@ curl "$BASE_URL/analytics/preview-trace?range=1d&payment_id=volume_decision_001"
 
 ## Related
 
-- [Evaluate Routing Rule](/api-reference/endpoint/evaluateRoutingRule)
-- [Payment Audit](/api-reference/endpoint/analyticsPaymentAudit)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Evaluate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/evaluateRoutingRule.mdx)
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsPaymentAudit.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsRoutingEvents.mdx
+++ b/docs/api-reference/endpoint/analyticsRoutingEvents.mdx
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/routing-events`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -79,10 +79,10 @@ curl "$BASE_URL/analytics/routing-events?range=1d&payment_method_type=CARD" \
 
 - Analytics reads are ClickHouse-backed and merchant-scoped by the authenticated context.
 - `event_type` is one of `leader_changed`, `gateway_entered_auth_band`, `gateway_exited_auth_band`, or `calibration_applied`.
-- `calibration_applied` events come from [Autopilot](/api-refs/merchant-features) re-tuning SR hedging/bucket size and carry `bucket_size`/`previous_bucket_size` instead of the score fields.
+- `calibration_applied` events come from [Autopilot](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx) re-tuning SR hedging/bucket size and carry `bucket_size`/`previous_bucket_size` instead of the score fields.
 
 ## Related
 
-- [Merchant Features](/api-refs/merchant-features)
-- [Multi-Objective Routing](/api-refs/decide-gateway-multi-objective)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Merchant Features](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx)
+- [Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/analyticsRoutingStats.mdx
+++ b/docs/api-reference/endpoint/analyticsRoutingStats.mdx
@@ -29,7 +29,7 @@ export TENANT_HEADER="x-tenant-id: public"
 
 - Method and path: `GET /analytics/routing-stats`
 - Parameters:
-  - `x-tenant-id` (header, required, string) — see [Environment setup](/api-refs/api-ref#environment-setup).
+  - `x-tenant-id` (header, required, string) — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
   - `range` (query, optional, string)
   - `start_ms` (query, optional, integer)
   - `end_ms` (query, optional, integer)
@@ -100,6 +100,6 @@ curl "$BASE_URL/analytics/routing-stats?range=1d&payment_method_type=CARD" \
 
 ## Related
 
-- [Analytics Decisions](/api-reference/endpoint/analyticsDecisions)
-- [Analytics Gateway Scores](/api-reference/endpoint/analyticsGatewayScores)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [Analytics Decisions](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsDecisions.mdx)
+- [Analytics Gateway Scores](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsGatewayScores.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-reference/endpoint/configSrDimension.mdx
+++ b/docs/api-reference/endpoint/configSrDimension.mdx
@@ -62,6 +62,6 @@ curl --location "$BASE_URL/config-sr-dimension" \
 
 ## Related
 
-- [Get Routing Config](/api-reference/endpoint/getRoutingConfig)
-- [Analytics Gateway Scores](/api-reference/endpoint/analyticsGatewayScores)
-- [Config Endpoints](/api-refs/config-endpoints)
+- [Get Routing Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getRoutingConfig.mdx)
+- [Analytics Gateway Scores](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsGatewayScores.mdx)
+- [Config Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/config-endpoints.mdx)

--- a/docs/api-reference/endpoint/createApiKey.mdx
+++ b/docs/api-reference/endpoint/createApiKey.mdx
@@ -62,6 +62,6 @@ curl --location "$BASE_URL/api-key/create" \
 
 ## Related
 
-- [List API Keys](/api-reference/endpoint/listApiKeys)
-- [Revoke API Key](/api-reference/endpoint/revokeApiKey)
-- [Decide Gateway](/api-reference/endpoint/decideGateway)
+- [List API Keys](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listApiKeys.mdx)
+- [Revoke API Key](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/revokeApiKey.mdx)
+- [Decide Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/decideGateway.mdx)

--- a/docs/api-reference/endpoint/createMerchant.mdx
+++ b/docs/api-reference/endpoint/createMerchant.mdx
@@ -61,6 +61,6 @@ curl --location "$BASE_URL/merchant-account/create" \
 
 ## Related
 
-- [Get Merchant](/api-reference/endpoint/getMerchant)
-- [Delete Merchant](/api-reference/endpoint/deleteMerchant)
-- [Update Merchant Debit Routing](/api-reference/endpoint/updateMerchantDebitRouting)
+- [Get Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getMerchant.mdx)
+- [Delete Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/deleteMerchant.mdx)
+- [Update Merchant Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateMerchantDebitRouting.mdx)

--- a/docs/api-reference/endpoint/createRoutingRule.mdx
+++ b/docs/api-reference/endpoint/createRoutingRule.mdx
@@ -258,7 +258,7 @@ Use `nested` when a parent condition must match first, and then one of multiple 
 }
 ```
 
-For more advanced rule examples, including `volume_split_priority`, `enum_variant_array`, `number_array`, and `number_comparison_array`, see [Advanced Routing Example](/api-refs/routing-advanced-example).
+For more advanced rule examples, including `volume_split_priority`, `enum_variant_array`, `number_array`, and `number_comparison_array`, see [Advanced Routing Example](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-advanced-example.mdx).
 
 ## Response
 
@@ -278,8 +278,8 @@ For more advanced rule examples, including `volume_split_priority`, `enum_varian
 
 ## Related
 
-- [Activate Routing Rule](/api-reference/endpoint/activateRoutingRule)
-- [Evaluate Routing Rule](/api-reference/endpoint/evaluateRoutingRule)
-- [Advanced Routing Example](/api-refs/routing-advanced-example)
-- [Priority Routing](/api-refs/routing-priority-example)
-- [Volume Split Routing](/api-refs/routing-volume-split-example)
+- [Activate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/activateRoutingRule.mdx)
+- [Evaluate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/evaluateRoutingRule.mdx)
+- [Advanced Routing Example](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-advanced-example.mdx)
+- [Priority Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-priority-example.mdx)
+- [Volume Split Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-volume-split-example.mdx)

--- a/docs/api-reference/endpoint/createRuleConfig.mdx
+++ b/docs/api-reference/endpoint/createRuleConfig.mdx
@@ -89,7 +89,7 @@ curl --location "$BASE_URL/rule/create" \
 
 ## Related
 
-- [Get Rule Config](/api-reference/endpoint/getRuleConfig)
-- [Update Rule Config](/api-reference/endpoint/updateRuleConfig)
-- [Create Success-Rate Config](/api-refs/success-rate-config-create)
-- [Create Elimination Config](/api-refs/elimination-config-create)
+- [Get Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getRuleConfig.mdx)
+- [Update Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateRuleConfig.mdx)
+- [Create Success-Rate Config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/success-rate-config-create.mdx)
+- [Create Elimination Config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/elimination-config-create.mdx)

--- a/docs/api-reference/endpoint/deactivateRoutingRule.mdx
+++ b/docs/api-reference/endpoint/deactivateRoutingRule.mdx
@@ -56,7 +56,7 @@ Success returns HTTP `200` with an empty response body.
 
 ## Related
 
-- [Create Routing Rule](/api-reference/endpoint/createRoutingRule)
-- [Activate Routing Rule](/api-reference/endpoint/activateRoutingRule)
-- [Get Active Routing Rule](/api-reference/endpoint/getActiveRoutingRule)
-- [Deactivate Routing Algorithm](/api-refs/routing-algorithm-deactivate)
+- [Create Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRoutingRule.mdx)
+- [Activate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/activateRoutingRule.mdx)
+- [Get Active Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getActiveRoutingRule.mdx)
+- [Deactivate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-deactivate.mdx)

--- a/docs/api-reference/endpoint/decideGateway.mdx
+++ b/docs/api-reference/endpoint/decideGateway.mdx
@@ -191,9 +191,9 @@ curl --location "$BASE_URL/decide-gateway" \
 
 ## Related
 
-- [Decide Gateway: SR Based Routing](/api-refs/decide-gateway-sr-based)
-- [Decide Gateway: PL Based Routing](/api-refs/decide-gateway-pl-based)
-- [Decide Gateway: Debit Routing](/api-refs/decide-gateway-debit-routing)
-- [Decide Gateway: Hybrid Routing](/api-refs/decide-gateway-hybrid-routing)
-- [Decide Gateway: Multi-Objective Routing](/api-refs/decide-gateway-multi-objective)
-- [Update Gateway Score](/api-reference/endpoint/updateGatewayScore)
+- [Decide Gateway: SR Based Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-sr-based.mdx)
+- [Decide Gateway: PL Based Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-pl-based.mdx)
+- [Decide Gateway: Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-debit-routing.mdx)
+- [Decide Gateway: Hybrid Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-hybrid-routing.mdx)
+- [Decide Gateway: Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx)
+- [Update Gateway Score](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateGatewayScore.mdx)

--- a/docs/api-reference/endpoint/deleteMerchant.mdx
+++ b/docs/api-reference/endpoint/deleteMerchant.mdx
@@ -57,5 +57,5 @@ curl --location "$BASE_URL/merchant-account/merchant_demo" \
 
 ## Related
 
-- [Create Merchant](/api-reference/endpoint/createMerchant)
-- [Get Merchant](/api-reference/endpoint/getMerchant)
+- [Create Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createMerchant.mdx)
+- [Get Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getMerchant.mdx)

--- a/docs/api-reference/endpoint/deleteRuleConfig.mdx
+++ b/docs/api-reference/endpoint/deleteRuleConfig.mdx
@@ -73,7 +73,7 @@ curl --location "$BASE_URL/rule/delete" \
 
 ## Related
 
-- [Create Rule Config](/api-reference/endpoint/createRuleConfig)
-- [Get Rule Config](/api-reference/endpoint/getRuleConfig)
-- [Delete Success-Rate Config](/api-refs/success-rate-config-delete)
-- [Delete Elimination Config](/api-refs/elimination-config-delete)
+- [Create Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRuleConfig.mdx)
+- [Get Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getRuleConfig.mdx)
+- [Delete Success-Rate Config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/success-rate-config-delete.mdx)
+- [Delete Elimination Config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/elimination-config-delete.mdx)

--- a/docs/api-reference/endpoint/evaluateRoutingRule.mdx
+++ b/docs/api-reference/endpoint/evaluateRoutingRule.mdx
@@ -75,6 +75,6 @@ curl --location "$BASE_URL/routing/evaluate" \
 
 ## Related
 
-- [Create Routing Rule](/api-reference/endpoint/createRoutingRule)
-- [Preview Trace](/api-reference/endpoint/analyticsPreviewTrace)
-- [Evaluate Routing Algorithm](/api-refs/routing-algorithm-evaluate)
+- [Create Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRoutingRule.mdx)
+- [Preview Trace](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsPreviewTrace.mdx)
+- [Evaluate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-evaluate.mdx)

--- a/docs/api-reference/endpoint/getActiveRoutingRule.mdx
+++ b/docs/api-reference/endpoint/getActiveRoutingRule.mdx
@@ -62,6 +62,6 @@ curl --location "$BASE_URL/routing/list/active/merchant_demo" \
 
 ## Related
 
-- [List Routing Rules](/api-reference/endpoint/listRoutingRules)
-- [Activate Routing Rule](/api-reference/endpoint/activateRoutingRule)
-- [List Active Routing Algorithms](/api-refs/routing-algorithm-list-active)
+- [List Routing Rules](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listRoutingRules.mdx)
+- [Activate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/activateRoutingRule.mdx)
+- [List Active Routing Algorithms](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-list-active.mdx)

--- a/docs/api-reference/endpoint/getMerchant.mdx
+++ b/docs/api-reference/endpoint/getMerchant.mdx
@@ -57,6 +57,6 @@ curl "$BASE_URL/merchant-account/merchant_demo" \
 
 ## Related
 
-- [Create Merchant](/api-reference/endpoint/createMerchant)
-- [Get Merchant Debit Routing](/api-reference/endpoint/getMerchantDebitRouting)
-- [List User Merchants](/api-reference/endpoint/listUserMerchants)
+- [Create Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createMerchant.mdx)
+- [Get Merchant Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getMerchantDebitRouting.mdx)
+- [List User Merchants](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listUserMerchants.mdx)

--- a/docs/api-reference/endpoint/getMerchantDebitRouting.mdx
+++ b/docs/api-reference/endpoint/getMerchantDebitRouting.mdx
@@ -56,6 +56,6 @@ curl "$BASE_URL/merchant-account/merchant_demo/debit-routing" \
 
 ## Related
 
-- [Update Merchant Debit Routing](/api-reference/endpoint/updateMerchantDebitRouting)
-- [Decide Gateway](/api-reference/endpoint/decideGateway)
-- [Merchant Debit Routing](/api-refs/merchant-debit-routing)
+- [Update Merchant Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateMerchantDebitRouting.mdx)
+- [Decide Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/decideGateway.mdx)
+- [Merchant Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-debit-routing.mdx)

--- a/docs/api-reference/endpoint/getRoutingConfig.mdx
+++ b/docs/api-reference/endpoint/getRoutingConfig.mdx
@@ -61,6 +61,6 @@ curl "$BASE_URL/config/routing-keys" \
 
 ## Related
 
-- [Configure SR Dimensions](/api-reference/endpoint/configSrDimension)
-- [Create Routing Rule](/api-reference/endpoint/createRoutingRule)
-- [Config Endpoints](/api-refs/config-endpoints)
+- [Configure SR Dimensions](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/configSrDimension.mdx)
+- [Create Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRoutingRule.mdx)
+- [Config Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/config-endpoints.mdx)

--- a/docs/api-reference/endpoint/getRuleConfig.mdx
+++ b/docs/api-reference/endpoint/getRuleConfig.mdx
@@ -78,7 +78,7 @@ curl --location "$BASE_URL/rule/get" \
 
 ## Related
 
-- [Create Rule Config](/api-reference/endpoint/createRuleConfig)
-- [Update Rule Config](/api-reference/endpoint/updateRuleConfig)
-- [Get Success-Rate Config](/api-refs/success-rate-config-get)
-- [Get Elimination Config](/api-refs/elimination-config-get)
+- [Create Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createRuleConfig.mdx)
+- [Update Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateRuleConfig.mdx)
+- [Get Success-Rate Config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/success-rate-config-get.mdx)
+- [Get Elimination Config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/elimination-config-get.mdx)

--- a/docs/api-reference/endpoint/healthCheck.mdx
+++ b/docs/api-reference/endpoint/healthCheck.mdx
@@ -54,5 +54,5 @@ curl "$BASE_URL/health"
 
 ## Related
 
-- [Health Ready](/api-reference/endpoint/healthReady)
-- [Health Diagnostics](/api-reference/endpoint/healthDiagnostics)
+- [Health Ready](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthReady.mdx)
+- [Health Diagnostics](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthDiagnostics.mdx)

--- a/docs/api-reference/endpoint/healthDiagnostics.mdx
+++ b/docs/api-reference/endpoint/healthDiagnostics.mdx
@@ -59,5 +59,5 @@ curl "$BASE_URL/health/diagnostics" \
 
 ## Related
 
-- [Health Check](/api-reference/endpoint/healthCheck)
-- [Health Ready](/api-reference/endpoint/healthReady)
+- [Health Check](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthCheck.mdx)
+- [Health Ready](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthReady.mdx)

--- a/docs/api-reference/endpoint/healthReady.mdx
+++ b/docs/api-reference/endpoint/healthReady.mdx
@@ -58,5 +58,5 @@ curl "$BASE_URL/health/ready"
 
 ## Related
 
-- [Health Check](/api-reference/endpoint/healthCheck)
-- [Health Diagnostics](/api-reference/endpoint/healthDiagnostics)
+- [Health Check](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthCheck.mdx)
+- [Health Diagnostics](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/healthDiagnostics.mdx)

--- a/docs/api-reference/endpoint/hybridRouting.mdx
+++ b/docs/api-reference/endpoint/hybridRouting.mdx
@@ -72,6 +72,6 @@ curl --location "$BASE_URL/routing/hybrid" \
 
 ## Related
 
-- [Evaluate Routing Rule](/api-reference/endpoint/evaluateRoutingRule)
-- [Decide Gateway](/api-reference/endpoint/decideGateway)
-- [Hybrid Routing](/api-refs/routing-hybrid)
+- [Evaluate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/evaluateRoutingRule.mdx)
+- [Decide Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/decideGateway.mdx)
+- [Hybrid Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-hybrid.mdx)

--- a/docs/api-reference/endpoint/legacyDecisionGateway.mdx
+++ b/docs/api-reference/endpoint/legacyDecisionGateway.mdx
@@ -77,5 +77,5 @@ curl --location "$BASE_URL/decision_gateway" \
 
 ## Related
 
-- [Decide Gateway](/api-reference/endpoint/decideGateway)
-- [Legacy Decision Gateway](/api-refs/decision-gateway-legacy)
+- [Decide Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/decideGateway.mdx)
+- [Legacy Decision Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decision-gateway-legacy.mdx)

--- a/docs/api-reference/endpoint/legacyUpdateScore.mdx
+++ b/docs/api-reference/endpoint/legacyUpdateScore.mdx
@@ -62,5 +62,5 @@ curl --location "$BASE_URL/update-score" \
 
 ## Related
 
-- [Update Gateway Score](/api-reference/endpoint/updateGatewayScore)
-- [Legacy Update Score](/api-refs/update-score-legacy)
+- [Update Gateway Score](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/updateGatewayScore.mdx)
+- [Legacy Update Score](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/update-score-legacy.mdx)

--- a/docs/api-reference/endpoint/listApiKeys.mdx
+++ b/docs/api-reference/endpoint/listApiKeys.mdx
@@ -62,5 +62,5 @@ curl "$BASE_URL/api-key/list/merchant_demo" \
 
 ## Related
 
-- [Create API Key](/api-reference/endpoint/createApiKey)
-- [Revoke API Key](/api-reference/endpoint/revokeApiKey)
+- [Create API Key](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createApiKey.mdx)
+- [Revoke API Key](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/revokeApiKey.mdx)

--- a/docs/api-reference/endpoint/listRoutingRules.mdx
+++ b/docs/api-reference/endpoint/listRoutingRules.mdx
@@ -64,6 +64,6 @@ curl --location "$BASE_URL/routing/list/merchant_demo" \
 
 ## Related
 
-- [Get Active Routing Rule](/api-reference/endpoint/getActiveRoutingRule)
-- [Activate Routing Rule](/api-reference/endpoint/activateRoutingRule)
-- [List Routing Algorithms](/api-refs/routing-algorithm-list)
+- [Get Active Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getActiveRoutingRule.mdx)
+- [Activate Routing Rule](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/activateRoutingRule.mdx)
+- [List Routing Algorithms](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-list.mdx)

--- a/docs/api-reference/endpoint/listUserMerchants.mdx
+++ b/docs/api-reference/endpoint/listUserMerchants.mdx
@@ -63,6 +63,6 @@ curl "$BASE_URL/auth/merchants" \
 
 ## Related
 
-- [Switch Merchant](/api-reference/endpoint/switchMerchant)
-- [Onboard Merchant](/api-reference/endpoint/onboardMerchant)
-- [Current User](/api-reference/endpoint/me)
+- [Switch Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/switchMerchant.mdx)
+- [Onboard Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/onboardMerchant.mdx)
+- [Current User](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/me.mdx)

--- a/docs/api-reference/endpoint/login.mdx
+++ b/docs/api-reference/endpoint/login.mdx
@@ -68,6 +68,6 @@ curl --location "$BASE_URL/auth/login" \
 
 ## Related
 
-- [Signup](/api-reference/endpoint/signup)
-- [Current User](/api-reference/endpoint/me)
-- [List User Merchants](/api-reference/endpoint/listUserMerchants)
+- [Signup](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/signup.mdx)
+- [Current User](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/me.mdx)
+- [List User Merchants](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listUserMerchants.mdx)

--- a/docs/api-reference/endpoint/logout.mdx
+++ b/docs/api-reference/endpoint/logout.mdx
@@ -56,5 +56,5 @@ curl --location "$BASE_URL/auth/logout" \
 
 ## Related
 
-- [Login](/api-reference/endpoint/login)
-- [Current User](/api-reference/endpoint/me)
+- [Login](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/login.mdx)
+- [Current User](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/me.mdx)

--- a/docs/api-reference/endpoint/me.mdx
+++ b/docs/api-reference/endpoint/me.mdx
@@ -57,6 +57,6 @@ curl "$BASE_URL/auth/me" \
 
 ## Related
 
-- [Login](/api-reference/endpoint/login)
-- [List User Merchants](/api-reference/endpoint/listUserMerchants)
-- [Switch Merchant](/api-reference/endpoint/switchMerchant)
+- [Login](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/login.mdx)
+- [List User Merchants](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listUserMerchants.mdx)
+- [Switch Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/switchMerchant.mdx)

--- a/docs/api-reference/endpoint/onboardMerchant.mdx
+++ b/docs/api-reference/endpoint/onboardMerchant.mdx
@@ -60,6 +60,6 @@ curl --location "$BASE_URL/onboarding/merchant" \
 
 ## Related
 
-- [Switch Merchant](/api-reference/endpoint/switchMerchant)
-- [Create Merchant](/api-reference/endpoint/createMerchant)
-- [Get Merchant](/api-reference/endpoint/getMerchant)
+- [Switch Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/switchMerchant.mdx)
+- [Create Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createMerchant.mdx)
+- [Get Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getMerchant.mdx)

--- a/docs/api-reference/endpoint/revokeApiKey.mdx
+++ b/docs/api-reference/endpoint/revokeApiKey.mdx
@@ -57,5 +57,5 @@ curl --location "$BASE_URL/api-key/key_123" \
 
 ## Related
 
-- [Create API Key](/api-reference/endpoint/createApiKey)
-- [List API Keys](/api-reference/endpoint/listApiKeys)
+- [Create API Key](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createApiKey.mdx)
+- [List API Keys](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listApiKeys.mdx)

--- a/docs/api-reference/endpoint/signup.mdx
+++ b/docs/api-reference/endpoint/signup.mdx
@@ -69,6 +69,6 @@ curl --location "$BASE_URL/auth/signup" \
 
 ## Related
 
-- [Login](/api-reference/endpoint/login)
-- [Onboard Merchant](/api-reference/endpoint/onboardMerchant)
-- [Create Merchant](/api-reference/endpoint/createMerchant)
+- [Login](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/login.mdx)
+- [Onboard Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/onboardMerchant.mdx)
+- [Create Merchant](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/createMerchant.mdx)

--- a/docs/api-reference/endpoint/switchMerchant.mdx
+++ b/docs/api-reference/endpoint/switchMerchant.mdx
@@ -60,6 +60,6 @@ curl --location "$BASE_URL/auth/switch-merchant" \
 
 ## Related
 
-- [List User Merchants](/api-reference/endpoint/listUserMerchants)
-- [Current User](/api-reference/endpoint/me)
-- [Analytics Overview](/api-reference/endpoint/analyticsOverview)
+- [List User Merchants](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/listUserMerchants.mdx)
+- [Current User](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/me.mdx)
+- [Analytics Overview](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsOverview.mdx)

--- a/docs/api-reference/endpoint/updateGatewayScore.mdx
+++ b/docs/api-reference/endpoint/updateGatewayScore.mdx
@@ -68,6 +68,6 @@ curl --location "$BASE_URL/update-gateway-score" \
 
 ## Related
 
-- [Decide Gateway](/api-reference/endpoint/decideGateway)
-- [Analytics Gateway Scores](/api-reference/endpoint/analyticsGatewayScores)
-- [Update Gateway Score](/api-refs/update-gateway-score)
+- [Decide Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/decideGateway.mdx)
+- [Analytics Gateway Scores](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/analyticsGatewayScores.mdx)
+- [Update Gateway Score](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/update-gateway-score.mdx)

--- a/docs/api-reference/endpoint/updateMerchantDebitRouting.mdx
+++ b/docs/api-reference/endpoint/updateMerchantDebitRouting.mdx
@@ -71,6 +71,6 @@ curl --location "$BASE_URL/merchant-account/merchant_demo/debit-routing" \
 
 ## Related
 
-- [Get Merchant Debit Routing](/api-reference/endpoint/getMerchantDebitRouting)
-- [Decide Gateway](/api-reference/endpoint/decideGateway)
-- [Decide Gateway: Debit Routing](/api-refs/decide-gateway-debit-routing)
+- [Get Merchant Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getMerchantDebitRouting.mdx)
+- [Decide Gateway](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/decideGateway.mdx)
+- [Decide Gateway: Debit Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-debit-routing.mdx)

--- a/docs/api-reference/endpoint/updateRuleConfig.mdx
+++ b/docs/api-reference/endpoint/updateRuleConfig.mdx
@@ -89,7 +89,7 @@ curl --location "$BASE_URL/rule/update" \
 
 ## Related
 
-- [Get Rule Config](/api-reference/endpoint/getRuleConfig)
-- [Delete Rule Config](/api-reference/endpoint/deleteRuleConfig)
-- [Update Success-Rate Config](/api-refs/success-rate-config-update)
-- [Update Elimination Config](/api-refs/elimination-config-update)
+- [Get Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/getRuleConfig.mdx)
+- [Delete Rule Config](https://github.com/juspay/decision-engine/blob/main/docs/api-reference/endpoint/deleteRuleConfig.mdx)
+- [Update Success-Rate Config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/success-rate-config-update.mdx)
+- [Update Elimination Config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/elimination-config-update.mdx)

--- a/docs/api-refs/ab-testing-create.mdx
+++ b/docs/api-refs/ab-testing-create.mdx
@@ -5,7 +5,7 @@ description: "Curl examples for creating and activating a routing A/B test via /
 
 # A/B Testing: Create An Experiment
 
-A/B testing lets you compare two routing strategies — or two configurations of the same strategy — on a live split of traffic, with built-in guardrails and statistical significance checks. There is no separate create/manage API: an experiment is just another `algorithm.type` on the existing [`/routing/create`](/api-refs/routing-algorithm-create) endpoint, alongside `single`, `priority`, `volume_split`, and `advanced`.
+A/B testing lets you compare two routing strategies — or two configurations of the same strategy — on a live split of traffic, with built-in guardrails and statistical significance checks. There is no separate create/manage API: an experiment is just another `algorithm.type` on the existing [`/routing/create`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx) endpoint, alongside `single`, `priority`, `volume_split`, and `advanced`.
 
 ## algorithm.type = "ab_test"
 
@@ -69,7 +69,7 @@ Response is the standard routing-algorithm create response:
 }
 ```
 
-All fields are optional — set only the ones you want to override for that arm; anything omitted falls back to the merchant's live SR config. `enable_multi_objective` and `use_autopilot` are the same dials used by [multi-objective routing](/api-refs/decide-gateway-multi-objective) and [autopilot](/api-refs/merchant-features), scoped to just this arm.
+All fields are optional — set only the ones you want to override for that arm; anything omitted falls back to the merchant's live SR config. `enable_multi_objective` and `use_autopilot` are the same dials used by [multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx) and [autopilot](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx), scoped to just this arm.
 
 ## Common Experiment Shapes
 
@@ -104,18 +104,18 @@ Arm assignment is deterministic per payment: `payment_id` is hashed and taken mo
 
 Two integration points use this assignment:
 
-- **Real payments** — `/decide-gateway` / `/decision_gateway` route into the assigned arm. This only happens when the merchant feature `ab-test-real-payments` is enabled — see [Merchant Features](/api-refs/merchant-features). Off by default so a newly created experiment doesn't affect live traffic until you opt in.
-- **Simulation / Decision Explorer** — [`/routing/evaluate`](/api-refs/routing-algorithm-evaluate) previews what each arm would do for a given payment context, without a real transaction.
+- **Real payments** — `/decide-gateway` / `/decision_gateway` route into the assigned arm. This only happens when the merchant feature `ab-test-real-payments` is enabled — see [Merchant Features](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx). Off by default so a newly created experiment doesn't affect live traffic until you opt in.
+- **Simulation / Decision Explorer** — [`/routing/evaluate`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-evaluate.mdx) previews what each arm would do for a given payment context, without a real transaction.
 
 If an arm's algorithm id resolves to `sr_routing`, the payment proceeds through normal SR routing carrying that arm's `SrConfigOverride`. If it resolves to another algorithm's id, that algorithm's output is used directly and the response's `routing_approach` becomes `AB_TEST_STATIC_ALGORITHM`.
 
 ## Editing Or Removing An Experiment
 
-Only an **inactive** experiment can be edited or deleted — see [Update & Delete Routing Algorithm](/api-refs/routing-algorithm-update-delete). Deactivate first with [`/routing/deactivate`](/api-refs/routing-algorithm-deactivate) if it's currently live.
+Only an **inactive** experiment can be edited or deleted — see [Update & Delete Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-update-delete.mdx). Deactivate first with [`/routing/deactivate`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-deactivate.mdx) if it's currently live.
 
 ## Related
 
-- [A/B Testing: Results](/api-refs/ab-testing-results)
-- [Merchant Features](/api-refs/merchant-features) — enabling `ab-test-real-payments` and autopilot.
-- [Multi-Objective Routing](/api-refs/decide-gateway-multi-objective)
-- [Create Routing Algorithm](/api-refs/routing-algorithm-create)
+- [A/B Testing: Results](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-results.mdx)
+- [Merchant Features](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx) — enabling `ab-test-real-payments` and autopilot.
+- [Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx)
+- [Create Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx)

--- a/docs/api-refs/ab-testing-results.mdx
+++ b/docs/api-refs/ab-testing-results.mdx
@@ -5,7 +5,7 @@ description: "Curl examples for reading A/B test results, transaction logs, and 
 
 # A/B Testing: Results
 
-Once an experiment (see [Create An Experiment](/api-refs/ab-testing-create)) is active and taking traffic, use these endpoints to monitor it. Both routes below live under `/analytics/` and require `$TENANT_HEADER` in addition to `$AUTH_HEADER` — see [Environment setup](/api-refs/api-ref#environment-setup).
+Once an experiment (see [Create An Experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx)) is active and taking traffic, use these endpoints to monitor it. Both routes below live under `/analytics/` and require `$TENANT_HEADER` in addition to `$AUTH_HEADER` — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
 
 ## Experiment Results
 
@@ -110,10 +110,10 @@ curl --location "$BASE_URL/merchant-account/merchant_demo/features/ab-test-real-
   --data '{ "enabled": true }'
 ```
 
-See [Merchant Features](/api-refs/merchant-features) for the full feature-flag reference. Until this is enabled, `/routing/evaluate` still previews both arms for simulation purposes even though `/decide-gateway` traffic is unaffected.
+See [Merchant Features](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx) for the full feature-flag reference. Until this is enabled, `/routing/evaluate` still previews both arms for simulation purposes even though `/decide-gateway` traffic is unaffected.
 
 ## Related
 
-- [A/B Testing: Create An Experiment](/api-refs/ab-testing-create)
-- [Merchant Features](/api-refs/merchant-features)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [A/B Testing: Create An Experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx)
+- [Merchant Features](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-refs/analytics-endpoints.mdx
+++ b/docs/api-refs/analytics-endpoints.mdx
@@ -7,7 +7,7 @@ description: "Curl examples for ClickHouse-backed analytics, charts, payment aud
 
 Analytics routes derive the merchant from the authenticated user/API key context and read from the analytics store. Use these endpoints for dashboard charts, payment audit, rule/volume decision inspection, and debit-routing audit.
 
-Every route on this page also requires `x-tenant-id` (`$TENANT_HEADER` — see [Environment setup](/api-refs/api-ref#environment-setup)) in addition to `$AUTH_HEADER`. It has no fallback: omitting it fails with `TE_03: x-tenant-id not found in headers` even with a valid API key or JWT. This is the one header group most other Decision Engine routes (`/decide-gateway`, `/routing/*`, `/merchant-account/*`, etc.) don't need.
+Every route on this page also requires `x-tenant-id` (`$TENANT_HEADER` — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup)) in addition to `$AUTH_HEADER`. It has no fallback: omitting it fails with `TE_03: x-tenant-id not found in headers` even with a valid API key or JWT. This is the one header group most other Decision Engine routes (`/decide-gateway`, `/routing/*`, `/merchant-account/*`, etc.) don't need.
 
 Common query parameters:
 
@@ -165,7 +165,7 @@ curl "$BASE_URL/analytics/payment-audit?range=1d&routing_approach=NTW_BASED_ROUT
 
 ## Cost Savings
 
-Rollup of savings attributed to [multi-objective routing](/api-refs/decide-gateway-multi-objective) — how much cheaper the chosen gateway was versus the plain SR head, trended over the window.
+Rollup of savings attributed to [multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx) — how much cheaper the chosen gateway was versus the plain SR head, trended over the window.
 
 ```bash
 curl "$BASE_URL/analytics/cost-savings?range=1w&currency=USD" \
@@ -228,11 +228,11 @@ curl "$BASE_URL/analytics/routing-events?range=1d&payment_method_type=CARD" \
 }
 ```
 
-`event_type` is one of `leader_changed`, `gateway_entered_auth_band`, `gateway_exited_auth_band`, or `calibration_applied` (an autopilot re-tune — see [Merchant Features](/api-refs/merchant-features)). Auth-band events only fire when multi-objective routing is enabled for the merchant. Additional filters: `min_transaction_count`, `min_score_delta`, `tolerance_pp` (auth-band width override), `limit`.
+`event_type` is one of `leader_changed`, `gateway_entered_auth_band`, `gateway_exited_auth_band`, or `calibration_applied` (an autopilot re-tune — see [Merchant Features](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx)). Auth-band events only fire when multi-objective routing is enabled for the merchant. Additional filters: `min_transaction_count`, `min_score_delta`, `tolerance_pp` (auth-band width override), `limit`.
 
 ## A/B Test Experiment Results
 
-Statistical significance results and the per-transaction log for a routing A/B test. Full reference, including the verdict enum and guardrail behavior: [A/B Testing: Results](/api-refs/ab-testing-results).
+Statistical significance results and the per-transaction log for a routing A/B test. Full reference, including the verdict enum and guardrail behavior: [A/B Testing: Results](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-results.mdx).
 
 ```bash
 curl "$BASE_URL/analytics/experiment/routing_a1b2c3d4-1111-2222-3333-444455556666/results" \

--- a/docs/api-refs/api-ref.mdx
+++ b/docs/api-refs/api-ref.mdx
@@ -7,7 +7,7 @@ description: "A practical, copy-paste guide to the Decision Engine API — from 
 
 This guide walks the Decision Engine API in the order you'll actually use it: set up a merchant, configure how transactions should be routed, send transactions to `/decide-gateway`, feed outcomes back, and review analytics.
 
-Every page below includes ready-to-run `curl` examples with realistic payloads. For exact request and response schemas plus an interactive playground, use the [OpenAPI Reference](/api-reference).
+Every page below includes ready-to-run `curl` examples with realistic payloads. For exact request and response schemas plus an interactive playground, use the [OpenAPI Reference](https://github.com/juspay/decision-engine/blob/main/docs/api-reference.md).
 
 <Note>
   **Two reference surfaces are available.** Start here for task-oriented flows; switch to the OpenAPI Reference when you need exact schemas.
@@ -15,7 +15,7 @@ Every page below includes ready-to-run `curl` examples with realistic payloads. 
   | Surface | Best for |
   | --- | --- |
   | **API Guide** (this section) | Copy-paste `curl` examples, end-to-end flows, and request variants. |
-  | **[OpenAPI Reference](/api-reference)** | One page per endpoint with full schemas and a request playground. |
+  | **[OpenAPI Reference](https://github.com/juspay/decision-engine/blob/main/docs/api-reference.md)** | One page per endpoint with full schemas and a request playground. |
 </Note>
 
 ## Integration flow
@@ -25,27 +25,27 @@ A typical integration follows these steps. Each links to the page with the exact
 <Steps>
   <Step title="Create a merchant">
     Create the merchant record that owns your routing config, API keys, and analytics.
-    See [Create Merchant Account](/api-refs/merchant-account-create).
+    See [Create Merchant Account](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-account-create.mdx).
   </Step>
   <Step title="Create an API key">
     Issue a server-to-server API key to authenticate the calls that follow.
-    See [API Keys](/api-refs/api-keys).
+    See [API Keys](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-keys.mdx).
   </Step>
   <Step title="Configure routing">
     Decide how connectors are chosen — a fixed connector, a priority list, a volume split, or an advanced rule tree — then activate it.
-    See [Create Routing Algorithm](/api-refs/routing-algorithm-create).
+    See [Create Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx).
   </Step>
   <Step title="Run transactions">
     Call `/decide-gateway` for each payment to get the connector to use.
-    See [Run Transactions](/api-refs/decide-gateway-sr-based).
+    See [Run Transactions](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-sr-based.mdx).
   </Step>
   <Step title="Send feedback">
     Report the authorization outcome so scoring and analytics stay accurate.
-    See [Update Gateway Score](/api-refs/update-gateway-score).
+    See [Update Gateway Score](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/update-gateway-score.mdx).
   </Step>
   <Step title="Review analytics">
     Inspect gateway scores, decisions, and audit trails.
-    See [Analytics & Audit](/api-refs/analytics-endpoints).
+    See [Analytics & Audit](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx).
   </Step>
 </Steps>
 
@@ -100,40 +100,40 @@ curl "$BASE_URL/analytics/overview?range=1d" \
 ## Browse by task
 
 <CardGroup cols={2}>
-  <Card title="Health & Status" icon="heart-pulse" href="/api-refs/health-check">
+  <Card title="Health & Status" icon="heart-pulse" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/health-check.mdx">
     Liveness, readiness, and dependency diagnostics.
   </Card>
-  <Card title="Authentication & Onboarding" icon="key" href="/api-refs/auth-and-onboarding">
+  <Card title="Authentication & Onboarding" icon="key" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/auth-and-onboarding.mdx">
     Sign up, log in, switch merchants, and manage API keys.
   </Card>
-  <Card title="Merchant Accounts" icon="building" href="/api-refs/merchant-account-create">
+  <Card title="Merchant Accounts" icon="building" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-account-create.mdx">
     Create, read, delete a merchant, and manage debit routing.
   </Card>
-  <Card title="Configure Routing" icon="route" href="/api-refs/routing-algorithm-create">
+  <Card title="Configure Routing" icon="route" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx">
     Single, priority, volume-split, and advanced rule trees — plus activation.
   </Card>
-  <Card title="Scoring Configuration" icon="sliders" href="/api-refs/success-rate-config-create">
+  <Card title="Scoring Configuration" icon="sliders" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/success-rate-config-create.mdx">
     Success-rate and elimination (downtime) scoring config.
   </Card>
-  <Card title="Run Transactions" icon="bolt" href="/api-refs/decide-gateway-sr-based">
+  <Card title="Run Transactions" icon="bolt" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-sr-based.mdx">
     Choose a connector per payment via `/decide-gateway`.
   </Card>
-  <Card title="Feedback & Scoring" icon="arrow-rotate-left" href="/api-refs/update-gateway-score">
+  <Card title="Feedback & Scoring" icon="arrow-rotate-left" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/update-gateway-score.mdx">
     Report authorization outcomes to keep scoring accurate.
   </Card>
-  <Card title="Analytics & Audit" icon="chart-line" href="/api-refs/analytics-endpoints">
+  <Card title="Analytics & Audit" icon="chart-line" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx">
     Overview, gateway scores, decisions, routing stats, and audit.
   </Card>
-  <Card title="Multi-Objective Routing" icon="scale-balanced" href="/api-refs/decide-gateway-multi-objective">
+  <Card title="Multi-Objective Routing" icon="scale-balanced" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx">
     Cost-aware post-step that re-ranks gateways on expected value.
   </Card>
-  <Card title="Cost Data Ingestion" icon="file-invoice-dollar" href="/api-refs/cost-ingestion-setup">
+  <Card title="Cost Data Ingestion" icon="file-invoice-dollar" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx">
     Learn real per-gateway fees from settlement reports and invoices.
   </Card>
-  <Card title="A/B Testing" icon="flask" href="/api-refs/ab-testing-create">
+  <Card title="A/B Testing" icon="flask" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx">
     Compare two routing strategies on live traffic with guardrails.
   </Card>
-  <Card title="Autopilot & Feature Flags" icon="sliders" href="/api-refs/merchant-features">
+  <Card title="Autopilot & Feature Flags" icon="sliders" href="https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx">
     Self-tuning SR scoring, plus every merchant-level toggle.
   </Card>
 </CardGroup>
@@ -144,13 +144,13 @@ curl "$BASE_URL/analytics/overview?range=1d" \
 
 | Strategy | Request value | Guide |
 | --- | --- | --- |
-| Success-rate (auth-rate) based | `SR_BASED_ROUTING` | [SR-based routing](/api-refs/decide-gateway-sr-based) |
-| Priority-list based | `PL_BASED_ROUTING` | [Priority-list routing](/api-refs/decide-gateway-pl-based) |
-| Debit / network based | `NTW_BASED_ROUTING` | [Debit routing](/api-refs/decide-gateway-debit-routing) |
-| Network + SR hybrid | `NTW_SR_HYBRID_ROUTING` | [Hybrid routing](/api-refs/decide-gateway-hybrid-routing) |
+| Success-rate (auth-rate) based | `SR_BASED_ROUTING` | [SR-based routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-sr-based.mdx) |
+| Priority-list based | `PL_BASED_ROUTING` | [Priority-list routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-pl-based.mdx) |
+| Debit / network based | `NTW_BASED_ROUTING` | [Debit routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-debit-routing.mdx) |
+| Network + SR hybrid | `NTW_SR_HYBRID_ROUTING` | [Hybrid routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-hybrid-routing.mdx) |
 
 <Info>
-  **Multi-objective (cost-aware) routing** is not a `rankingAlgorithm` value. It is a post-step on success-rate scoring, toggled per request with `enableMultiObjective` or per merchant with the `multi_objective_routing_enabled` feature flag. When active, responses carry a `multi_objective_info` block. See [Multi-objective routing](/api-refs/decide-gateway-multi-objective).
+  **Multi-objective (cost-aware) routing** is not a `rankingAlgorithm` value. It is a post-step on success-rate scoring, toggled per request with `enableMultiObjective` or per merchant with the `multi_objective_routing_enabled` feature flag. When active, responses carry a `multi_objective_info` block. See [Multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx).
 </Info>
 
 ## Advanced capabilities
@@ -159,14 +159,14 @@ Beyond the core decide/feedback loop, Decision Engine ships several self-contain
 
 | Capability | What it does | Start here |
 | --- | --- | --- |
-| Cost data ingestion | Learns each connector's actual fee (from settlement reports and invoices) at a per-cluster level, feeding multi-objective routing's expected-value ranking. | [Connector setup](/api-refs/cost-ingestion-setup) → [uploads](/api-refs/cost-ingestion-uploads) → [fees & coverage](/api-refs/cost-ingestion-fees) |
-| A/B testing | Splits traffic between a control and variant routing strategy — auth vs. cost-aware, manual vs. autopilot, or any two saved algorithms — with a guardrail and significance testing. | [Create an experiment](/api-refs/ab-testing-create) → [read results](/api-refs/ab-testing-results) |
-| Simulation | Preview what any routing algorithm (including an A/B test arm) would decide for a given payment context, without a real transaction. | [Evaluate Routing Algorithm](/api-refs/routing-algorithm-evaluate) |
-| Autopilot & auto-calibration | Background job that self-tunes SR hedging % and bucket size from observed traffic, with a hard-reset endpoint for simulation runs. | [Merchant Features](/api-refs/merchant-features) |
+| Cost data ingestion | Learns each connector's actual fee (from settlement reports and invoices) at a per-cluster level, feeding multi-objective routing's expected-value ranking. | [Connector setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx) → [uploads](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-uploads.mdx) → [fees & coverage](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-fees.mdx) |
+| A/B testing | Splits traffic between a control and variant routing strategy — auth vs. cost-aware, manual vs. autopilot, or any two saved algorithms — with a guardrail and significance testing. | [Create an experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx) → [read results](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-results.mdx) |
+| Simulation | Preview what any routing algorithm (including an A/B test arm) would decide for a given payment context, without a real transaction. | [Evaluate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-evaluate.mdx) |
+| Autopilot & auto-calibration | Background job that self-tunes SR hedging % and bucket size from observed traffic, with a hard-reset endpoint for simulation runs. | [Merchant Features](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx) |
 
 ## Backward compatibility
 
 Legacy routes are kept for older integrations. New integrations should use `/decide-gateway` and `/update-gateway-score`.
 
-- [Legacy decision endpoint](/api-refs/decision-gateway-legacy) — the older `/decision_gateway` route.
-- [Legacy update score](/api-refs/update-score-legacy) — the older `/update-score` route.
+- [Legacy decision endpoint](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decision-gateway-legacy.mdx) — the older `/decision_gateway` route.
+- [Legacy update score](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/update-score-legacy.mdx) — the older `/update-score` route.

--- a/docs/api-refs/config-endpoints.mdx
+++ b/docs/api-refs/config-endpoints.mdx
@@ -49,7 +49,7 @@ Returns an empty default (`fields: null`) when nothing has been configured for t
 
 ## GSM Options
 
-Gateway Status Mapper rule catalog — the error-code classification options used by the `gsm-scoring-filter` merchant feature (see [Merchant Features](/api-refs/merchant-features)).
+Gateway Status Mapper rule catalog — the error-code classification options used by the `gsm-scoring-filter` merchant feature (see [Merchant Features](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx)).
 
 ```bash
 curl "$BASE_URL/gsm/options" \

--- a/docs/api-refs/cost-ingestion-fees.mdx
+++ b/docs/api-refs/cost-ingestion-fees.mdx
@@ -5,7 +5,7 @@ description: "Curl examples for reading fitted connector fees, setting manual ov
 
 # Cost Ingestion: Fees & Coverage
 
-Once settlement data has been ingested (see [Connector Setup](/api-refs/cost-ingestion-setup) and [Uploads](/api-refs/cost-ingestion-uploads)), Decision Engine fits a per-cluster cost model — the input to [multi-objective routing](/api-refs/decide-gateway-multi-objective)'s expected-value ranking. These endpoints read that model and let you override it manually.
+Once settlement data has been ingested (see [Connector Setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx) and [Uploads](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-uploads.mdx)), Decision Engine fits a per-cluster cost model — the input to [multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx)'s expected-value ranking. These endpoints read that model and let you override it manually.
 
 Overrides take priority in this order: **cluster override** → **connector override** → **learned model**.
 
@@ -160,7 +160,7 @@ curl "$BASE_URL/merchant-account/merchant_demo/cost-coverage" \
 
 ## Related
 
-- [Cost Ingestion: Connector Setup](/api-refs/cost-ingestion-setup)
-- [Cost Ingestion: Uploads](/api-refs/cost-ingestion-uploads)
-- [Multi-Objective Routing](/api-refs/decide-gateway-multi-objective)
-- [Analytics Endpoints](/api-refs/analytics-endpoints) — see Cost Savings for the merchant-facing rollup.
+- [Cost Ingestion: Connector Setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx)
+- [Cost Ingestion: Uploads](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-uploads.mdx)
+- [Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx) — see Cost Savings for the merchant-facing rollup.

--- a/docs/api-refs/cost-ingestion-setup.mdx
+++ b/docs/api-refs/cost-ingestion-setup.mdx
@@ -5,7 +5,7 @@ description: "Curl examples for registering connector settlement credentials and
 
 # Cost Ingestion: Connector Setup
 
-Cost ingestion learns each connector's *actual* per-transaction fee (percentage + flat component) from real settlement reports and invoices, at a fine-grained cluster level (connector × card network × card variant × funding × issuer country × currency × interchange category). That fitted cost model is what [multi-objective routing](/api-refs/decide-gateway-multi-objective) ranks gateways on.
+Cost ingestion learns each connector's *actual* per-transaction fee (percentage + flat component) from real settlement reports and invoices, at a fine-grained cluster level (connector × card network × card variant × funding × issuer country × currency × interchange category). That fitted cost model is what [multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx) ranks gateways on.
 
 Before any report or invoice can be ingested, register the connector account's settlement credentials.
 
@@ -17,7 +17,7 @@ Settlement data reaches Decision Engine through three paths, all feeding the sam
 | --- | --- | --- |
 | Webhook push | The connector calls Decision Engine when a report is ready. Verified via the stored `webhook_secret`, then queued. | This page |
 | Scheduled poll | A background job polls the connector's reporting API for ready reports. No merchant action needed once credentials are set. | This page |
-| Manual upload | Upload a report or invoice file directly — useful before webhooks are wired, for backfills, or testing. | [Uploads](/api-refs/cost-ingestion-uploads) |
+| Manual upload | Upload a report or invoice file directly — useful before webhooks are wired, for backfills, or testing. | [Uploads](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-uploads.mdx) |
 
 ## Register Connector Credentials
 
@@ -97,11 +97,11 @@ The handler ACKs immediately and enqueues the report for background processing �
 
 ## Notes
 
-- Manual and webhook/poll-based ingestions share the same pipeline and history — see [Uploads](/api-refs/cost-ingestion-uploads) for the manual path and ingestion history.
-- Once enough settlement data has been fitted, check [Cost Coverage](/api-refs/cost-ingestion-fees#cost-coverage) to see what share of volume has a trustworthy cost model.
+- Manual and webhook/poll-based ingestions share the same pipeline and history — see [Uploads](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-uploads.mdx) for the manual path and ingestion history.
+- Once enough settlement data has been fitted, check [Cost Coverage](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-fees.mdx#cost-coverage) to see what share of volume has a trustworthy cost model.
 
 ## Related
 
-- [Cost Ingestion: Uploads](/api-refs/cost-ingestion-uploads)
-- [Cost Ingestion: Fees & Coverage](/api-refs/cost-ingestion-fees)
-- [Multi-Objective Routing](/api-refs/decide-gateway-multi-objective)
+- [Cost Ingestion: Uploads](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-uploads.mdx)
+- [Cost Ingestion: Fees & Coverage](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-fees.mdx)
+- [Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx)

--- a/docs/api-refs/cost-ingestion-uploads.mdx
+++ b/docs/api-refs/cost-ingestion-uploads.mdx
@@ -5,7 +5,7 @@ description: "Curl examples for manually uploading settlement reports and invoic
 
 # Cost Ingestion: Uploads
 
-Use manual upload when webhooks aren't wired yet, for backfilling historical data, or for testing. Manual uploads share the same `cost_ingestion` pipeline and history as webhook- and poll-based ingestion (see [Connector Setup](/api-refs/cost-ingestion-setup)).
+Use manual upload when webhooks aren't wired yet, for backfilling historical data, or for testing. Manual uploads share the same `cost_ingestion` pipeline and history as webhook- and poll-based ingestion (see [Connector Setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx)).
 
 ## Upload A Settlement Report
 
@@ -161,5 +161,5 @@ curl "$BASE_URL/merchant-account/merchant_demo/invoice-reconciliation" \
 
 ## Related
 
-- [Cost Ingestion: Connector Setup](/api-refs/cost-ingestion-setup)
-- [Cost Ingestion: Fees & Coverage](/api-refs/cost-ingestion-fees)
+- [Cost Ingestion: Connector Setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx)
+- [Cost Ingestion: Fees & Coverage](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-fees.mdx)

--- a/docs/api-refs/decide-gateway-debit-routing.mdx
+++ b/docs/api-refs/decide-gateway-debit-routing.mdx
@@ -67,4 +67,4 @@ curl --location "$BASE_URL/decide-gateway" \
 
 ## Multi-Objective Option
 
-When multi-objective routing is enabled (request field `enableMultiObjective`, or the `multi_objective_routing_enabled` merchant feature flag), a cost-aware post-step may re-rank the SR result and the response gains a `multi_objective_info` block. Details and examples: [Multi-objective routing](/api-refs/decide-gateway-multi-objective).
+When multi-objective routing is enabled (request field `enableMultiObjective`, or the `multi_objective_routing_enabled` merchant feature flag), a cost-aware post-step may re-rank the SR result and the response gains a `multi_objective_info` block. Details and examples: [Multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx).

--- a/docs/api-refs/decide-gateway-hybrid-routing.mdx
+++ b/docs/api-refs/decide-gateway-hybrid-routing.mdx
@@ -50,4 +50,4 @@ curl --location "$BASE_URL/decide-gateway" \
 
 ## Multi-Objective Option
 
-When multi-objective routing is enabled (request field `enableMultiObjective`, or the `multi_objective_routing_enabled` merchant feature flag), a cost-aware post-step may re-rank the SR result and the response gains a `multi_objective_info` block. Details and examples: [Multi-objective routing](/api-refs/decide-gateway-multi-objective).
+When multi-objective routing is enabled (request field `enableMultiObjective`, or the `multi_objective_routing_enabled` merchant feature flag), a cost-aware post-step may re-rank the SR result and the response gains a `multi_objective_info` block. Details and examples: [Multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx).

--- a/docs/api-refs/decide-gateway-multi-objective.mdx
+++ b/docs/api-refs/decide-gateway-multi-objective.mdx
@@ -12,7 +12,7 @@ Economic value (EV) = auth rate × settlement value
 settlement value = txn amount − cost of payment processing (acquirer, issuer & network fee)
 ```
 
-The settlement value is derived from the merchant's `margin` and the per-PSP cost estimate (see the `margin` field on [Create success-rate config](/api-refs/success-rate-config-create)).
+The settlement value is derived from the merchant's `margin` and the per-PSP cost estimate (see the `margin` field on [Create success-rate config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/success-rate-config-create.mdx)).
 
 If a cheaper PSP has a strictly higher expected value than the SR head, it is promoted (`outcome: COST_WON`) and `routing_approach` becomes `SR_SELECTION_MULTI_OBJECTIVE`. Otherwise the SR head is kept (`outcome: AUTH_WON`) and `routing_approach` keeps its normal SR value. Either way, the response carries a `multi_objective_info` block explaining the decision.
 
@@ -26,11 +26,11 @@ If a cheaper PSP has a strictly higher expected value than the SR head, it is pr
 Notes:
 
 - The post-step only runs on SR-scored decisions and is skipped while hedging (exploration) is active for the transaction.
-- `margin` (fraction of ticket, e.g. `0.20`) comes from the merchant's success-rate config — see [Create success-rate config](/api-refs/success-rate-config-create). It defaults to `1.0` when unset.
-- This post-step re-ranks the SR scores it is handed; it does not tune them. [Autopilot](/api-refs/merchant-features) is the separate self-tuning job that calibrates SR hedging and bucket size, and can run alongside this post-step (they are independent dials — `enableMultiObjective` and `use_autopilot`).
+- `margin` (fraction of ticket, e.g. `0.20`) comes from the merchant's success-rate config — see [Create success-rate config](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/success-rate-config-create.mdx). It defaults to `1.0` when unset.
+- This post-step re-ranks the SR scores it is handed; it does not tune them. [Autopilot](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx) is the separate self-tuning job that calibrates SR hedging and bucket size, and can run alongside this post-step (they are independent dials — `enableMultiObjective` and `use_autopilot`).
 - Gateways without fee data cannot be ranked on expected value and never win on cost; if the SR head itself has no fee data, the SR order is kept.
-- Per-gateway fee data comes from [cost ingestion](/api-refs/cost-ingestion-setup) — settlement reports and invoices fitted into a per-cluster cost model. Check [cost coverage](/api-refs/cost-ingestion-fees#cost-coverage) to see what share of volume actually has a trustworthy fee estimate before relying on this post-step.
-- To compare cost-aware routing against a plain auth-rate baseline on live traffic before flipping the merchant flag, run it as an [A/B test experiment](/api-refs/ab-testing-create) arm (`enable_multi_objective: true` on one arm only).
+- Per-gateway fee data comes from [cost ingestion](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx) — settlement reports and invoices fitted into a per-cluster cost model. Check [cost coverage](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-fees.mdx#cost-coverage) to see what share of volume actually has a trustworthy fee estimate before relying on this post-step.
+- To compare cost-aware routing against a plain auth-rate baseline on live traffic before flipping the merchant flag, run it as an [A/B test experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx) arm (`enable_multi_objective: true` on one arm only).
 
 ## Request
 

--- a/docs/api-refs/decide-gateway-pl-based.mdx
+++ b/docs/api-refs/decide-gateway-pl-based.mdx
@@ -46,4 +46,4 @@ curl --location "$BASE_URL/decide-gateway" \
 
 ## Multi-Objective Option
 
-When multi-objective routing is enabled (request field `enableMultiObjective`, or the `multi_objective_routing_enabled` merchant feature flag), a cost-aware post-step may re-rank the SR result and the response gains a `multi_objective_info` block. Details and examples: [Multi-objective routing](/api-refs/decide-gateway-multi-objective).
+When multi-objective routing is enabled (request field `enableMultiObjective`, or the `multi_objective_routing_enabled` merchant feature flag), a cost-aware post-step may re-rank the SR result and the response gains a `multi_objective_info` block. Details and examples: [Multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx).

--- a/docs/api-refs/decide-gateway-sr-based.mdx
+++ b/docs/api-refs/decide-gateway-sr-based.mdx
@@ -75,8 +75,8 @@ curl --location "$BASE_URL/decide-gateway" \
 - `SR_V3_HEDGING`: exploration mode across eligible gateways.
 - `SR_V3_DOWNTIME_HEDGING`: hedging with partial downtime.
 - `SR_V3_ALL_DOWNTIME_HEDGING`: hedging while all eligible gateways are down.
-- `SR_SELECTION_MULTI_OBJECTIVE`: the multi-objective post-step promoted a cheaper gateway over the SR head on expected value — see [Multi-objective routing](/api-refs/decide-gateway-multi-objective).
+- `SR_SELECTION_MULTI_OBJECTIVE`: the multi-objective post-step promoted a cheaper gateway over the SR head on expected value — see [Multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx).
 
 ## Multi-Objective Option
 
-When multi-objective routing is enabled (request field `enableMultiObjective`, or the `multi_objective_routing_enabled` merchant feature flag), a cost-aware post-step may re-rank the SR result and the response gains a `multi_objective_info` block. Details and examples: [Multi-objective routing](/api-refs/decide-gateway-multi-objective).
+When multi-objective routing is enabled (request field `enableMultiObjective`, or the `multi_objective_routing_enabled` merchant feature flag), a cost-aware post-step may re-rank the SR result and the response gains a `multi_objective_info` block. Details and examples: [Multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx).

--- a/docs/api-refs/decision-gateway-legacy.mdx
+++ b/docs/api-refs/decision-gateway-legacy.mdx
@@ -5,7 +5,7 @@ description: "Compatibility example for the legacy /decision_gateway route."
 
 # Legacy Decision Gateway
 
-`/decision_gateway` is retained for compatibility with older integrations. New integrations should use [`/decide-gateway`](/api-refs/decide-gateway-sr-based).
+`/decision_gateway` is retained for compatibility with older integrations. New integrations should use [`/decide-gateway`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-sr-based.mdx).
 
 ```bash
 curl --location "$BASE_URL/decision_gateway" \

--- a/docs/api-refs/merchant-debit-routing.mdx
+++ b/docs/api-refs/merchant-debit-routing.mdx
@@ -96,6 +96,6 @@ curl --location "$BASE_URL/decide-gateway" \
 
 ## Related
 
-- [Debit Gateway Transaction](/api-refs/decide-gateway-debit-routing)
-- [Network + SR Hybrid Routing](/api-refs/decide-gateway-hybrid-routing)
-- [Payment Audit](/api-refs/analytics-endpoints)
+- [Debit Gateway Transaction](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-debit-routing.mdx)
+- [Network + SR Hybrid Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-hybrid-routing.mdx)
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-refs/merchant-features.mdx
+++ b/docs/api-refs/merchant-features.mdx
@@ -46,8 +46,8 @@ Response is the same shape as the list call, re-read after the change so you alw
 | --- | --- |
 | `gsm-scoring-filter` | Filters gateway scoring using Gateway Status Mapper error-code classification. |
 | `explore-exploit-srv3` | Explore/exploit hedging on the SRv3 scoring path. |
-| `ab-test-real-payments` | Whether active A/B test experiments intercept real `/decide-gateway` traffic — see [A/B Testing: Results](/api-refs/ab-testing-results). |
-| `multi-objective-routing` | Merchant-wide default for the cost-aware post-step — see [Multi-Objective Routing](/api-refs/decide-gateway-multi-objective). Per-request `enableMultiObjective` overrides this. |
+| `ab-test-real-payments` | Whether active A/B test experiments intercept real `/decide-gateway` traffic — see [A/B Testing: Results](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-results.mdx). |
+| `multi-objective-routing` | Merchant-wide default for the cost-aware post-step — see [Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx). Per-request `enableMultiObjective` overrides this. |
 | `elimination` | Gateway-level SR-based elimination (excluding gateways in downtime). |
 | `auto-calibration` | Enables the self-tuning background job (see below). Must be on **together with** `autopilot` for the job to actually write changes. |
 | `autopilot` | Master write-permission switch for the self-tuning job. With `auto-calibration` off, this alone does nothing. |
@@ -62,15 +62,15 @@ Every polling interval (default 900s, configurable via `[sr_auto_calibration]` i
 2. Derives two SRv3 knobs purely from observed data — no merchant input:
    - **Bucket size** — clamped between 100 and 2000, only rewritten on a meaningful (25-step) change.
    - **Hedging %** — capped at 30%, with a 1.0pp minimum move before it updates.
-3. Writes the result back into the merchant's SR config (readable via [`GET /config/routing-keys`](/api-refs/config-endpoints) and [`GET /config-sr-dimension/:merchant_id`](/api-refs/config-endpoints#get-sr-dimensions)), stamped with `"source": "autopilot"` so autopilot-written values are distinguishable from human-authored overrides.
+3. Writes the result back into the merchant's SR config (readable via [`GET /config/routing-keys`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/config-endpoints.mdx) and [`GET /config-sr-dimension/:merchant_id`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/config-endpoints.mdx#get-sr-dimensions)), stamped with `"source": "autopilot"` so autopilot-written values are distinguishable from human-authored overrides.
 
-Every calibration run also emits an analytics event (`flow_type: autopilot_calibration`) — this is what powers the "Autopilot Actions" panel in the simulation UI, and is queryable via [Routing Events](/api-refs/analytics-endpoints#routing-events).
+Every calibration run also emits an analytics event (`flow_type: autopilot_calibration`) — this is what powers the "Autopilot Actions" panel in the simulation UI, and is queryable via [Routing Events](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx#routing-events).
 
 ## Reset Gateway Scores
 
 Flushes all SR v2/v3 score and queue keys for a merchant from Redis, and strips any autopilot-written (`source: "autopilot"`) sub-level config overrides — human-authored overrides are preserved. Used by the simulator's "Hard refresh" so a new simulation run starts from a clean slate.
 
-Unlike the feature-flag calls above, this route requires `$TENANT_HEADER` in addition to `$AUTH_HEADER` — see [Environment setup](/api-refs/api-ref#environment-setup).
+Unlike the feature-flag calls above, this route requires `$TENANT_HEADER` in addition to `$AUTH_HEADER` — see [Environment setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
 
 ```bash
 curl --location "$BASE_URL/gateway-score/reset" \
@@ -92,7 +92,7 @@ This does not disable routing or delete configuration — it only clears live sc
 
 ## Related
 
-- [A/B Testing: Create An Experiment](/api-refs/ab-testing-create)
-- [Multi-Objective Routing](/api-refs/decide-gateway-multi-objective)
-- [Routing Config Endpoints](/api-refs/config-endpoints)
-- [Analytics Endpoints](/api-refs/analytics-endpoints)
+- [A/B Testing: Create An Experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx)
+- [Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx)
+- [Routing Config Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/config-endpoints.mdx)
+- [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx)

--- a/docs/api-refs/routing-advanced-example.mdx
+++ b/docs/api-refs/routing-advanced-example.mdx
@@ -347,7 +347,7 @@ Use `volume_split_priority` when each split should return a priority list rather
 
 ## Related
 
-- [Create Routing Algorithm](/api-refs/routing-algorithm-create)
-- [Evaluate Routing Algorithm](/api-refs/routing-algorithm-evaluate)
-- [Priority Routing](/api-refs/routing-priority-example)
-- [Volume Split Routing](/api-refs/routing-volume-split-example)
+- [Create Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx)
+- [Evaluate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-evaluate.mdx)
+- [Priority Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-priority-example.mdx)
+- [Volume Split Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-volume-split-example.mdx)

--- a/docs/api-refs/routing-algorithm-activate.mdx
+++ b/docs/api-refs/routing-algorithm-activate.mdx
@@ -25,5 +25,5 @@ Success returns HTTP `200` with an empty response body.
 
 ## Related
 
-- [Deactivate Routing Algorithm](/api-refs/routing-algorithm-deactivate)
-- [List Active Routing Algorithms](/api-refs/routing-algorithm-list-active)
+- [Deactivate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-deactivate.mdx)
+- [List Active Routing Algorithms](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-list-active.mdx)

--- a/docs/api-refs/routing-algorithm-create.mdx
+++ b/docs/api-refs/routing-algorithm-create.mdx
@@ -5,19 +5,19 @@ description: "Curl examples for /routing/create."
 
 # Create Routing Algorithm
 
-Use `/routing/create` to persist a merchant-scoped routing algorithm. Creating an algorithm does not make it active; call [`/routing/activate`](/api-refs/routing-algorithm-activate) after creation.
+Use `/routing/create` to persist a merchant-scoped routing algorithm. Creating an algorithm does not make it active; call [`/routing/activate`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-activate.mdx) after creation.
 
 Supported `algorithm.type` values:
 
 | Type | Use case | Full example |
 | --- | --- | --- |
-| `single` | Always return one connector. | [Single connector](/api-refs/routing-single-connector-example) |
-| `priority` | Return connectors in the configured order. | [Priority routing](/api-refs/routing-priority-example) |
-| `volume_split` | Split decisions by percentage. | [Volume split](/api-refs/routing-volume-split-example) |
-| `advanced` | Evaluate AND/OR/nested conditions before returning an output. | [Advanced routing](/api-refs/routing-advanced-example) |
-| `ab_test` | Split traffic between a control and variant strategy with guardrails and significance testing. | [A/B testing](/api-refs/ab-testing-create) |
+| `single` | Always return one connector. | [Single connector](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-single-connector-example.mdx) |
+| `priority` | Return connectors in the configured order. | [Priority routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-priority-example.mdx) |
+| `volume_split` | Split decisions by percentage. | [Volume split](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-volume-split-example.mdx) |
+| `advanced` | Evaluate AND/OR/nested conditions before returning an output. | [Advanced routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-advanced-example.mdx) |
+| `ab_test` | Split traffic between a control and variant strategy with guardrails and significance testing. | [A/B testing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx) |
 
-Use [`/routing/deactivate`](/api-refs/routing-algorithm-deactivate) to deactivate the currently active algorithm without deleting it, and [update or delete](/api-refs/routing-algorithm-update-delete) an inactive algorithm in place.
+Use [`/routing/deactivate`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-deactivate.mdx) to deactivate the currently active algorithm without deleting it, and [update or delete](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-update-delete.mdx) an inactive algorithm in place.
 
 ## Priority Rule
 
@@ -87,7 +87,7 @@ curl --location "$BASE_URL/routing/create" \
 
 ## Advanced Rule
 
-Use `advanced` for conditional routing. The complete AND/OR/nested reference is in [Advanced Routing Example](/api-refs/routing-advanced-example).
+Use `advanced` for conditional routing. The complete AND/OR/nested reference is in [Advanced Routing Example](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-advanced-example.mdx).
 
 ```bash
 curl --location "$BASE_URL/routing/create" \
@@ -149,9 +149,9 @@ curl --location "$BASE_URL/routing/create" \
 
 ## Related
 
-- [Activate Routing Algorithm](/api-refs/routing-algorithm-activate)
-- [Update & Delete Routing Algorithm](/api-refs/routing-algorithm-update-delete)
-- [List Routing Algorithms](/api-refs/routing-algorithm-list)
-- [Evaluate Routing Algorithm](/api-refs/routing-algorithm-evaluate)
-- [Advanced Routing Example](/api-refs/routing-advanced-example)
-- [A/B Testing: Create An Experiment](/api-refs/ab-testing-create)
+- [Activate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-activate.mdx)
+- [Update & Delete Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-update-delete.mdx)
+- [List Routing Algorithms](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-list.mdx)
+- [Evaluate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-evaluate.mdx)
+- [Advanced Routing Example](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-advanced-example.mdx)
+- [A/B Testing: Create An Experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx)

--- a/docs/api-refs/routing-algorithm-deactivate.mdx
+++ b/docs/api-refs/routing-algorithm-deactivate.mdx
@@ -31,6 +31,6 @@ Success returns HTTP `200` with an empty response body.
 
 ## Related
 
-- [Create Routing Algorithm](/api-refs/routing-algorithm-create)
-- [Activate Routing Algorithm](/api-refs/routing-algorithm-activate)
-- [List Active Routing Algorithms](/api-refs/routing-algorithm-list-active)
+- [Create Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx)
+- [Activate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-activate.mdx)
+- [List Active Routing Algorithms](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-list-active.mdx)

--- a/docs/api-refs/routing-algorithm-update-delete.mdx
+++ b/docs/api-refs/routing-algorithm-update-delete.mdx
@@ -5,7 +5,7 @@ description: "Curl examples for /routing/update and /routing/delete."
 
 # Update & Delete Routing Algorithm
 
-Edit or remove a previously created routing algorithm — including [A/B test experiments](/api-refs/ab-testing-create), which are stored the same way. Both operations only work on an **inactive** algorithm; deactivate it first with [`/routing/deactivate`](/api-refs/routing-algorithm-deactivate) if it's currently live.
+Edit or remove a previously created routing algorithm — including [A/B test experiments](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx), which are stored the same way. Both operations only work on an **inactive** algorithm; deactivate it first with [`/routing/deactivate`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-deactivate.mdx) if it's currently live.
 
 ## Update
 
@@ -30,7 +30,7 @@ curl --location "$BASE_URL/routing/update" \
   }'
 ```
 
-`algorithm` accepts the same `type` values as [`/routing/create`](/api-refs/routing-algorithm-create) — `single`, `priority`, `volume_split`, `advanced`, or `ab_test`.
+`algorithm` accepts the same `type` values as [`/routing/create`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx) — `single`, `priority`, `volume_split`, `advanced`, or `ab_test`.
 
 ```json
 {
@@ -65,7 +65,7 @@ curl --location "$BASE_URL/routing/delete" \
 
 ## Related
 
-- [Create Routing Algorithm](/api-refs/routing-algorithm-create)
-- [Activate Routing Algorithm](/api-refs/routing-algorithm-activate)
-- [Deactivate Routing Algorithm](/api-refs/routing-algorithm-deactivate)
-- [A/B Testing: Create An Experiment](/api-refs/ab-testing-create)
+- [Create Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx)
+- [Activate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-activate.mdx)
+- [Deactivate Routing Algorithm](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-deactivate.mdx)
+- [A/B Testing: Create An Experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx)

--- a/docs/api-refs/success-rate-config-create.mdx
+++ b/docs/api-refs/success-rate-config-create.mdx
@@ -32,4 +32,4 @@ curl --location "$BASE_URL/rule/create" \
 { "merchant_id": "merchant_demo", "config": { "type": "successRate" } }
 ```
 
-`margin` is the merchant margin as a fraction of ticket (e.g. `0.20` for 20%). It feeds the [multi-objective routing](/api-refs/decide-gateway-multi-objective) economic-value ranking `EV = auth rate × settlement value` (settlement value = txn amount − cost of payment processing) by setting the merchant's share of the ticket, and defaults to `1.0` when unset.
+`margin` is the merchant margin as a fraction of ticket (e.g. `0.20` for 20%). It feeds the [multi-objective routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx) economic-value ranking `EV = auth rate × settlement value` (settlement value = txn amount − cost of payment processing) by setting the merchant's share of the ticket, and defaults to `1.0` when unset.

--- a/docs/api-refs/update-score-legacy.mdx
+++ b/docs/api-refs/update-score-legacy.mdx
@@ -5,7 +5,7 @@ description: "Compatibility example for the legacy /update-score route."
 
 # Legacy Update Score
 
-`/update-score` is retained for compatibility. New integrations should use [`/update-gateway-score`](/api-refs/update-gateway-score).
+`/update-score` is retained for compatibility. New integrations should use [`/update-gateway-score`](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/update-gateway-score.mdx).
 
 ```bash
 curl --location "$BASE_URL/update-score" \

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -264,6 +264,6 @@ bash scripts/load-test/benchmark.sh --saturation --max-vus 300 --step-dur 20s
 
 ## Related Docs
 
-- [Configuration](/configuration) — log level and Redis pool settings referenced above.
-- [Local Setup Guide](/local-setup) — bringing up the stack these benchmarks run against.
-- [API Guide](/api-refs/api-ref) — `/decide-gateway` and `/routing/evaluate` request examples.
+- [Configuration](https://github.com/juspay/decision-engine/blob/main/docs/configuration.md) — log level and Redis pool settings referenced above.
+- [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md) — bringing up the stack these benchmarks run against.
+- [API Guide](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx) — `/decide-gateway` and `/routing/evaluate` request examples.

--- a/docs/clickhouse-analytics.mdx
+++ b/docs/clickhouse-analytics.mdx
@@ -125,6 +125,6 @@ SELECT name, engine FROM system.tables WHERE database = 'default' AND name LIKE 
 
 ## Related Docs
 
-- [Analytics](/analytics) — the operator-facing view built on this pipeline.
-- [Payment Audit](/payment-audit) — single-payment timeline lookups against these tables.
-- [Local Setup Guide](/local-setup) — bringing up the `analytics-clickhouse` profile.
+- [Analytics](https://github.com/juspay/decision-engine/blob/main/docs/analytics.mdx) — the operator-facing view built on this pipeline.
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/payment-audit.mdx) — single-payment timeline lookups against these tables.
+- [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md) — bringing up the `analytics-clickhouse` profile.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,7 +103,7 @@ public = { schema = "public" }
 
 Maps tenant identifiers to database schemas. The shipped config files (`config/development.toml`, `config/docker-configuration.toml`) define only the `public` tenant — add entries for any additional tenant you want to support.
 
-Some routes resolve the tenant from an `x-tenant-id` request header rather than the authenticated merchant, and reject the request outright if it's missing (`TE_03`). Send `x-tenant-id: public` on `GET /health/diagnostics`, every `GET /analytics/*` route, and `POST /gateway-score/reset` — see [API Guide](/api-refs/api-ref#environment-setup).
+Some routes resolve the tenant from an `x-tenant-id` request header rather than the authenticated merchant, and reject the request outright if it's missing (`TE_03`). Send `x-tenant-id: public` on `GET /health/diagnostics`, every `GET /analytics/*` route, and `POST /gateway-score/reset` — see [API Guide](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx#environment-setup).
 
 ### Redis
 
@@ -222,7 +222,7 @@ Selected values can be overridden at runtime via environment variables. This is 
 
 ## Related Docs
 
-- [Installation](/installation)
-- [Local Setup Guide](/local-setup)
-- [API Guide](/api-refs/api-ref)
-- [API Reference](/api-reference)
+- [Installation](https://github.com/juspay/decision-engine/blob/main/docs/installation.md)
+- [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md)
+- [API Guide](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx)
+- [API Reference](https://github.com/juspay/decision-engine/blob/main/docs/api-reference.md)

--- a/docs/dashboard-guide.mdx
+++ b/docs/dashboard-guide.mdx
@@ -58,7 +58,7 @@ Proxy behavior is defined in `nginx/nginx.conf`.
 
 ## Related Docs
 
-- [Installation](/installation)
-- [Local Setup Guide](/local-setup)
-- [Analytics](/analytics)
-- [Payment Audit](/payment-audit)
+- [Installation](https://github.com/juspay/decision-engine/blob/main/docs/installation.md)
+- [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md)
+- [Analytics](https://github.com/juspay/decision-engine/blob/main/docs/analytics.mdx)
+- [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/payment-audit.mdx)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,22 +22,22 @@ Expected response:
 { "message": "Health is good" }
 ```
 
-For the API, dashboard, and docs together, use `--profile dashboard-postgres-ghcr` instead — see [Dashboard](/dashboard-guide).
+For the API, dashboard, and docs together, use `--profile dashboard-postgres-ghcr` instead — see [Dashboard](https://github.com/juspay/decision-engine/blob/main/docs/dashboard-guide.mdx).
 
 ## In This Section
 
 | Page | Use it for |
 | --- | --- |
-| [Local Setup](/local-setup) | The canonical guide — Compose profiles, source builds, Docker images without Compose, Helm, and troubleshooting. |
-| [PostgreSQL Setup](/setup-guide-postgres) | Postgres-specific Compose profiles, `make` targets, and verification. |
-| [MySQL Setup](/setup-guide-mysql) | The same, for MySQL. |
-| [Configuration](/configuration) | Config file reference and environment variable overrides once the service is up. |
-| [Dashboard](/dashboard-guide) | Bring up the React operator dashboard alongside the API. |
+| [Local Setup](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md) | The canonical guide — Compose profiles, source builds, Docker images without Compose, Helm, and troubleshooting. |
+| [PostgreSQL Setup](https://github.com/juspay/decision-engine/blob/main/docs/setup-guide-postgres.md) | Postgres-specific Compose profiles, `make` targets, and verification. |
+| [MySQL Setup](https://github.com/juspay/decision-engine/blob/main/docs/setup-guide-mysql.md) | The same, for MySQL. |
+| [Configuration](https://github.com/juspay/decision-engine/blob/main/docs/configuration.md) | Config file reference and environment variable overrides once the service is up. |
+| [Dashboard](https://github.com/juspay/decision-engine/blob/main/docs/dashboard-guide.mdx) | Bring up the React operator dashboard alongside the API. |
 
 ## Choosing A Database
 
-Decision Engine supports PostgreSQL and MySQL as interchangeable backends. Pick one and follow its dedicated guide, or go straight to [Local Setup](/local-setup) if you want the full profile matrix (dashboard, monitoring, source builds) rather than a database-first walkthrough.
+Decision Engine supports PostgreSQL and MySQL as interchangeable backends. Pick one and follow its dedicated guide, or go straight to [Local Setup](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md) if you want the full profile matrix (dashboard, monitoring, source builds) rather than a database-first walkthrough.
 
 ## Next Steps
 
-- [API Guide](/api-refs/api-ref) — copy-paste `curl` examples once the service is running.
+- [API Guide](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx) — copy-paste `curl` examples once the service is running.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -21,31 +21,31 @@ Decision Engine is a Rust service that sits between your orchestrator and your p
 | **Network + SR hybrid routing** | `NTW_SR_HYBRID_ROUTING` — combines network eligibility with success-rate ranking. |
 | **Multi-objective (cost-aware) routing** | Not a `rankingAlgorithm` value — a post-step *on top of* success-rate routing. Re-ranks gateways with cost data by expected value and promotes a cheaper one if it wins. See below. |
 
-The first four are selected per request with `rankingAlgorithm`. See the [routing configuration guides](/api-refs/routing-algorithm-create) and [decide-gateway examples](/api-refs/decide-gateway-sr-based) for full request/response detail.
+The first four are selected per request with `rankingAlgorithm`. See the [routing configuration guides](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/routing-algorithm-create.mdx) and [decide-gateway examples](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-sr-based.mdx) for full request/response detail.
 
 ### Multi-Objective (Cost-Aware) Routing
 
-A post-step on top of success-rate scoring: after SR picks a head gateway, Decision Engine re-ranks every gateway with cost data by **economic value** (`EV = auth rate × settlement value`, where `settlement value = txn amount − cost of payment processing (acquirer, issuer & network fee)`), and promotes a cheaper gateway if it wins on EV. Toggle it per request (`enableMultiObjective`) or per merchant (`multi_objective_routing_enabled` feature flag). See [Multi-Objective Routing](/api-refs/decide-gateway-multi-objective).
+A post-step on top of success-rate scoring: after SR picks a head gateway, Decision Engine re-ranks every gateway with cost data by **economic value** (`EV = auth rate × settlement value`, where `settlement value = txn amount − cost of payment processing (acquirer, issuer & network fee)`), and promotes a cheaper gateway if it wins on EV. Toggle it per request (`enableMultiObjective`) or per merchant (`multi_objective_routing_enabled` feature flag). See [Multi-Objective Routing](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/decide-gateway-multi-objective.mdx).
 
 ### Cost Data Ingestion
 
-Learns each connector's *real* fee — not a static rate card — from settlement reports and invoices, fitted down to a per-cluster level (connector × card network × variant × funding × issuer country × currency × interchange category). This is what feeds multi-objective routing's cost side. Reports arrive by webhook, scheduled poll, or manual upload; fees can be read, overridden per connector or per cluster, and audited for coverage. See [Cost Ingestion: Connector Setup](/api-refs/cost-ingestion-setup).
+Learns each connector's *real* fee — not a static rate card — from settlement reports and invoices, fitted down to a per-cluster level (connector × card network × variant × funding × issuer country × currency × interchange category). This is what feeds multi-objective routing's cost side. Reports arrive by webhook, scheduled poll, or manual upload; fees can be read, overridden per connector or per cluster, and audited for coverage. See [Cost Ingestion: Connector Setup](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/cost-ingestion-setup.mdx).
 
 ### A/B Testing
 
-Split live traffic between a control and variant routing strategy — auth-only vs. cost-aware, manual vs. autopilot, or any two saved algorithms — with a configurable split percentage, a minimum sample size, and a guardrail that auto-flags a regression before it does damage. Built-in statistical significance testing (two-sample z-test) tells you when a variant actually wins. See [A/B Testing: Create An Experiment](/api-refs/ab-testing-create).
+Split live traffic between a control and variant routing strategy — auth-only vs. cost-aware, manual vs. autopilot, or any two saved algorithms — with a configurable split percentage, a minimum sample size, and a guardrail that auto-flags a regression before it does damage. Built-in statistical significance testing (two-sample z-test) tells you when a variant actually wins. See [A/B Testing: Create An Experiment](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/ab-testing-create.mdx).
 
 ### Autopilot & Auto-Calibration
 
-A background job that self-tunes success-rate scoring — hedging percentage and bucket size — from observed traffic, with no manual retuning. Every calibration run is logged as an auditable event, and a merchant can hard-reset live scores back to a clean baseline at any time. See [Merchant Features: Autopilot & Feature Flags](/api-refs/merchant-features).
+A background job that self-tunes success-rate scoring — hedging percentage and bucket size — from observed traffic, with no manual retuning. Every calibration run is logged as an auditable event, and a merchant can hard-reset live scores back to a clean baseline at any time. See [Merchant Features: Autopilot & Feature Flags](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/merchant-features.mdx).
 
 ### Analytics & Audit
 
-ClickHouse-backed views for everything above: routing overview, gateway score trends, decision volume, cost savings, routing events (leader changes, autopilot re-tunes), and a single-payment audit trail that answers "which gateway was picked, and why" for any transaction. See [Analytics Endpoints](/api-refs/analytics-endpoints) and [Payment Audit](/payment-audit).
+ClickHouse-backed views for everything above: routing overview, gateway score trends, decision volume, cost savings, routing events (leader changes, autopilot re-tunes), and a single-payment audit trail that answers "which gateway was picked, and why" for any transaction. See [Analytics Endpoints](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/analytics-endpoints.mdx) and [Payment Audit](https://github.com/juspay/decision-engine/blob/main/docs/payment-audit.mdx).
 
 ### Dashboard
 
-A React operator UI for configuring routing, running A/B tests, watching analytics, and auditing decisions without touching the API directly. See [Dashboard](/dashboard-guide).
+A React operator UI for configuring routing, running A/B tests, watching analytics, and auditing decisions without touching the API directly. See [Dashboard](https://github.com/juspay/decision-engine/blob/main/docs/dashboard-guide.mdx).
 
 ### Platform
 
@@ -69,7 +69,7 @@ The API is organized into the following endpoint groups:
 | Cost ingestion | `POST/GET/DELETE /merchant-account/{merchantId}/connectors/*`, `.../cost-*` | Connector credentials, settlement/invoice uploads, fee overrides. |
 | Analytics | `GET /analytics/*` | Gateway scores, decisions, cost savings, routing events, experiment results, audit. |
 
-For copy-paste `curl` examples of each flow, see the [API Guide](/api-refs/api-ref). For exact request and response schemas, use the OpenAPI-backed endpoint pages under [API Reference](/api-reference).
+For copy-paste `curl` examples of each flow, see the [API Guide](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx). For exact request and response schemas, use the OpenAPI-backed endpoint pages under [API Reference](https://github.com/juspay/decision-engine/blob/main/docs/api-reference.md).
 
 ## Run Locally
 
@@ -92,11 +92,11 @@ URLs:
 - Dashboard: `http://localhost:8081/dashboard/`
 - Docs: `http://localhost:8081/introduction`
 
-Use [Installation](/installation) for the full Compose, database, and Helm matrix.
+Use [Installation](https://github.com/juspay/decision-engine/blob/main/docs/installation.md) for the full Compose, database, and Helm matrix.
 
 ## Where To Go Next
 
-- [Installation](/installation) — Docker Compose, PostgreSQL/MySQL setup, and configuration, end to end.
-- [Dashboard](/dashboard-guide) — route-by-route guide to the React operator dashboard.
-- [API Guide (curl examples)](/api-refs/api-ref) — copy-paste flows for every route family, including cost ingestion, A/B testing, and autopilot.
-- [API Reference (OpenAPI)](/api-reference) — schema-backed endpoint pages with a request playground.
+- [Installation](https://github.com/juspay/decision-engine/blob/main/docs/installation.md) — Docker Compose, PostgreSQL/MySQL setup, and configuration, end to end.
+- [Dashboard](https://github.com/juspay/decision-engine/blob/main/docs/dashboard-guide.mdx) — route-by-route guide to the React operator dashboard.
+- [API Guide (curl examples)](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx) — copy-paste flows for every route family, including cost ingestion, A/B testing, and autopilot.
+- [API Reference (OpenAPI)](https://github.com/juspay/decision-engine/blob/main/docs/api-reference.md) — schema-backed endpoint pages with a request playground.

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -266,8 +266,8 @@ curl --user decision_engine:decision_engine \
 
 ## Related Docs
 
-- [Installation](/installation)
-- [PostgreSQL Setup](/setup-guide-postgres)
-- [MySQL Setup](/setup-guide-mysql)
-- [Configuration](/configuration)
-- [API Guide](/api-refs/api-ref)
+- [Installation](https://github.com/juspay/decision-engine/blob/main/docs/installation.md)
+- [PostgreSQL Setup](https://github.com/juspay/decision-engine/blob/main/docs/setup-guide-postgres.md)
+- [MySQL Setup](https://github.com/juspay/decision-engine/blob/main/docs/setup-guide-mysql.md)
+- [Configuration](https://github.com/juspay/decision-engine/blob/main/docs/configuration.md)
+- [API Guide](https://github.com/juspay/decision-engine/blob/main/docs/api-refs/api-ref.mdx)

--- a/docs/payment-audit.mdx
+++ b/docs/payment-audit.mdx
@@ -96,6 +96,6 @@ When the dashboard profile is running, open:
 
 ## Related Docs
 
-- [Analytics](/analytics) — the broader operator-facing metrics view.
-- [ClickHouse Analytics](/clickhouse-analytics) — the underlying ingestion pipeline and schema.
-- [Dashboard](/dashboard-guide) — where this view is surfaced.
+- [Analytics](https://github.com/juspay/decision-engine/blob/main/docs/analytics.mdx) — the broader operator-facing metrics view.
+- [ClickHouse Analytics](https://github.com/juspay/decision-engine/blob/main/docs/clickhouse-analytics.mdx) — the underlying ingestion pipeline and schema.
+- [Dashboard](https://github.com/juspay/decision-engine/blob/main/docs/dashboard-guide.mdx) — where this view is surfaced.

--- a/docs/setup-guide-mysql.md
+++ b/docs/setup-guide-mysql.md
@@ -5,7 +5,7 @@ description: "Set up Decision Engine with a MySQL database."
 
 # MySQL Setup Guide
 
-This page provides MySQL-focused commands. For the full end-to-end setup — CLI, Docker, Compose, Helm — see the [Local Setup Guide](/local-setup).
+This page provides MySQL-focused commands. For the full end-to-end setup — CLI, Docker, Compose, Helm — see the [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md).
 
 ## Docker Compose (GHCR track)
 
@@ -53,7 +53,7 @@ Expected response:
 
 ## Related Docs
 
-- [Installation](/installation)
-- [Local Setup Guide](/local-setup)
-- [PostgreSQL Setup](/setup-guide-postgres)
-- [Configuration](/configuration)
+- [Installation](https://github.com/juspay/decision-engine/blob/main/docs/installation.md)
+- [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md)
+- [PostgreSQL Setup](https://github.com/juspay/decision-engine/blob/main/docs/setup-guide-postgres.md)
+- [Configuration](https://github.com/juspay/decision-engine/blob/main/docs/configuration.md)

--- a/docs/setup-guide-postgres.md
+++ b/docs/setup-guide-postgres.md
@@ -5,7 +5,7 @@ description: "Set up Decision Engine with a PostgreSQL database."
 
 # PostgreSQL Setup Guide
 
-This page provides PostgreSQL-focused commands. For the full end-to-end setup — CLI, Docker, Compose, Helm — see the [Local Setup Guide](/local-setup).
+This page provides PostgreSQL-focused commands. For the full end-to-end setup — CLI, Docker, Compose, Helm — see the [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md).
 
 ## Docker Compose (GHCR track)
 
@@ -53,7 +53,7 @@ Expected response:
 
 ## Related Docs
 
-- [Installation](/installation)
-- [Local Setup Guide](/local-setup)
-- [MySQL Setup](/setup-guide-mysql)
-- [Configuration](/configuration)
+- [Installation](https://github.com/juspay/decision-engine/blob/main/docs/installation.md)
+- [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md)
+- [MySQL Setup](https://github.com/juspay/decision-engine/blob/main/docs/setup-guide-mysql.md)
+- [Configuration](https://github.com/juspay/decision-engine/blob/main/docs/configuration.md)

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -4,8 +4,8 @@ This page has been consolidated.
 
 Use the canonical guide:
 
-- [Local Setup Guide](/local-setup)
+- [Local Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/local-setup.md)
 
 For database-specific walkthroughs:
-- [PostgreSQL Setup Guide](/setup-guide-postgres)
-- [MySQL Setup Guide](/setup-guide-mysql)
+- [PostgreSQL Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/setup-guide-postgres.md)
+- [MySQL Setup Guide](https://github.com/juspay/decision-engine/blob/main/docs/setup-guide-mysql.md)


### PR DESCRIPTION
As Mintlify docs are moved to hyperswitch we can change docs links to GitHub one so that GitHub can render them 
This pull request updates internal documentation links to use absolute URLs pointing to the corresponding files in the GitHub repository. This ensures that all references are accurate and work correctly when viewed outside the deployed documentation site, improving reliability and consistency for users navigating the docs.

**Documentation link updates:**

* All internal Markdown links in `docs/api-reference.md`, `docs/analytics.mdx`, and various endpoint documentation files (e.g., `analyticsCostSavings.mdx`, `analyticsDecisions.mdx`, `analyticsExperimentResults.mdx`, `analyticsExperimentTransactions.mdx`, and `activateRoutingRule.mdx`) now use absolute URLs to the GitHub repository instead of relative paths. [[1]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL10-R19) [[2]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL34-R107) [[3]](diffhunk://#diff-a3816b5e7da070f13ad93399f5d53fb0a2afdf531f3521e92c4d9bc03bcc5716L94-R96) [[4]](diffhunk://#diff-11475c8fb55a0336170220c4dcaa8e90009f3252937a557d77390642fba84ce7L58-R61) [[5]](diffhunk://#diff-4646ae38f14ce40f070317c5f9b151d04054b3c92938a984a371d379e2f03ef7L11-R11) [[6]](diffhunk://#diff-4646ae38f14ce40f070317c5f9b151d04054b3c92938a984a371d379e2f03ef7L32-R32) [[7]](diffhunk://#diff-4646ae38f14ce40f070317c5f9b151d04054b3c92938a984a371d379e2f03ef7L91-R98) [[8]](diffhunk://#diff-6be4b87c9e74bed054b82e30a80d5b080049913e4e0b76e4776d2d47f8c52627L32-R32) [[9]](diffhunk://#diff-6be4b87c9e74bed054b82e30a80d5b080049913e4e0b76e4776d2d47f8c52627L104-R106) [[10]](diffhunk://#diff-2faec0c436d07f6c331347f77157030f9b93128f2d853caaf378f2480e4c0fd4L11-R11) [[11]](diffhunk://#diff-2faec0c436d07f6c331347f77157030f9b93128f2d853caaf378f2480e4c0fd4L32-R32) [[12]](diffhunk://#diff-2faec0c436d07f6c331347f77157030f9b93128f2d853caaf378f2480e4c0fd4L95-R101) [[13]](diffhunk://#diff-e0880d0a8989764b10969fcd4c29c988c78667514c9bc423c5ab3828f35ad137L11-R11) [[14]](diffhunk://#diff-e0880d0a8989764b10969fcd4c29c988c78667514c9bc423c5ab3828f35ad137L32-R32) [[15]](diffhunk://#diff-e0880d0a8989764b10969fcd4c29c988c78667514c9bc423c5ab3828f35ad137L72-R74)

No other functional or code changes are included in this pull request.