### PR TITLE
feat(simulator): scoped resets, connector picker and input fixes

### DIFF
--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -544,7 +544,9 @@ pub async fn switch_merchant(
     let claims = verify_jwt_not_revoked(token, &global_config.user_auth.jwt_secret).await?;
 
     if claims.token_type == TOKEN_TYPE_HS_REDIRECT {
-        return Err(error::ContainerError::from(UserAuthError::UnsupportedOperation));
+        return Err(error::ContainerError::from(
+            UserAuthError::UnsupportedOperation,
+        ));
     }
 
     let app_state = get_tenant_app_state().await;
@@ -601,7 +603,9 @@ pub async fn change_password(
     let claims = verify_jwt_not_revoked(token, &global_config.user_auth.jwt_secret).await?;
 
     if claims.token_type == TOKEN_TYPE_HS_REDIRECT {
-        return Err(error::ContainerError::from(UserAuthError::UnsupportedOperation));
+        return Err(error::ContainerError::from(
+            UserAuthError::UnsupportedOperation,
+        ));
     }
 
     let app_state = get_tenant_app_state().await;

--- a/website/src/components/pages/CostEstimationPanel.tsx
+++ b/website/src/components/pages/CostEstimationPanel.tsx
@@ -111,7 +111,7 @@ export function CostEstimationPanel({ merchantId }: { merchantId?: string }) {
   }, [section, sectionParam, ingestMode, sourceParam])
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[184px_1fr] lg:items-start">
+    <div className="grid gap-6 lg:grid-cols-[220px_1fr] lg:items-start">
       <SectionRail
         merchantId={merchantId}
         active={section}
@@ -172,31 +172,29 @@ function SectionRail({
               type="button"
               onClick={() => onSelect(id)}
               aria-current={on ? 'page' : undefined}
-              className={`flex w-full flex-col rounded-xl border px-2.5 py-2.5 text-left transition-colors ${
+              className={`flex w-full items-start gap-3 rounded-xl border px-3 py-2.5 text-left transition-colors ${
                 on
                   ? 'border-brand-500/40 bg-brand-500/8 text-slate-900 dark:text-white'
                   : 'border-transparent text-slate-600 hover:bg-slate-50 dark:text-[#9ca7ba] dark:hover:bg-[#141923]'
               }`}
             >
-              {/* The icon sits inline with the title rather than in its own column: the titles are
-                  short enough to share a line with it, and the hint below — the line that actually
-                  wraps — then gets the rail's full width instead of starting at an icon indent. */}
-              <span className="flex min-w-0 items-center gap-2">
-                <Icon
-                  size={16}
-                  className={`shrink-0 ${on ? 'text-brand-500' : 'text-slate-400'}`}
-                />
-                <span className="truncate text-sm font-medium">{title}</span>
-              </span>
-              <span className="mt-0.5 hidden text-xs text-slate-400 lg:block">
-                {hint[id] ?? blurb}
+              <Icon
+                size={18}
+                className={`mt-0.5 shrink-0 ${on ? 'text-brand-500' : 'text-slate-400'}`}
+              />
+              <span className="min-w-0">
+                <span className="block text-sm font-medium">{title}</span>
+                <span className="mt-0.5 hidden text-xs text-slate-400 lg:block">
+                  {hint[id] ?? blurb}
+                </span>
               </span>
             </button>
 
             {/* Ingestion's three sources hang off it as a nested rail, revealed only while the
-                section is open so the rail stays three items tall the rest of the time. */}
+                section is open so the rail stays three items tall the rest of the time. The indent
+                lines the divider up with the icon's centre (px-3 + half of an 18px icon). */}
             {id === 'ingestion' && on && (
-              <div className="ml-[1.125rem] mt-1 flex flex-col gap-0.5 border-l border-slate-200 pl-2 dark:border-[#2a3344]">
+              <div className="ml-[1.3125rem] mt-1 flex flex-col gap-0.5 border-l border-slate-200 pl-2 dark:border-[#2a3344]">
                 {INGEST_MODES.map((m) => {
                   const sub = ingestMode === m.id
                   return (

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -2727,10 +2727,39 @@ export function DecisionSimulatorPage() {
       .map(name => ({ name, hasCostModel: withCostModel.has(name) }))
   }, [seedRows, ingestedConnectors, eligibleGatewaysParsed])
 
-  const gatewayColorMap = useMemo(
-    () => Object.fromEntries(eligibleGatewaysParsed.map((gw, i) => [gw, GW_COLOR_OVERRIDES[gw.toLowerCase()] ?? GW_PALETTE[i % GW_PALETTE.length]])),
-    [eligibleGatewaysParsed],
-  )
+  /**
+   * One color per eligible connector. The overrides are keyed by name and the palette is handed out
+   * by position, so taking `GW_PALETTE[i]` blindly can re-issue a color an override already owns:
+   * Stripe's purple *is* `GW_PALETTE[1]`, so [stripe, adyen, checkout] rendered fine but dropping
+   * Adyen moved Checkout to index 1 and painted it Stripe's purple.
+   *
+   * So: claim the override colors up front, then let each remaining connector take the first unused
+   * palette entry at or after its own index. Searching from `i` rather than from 0 keeps a
+   * connector's color stable when one earlier in the list is removed — Checkout stays orange whether
+   * or not Adyen is present — instead of shuffling the whole legend on every add/remove.
+   */
+  const gatewayColorMap = useMemo(() => {
+    const used = new Set(
+      eligibleGatewaysParsed.map(gw => GW_COLOR_OVERRIDES[gw.toLowerCase()]).filter(Boolean),
+    )
+    const takeFrom = (start: number) => {
+      for (let k = 0; k < GW_PALETTE.length; k++) {
+        const color = GW_PALETTE[(start + k) % GW_PALETTE.length]
+        if (!used.has(color)) return color
+      }
+      // More connectors than colors — a repeat is unavoidable, so fall back to the positional pick.
+      return GW_PALETTE[start % GW_PALETTE.length]
+    }
+    return Object.fromEntries(
+      eligibleGatewaysParsed.map((gw, i) => {
+        const override = GW_COLOR_OVERRIDES[gw.toLowerCase()]
+        if (override) return [gw, override]
+        const color = takeFrom(i)
+        used.add(color)
+        return [gw, color]
+      }),
+    )
+  }, [eligibleGatewaysParsed])
 
   // Auto-populate errorInfo for any gateway whose config has no error code yet,
   // once GSM rules have loaded from the API.

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -1068,6 +1068,63 @@ function InspectorJsonPanel({
   )
 }
 
+/**
+ * A number input for one end of the amount range.
+ *
+ * The naive version — clamp `e.target.value` into state on every keystroke — makes the field
+ * impossible to retype: clearing "100" produces an empty string, which clamps to the lower bound
+ * and re-renders as "1", so the next digits land *after* that 1 ("5000" becomes 15000, truncated
+ * back down by the clamp). So while the field is focused we show exactly what was typed and keep
+ * the committed number in step behind it, and only re-sync the text to the canonical (clamped,
+ * cross-clamped) value on blur.
+ */
+function AmountBoundInput({
+  value,
+  min,
+  max,
+  ariaLabel,
+  className,
+  onCommit,
+  onSettle,
+}: {
+  value: number
+  min: number
+  max: number
+  ariaLabel: string
+  className: string
+  /** Called with a clamped number for every keystroke that parses — keeps a run's config valid. */
+  onCommit: (next: number) => void
+  /** Called on blur, after the draft is dropped — where the two bounds get cross-clamped. */
+  onSettle: () => void
+}) {
+  // null ⇒ not being edited, so mirror `value`. A string ⇒ the user's in-progress text, shown
+  // verbatim (including empty) no matter what the clamp did to the committed number.
+  const [draft, setDraft] = useState<string | null>(null)
+
+  return (
+    <input
+      type="number" min={min} max={max} step={5}
+      aria-label={ariaLabel}
+      value={draft ?? String(value)}
+      onChange={e => {
+        const text = e.target.value
+        setDraft(text)
+        // An empty or half-typed field leaves the last valid number committed, so starting a
+        // simulation mid-edit can never draw amounts from a NaN range.
+        const parsed = Number(text)
+        if (text !== '' && Number.isFinite(parsed)) {
+          onCommit(Math.max(min, Math.min(max, parsed)))
+        }
+      }}
+      onBlur={() => {
+        setDraft(null)
+        onSettle()
+      }}
+      className={className}
+    />
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Extracts RuleEvaluateParams from a routing algorithm's Euclid conditions.
 // Walks all rules and statements, collecting unique lhs keys with their first
@@ -1137,6 +1194,10 @@ export function DecisionSimulatorPage() {
   const eliminationEnabled = Object.values(gatewaySimConfigs).some(c => c.failureMode === 'timeout')
   const simulationAbortRef = useRef(false)
   useEffect(() => () => { simulationAbortRef.current = true }, [])
+  // Set when the results are cleared out from under a live run. Aborting alone isn't enough: the
+  // run loop owns a local `results` array and flushes it into state as it goes and once more on the
+  // way out, so without this the cleared transaction log would repopulate a moment later.
+  const discardRunResultsRef = useRef(false)
 
   const [debitForm, setDebitForm] = useState<DebitRoutingFormState>(initialState.debitForm)
 
@@ -2208,6 +2269,7 @@ export function DecisionSimulatorPage() {
     setSetupPrompt(null)
     if (!isResume) setSimulationResults([])
     simulationAbortRef.current = false
+    discardRunResultsRef.current = false
 
     const gateways = form.eligible_gateways.split(',').map(s => s.trim()).filter(Boolean)
     // Seed from the completed rows on resume so new transactions append rather than replace.
@@ -2386,6 +2448,8 @@ export function DecisionSimulatorPage() {
       // Commit the accumulated rows + refresh the events feed, throttled so a fast loop can't
       // spam re-renders (force=true bypasses the throttle for pause/end-of-run flushes).
       const flushResults = (force: boolean) => {
+        // The user cleared the results mid-run — this run's rows are no longer wanted on screen.
+        if (discardRunResultsRef.current) return
         const now = Date.now()
         if (force || now - lastUIUpdate > 150) {
           setSimulationResults([...results])
@@ -2449,7 +2513,7 @@ export function DecisionSimulatorPage() {
         return
       }
     } finally {
-      setSimulationResults([...results])
+      if (!discardRunResultsRef.current) setSimulationResults([...results])
       setIsSimulating(false)
       setIsPaused(false)
       simulationPausedRef.current = false
@@ -2615,6 +2679,24 @@ export function DecisionSimulatorPage() {
     () => form.eligible_gateways.split(',').map(s => s.trim().toLowerCase()).filter(Boolean),
     [form.eligible_gateways],
   )
+
+  // Processors we already know something about, offered as one-click options in the add modal so the
+  // common case isn't a spelling exercise. Two sources, both meaningful here because they're exactly
+  // what the sim can price: the merchant's contract-rate seeds, and anything we've fitted a cost
+  // model for from ingested reports. Ones already in the comparison are dropped — adding them again
+  // is a no-op the modal would only reject.
+  const addableConnectorOptions = useMemo(() => {
+    const withCostModel = new Set(ingestedConnectors)
+    const inComparison = new Set(eligibleGatewaysParsed)
+    const names = new Set<string>([
+      ...seedRows.map(r => r.psp.trim().toLowerCase()).filter(Boolean),
+      ...withCostModel,
+    ])
+    return [...names]
+      .filter(name => !inComparison.has(name))
+      .sort()
+      .map(name => ({ name, hasCostModel: withCostModel.has(name) }))
+  }, [seedRows, ingestedConnectors, eligibleGatewaysParsed])
 
   const gatewayColorMap = useMemo(
     () => Object.fromEntries(eligibleGatewaysParsed.map((gw, i) => [gw, GW_COLOR_OVERRIDES[gw.toLowerCase()] ?? GW_PALETTE[i % GW_PALETTE.length]])),
@@ -3152,26 +3234,76 @@ export function DecisionSimulatorPage() {
     setPreviewInspectorTab('summary')
   }
 
+  // Reset form fields to the first available option from routing config so
+  // required fields like currency are never sent as empty strings.
+  function populatedForm(base: FormState): FormState {
+    const next = { ...base }
+    if (currencyOptions.length > 0 && !currencyOptions.includes(next.currency))
+      next.currency = currencyOptions[0]
+    if (paymentMethodTypeOptions.length > 0 && !paymentMethodTypeOptions.includes(next.payment_method_type))
+      next.payment_method_type = paymentMethodTypeOptions[0]
+    const methodsForType = toUpperOptions(routingKeysConfig[next.payment_method_type.toLowerCase()]?.values || [])
+    if (methodsForType.length > 0 && !methodsForType.includes(next.payment_method))
+      next.payment_method = methodsForType[0]
+    if (authTypeOptions.length > 0 && !authTypeOptions.includes(next.auth_type))
+      next.auth_type = authTypeOptions[0]
+    if (cardBrandOptions.length > 0 && !cardBrandOptions.includes(next.card_brand))
+      next.card_brand = cardBrandOptions[0]
+    return next
+  }
+
+  // The batch tab's two halves clear independently, because wanting one rarely means wanting the
+  // other: retuning the controls shouldn't throw away the run you're comparing against, and
+  // clearing a finished run shouldn't undo the setup that produced it.
+
+  /** The control bar only — scenario inputs, amount range, TPS, retry, and the processor set. */
+  function resetBatchInputs() {
+    const defaults = getDefaultExplorerState()
+    setForm({ ...populatedForm(defaults.form), currency: MULTI_OBJECTIVE_CURRENCY })
+    setMoCurrency(MULTI_OBJECTIVE_CURRENCY)
+    setSimulationConfig(defaults.simulationConfig)
+    setMultiObjScenario(defaults.multiObjScenario)
+    // Drop any manually added/removed processors so the comparison returns to the default pair.
+    setExtraConnectors(defaults.extraConnectors)
+    setRemovedConnectors(defaults.removedConnectors)
+    setSmartRetryEnabled(defaults.smartRetryEnabled)
+    // Preserve the currently selected per-gateway success rate scores (e.g.
+    // Stripe/Adyen) across a reset — only clear the other sim config fields.
+    setGatewaySimConfigs(prev =>
+      Object.fromEntries(
+        Object.entries(prev).map(([gw, cfg]) => [
+          gw,
+          { ...DEFAULT_GW_SIM_CONFIG, successRate: cfg.successRate },
+        ]),
+      ),
+    )
+    setError(null)
+    setSetupPrompt(null)
+  }
+
+  /** Everything below the control bar — the charts, the summary column and the transaction log. */
+  function clearBatchResults() {
+    const defaults = getDefaultExplorerState()
+    setSimulationResults(defaults.simulationResults)
+    setResumableRun(defaults.resumableRun)
+    // Abort any in-flight run and drop the run-start timestamp so the
+    // Autopilot Actions feed (scoped to simulationStartedAtMs) clears back
+    // to its empty state instead of replaying the previous run's events.
+    simulationAbortRef.current = true
+    // Aborted workers still unwind through the loop's final flush, which would put the rows we
+    // just cleared straight back; this tells that run to drop them.
+    discardRunResultsRef.current = true
+    setSimulationStartedAtMs(null)
+    setIsSimulating(false)
+    setIsPaused(false)
+    simulationPausedRef.current = false
+    // The log's column filters describe rows that no longer exist.
+    setTxFilters({})
+    setError(null)
+  }
+
   function resetCurrentTabState() {
     const defaults = getDefaultExplorerState()
-
-    // Reset form fields to the first available option from routing config so
-    // required fields like currency are never sent as empty strings.
-    function populatedForm(base: FormState): FormState {
-      const next = { ...base }
-      if (currencyOptions.length > 0 && !currencyOptions.includes(next.currency))
-        next.currency = currencyOptions[0]
-      if (paymentMethodTypeOptions.length > 0 && !paymentMethodTypeOptions.includes(next.payment_method_type))
-        next.payment_method_type = paymentMethodTypeOptions[0]
-      const methodsForType = toUpperOptions(routingKeysConfig[next.payment_method_type.toLowerCase()]?.values || [])
-      if (methodsForType.length > 0 && !methodsForType.includes(next.payment_method))
-        next.payment_method = methodsForType[0]
-      if (authTypeOptions.length > 0 && !authTypeOptions.includes(next.auth_type))
-        next.auth_type = authTypeOptions[0]
-      if (cardBrandOptions.length > 0 && !cardBrandOptions.includes(next.card_brand))
-        next.card_brand = cardBrandOptions[0]
-      return next
-    }
 
     if (activeTab === 'single') {
       setForm(populatedForm(defaults.form))
@@ -3180,31 +3312,9 @@ export function DecisionSimulatorPage() {
       setSingleRunOutcome(defaults.singleRunOutcome)
       setResponseOpen(defaults.responseOpen)
     } else if (activeTab === 'batch') {
-      setForm({ ...populatedForm(defaults.form), currency: MULTI_OBJECTIVE_CURRENCY })
-      setMoCurrency(MULTI_OBJECTIVE_CURRENCY)
-      setSimulationConfig(defaults.simulationConfig)
-      setMultiObjScenario(defaults.multiObjScenario)
-      // Drop any manually added/removed processors so the comparison returns to the default pair.
-      setExtraConnectors(defaults.extraConnectors)
-      setRemovedConnectors(defaults.removedConnectors)
-      // Preserve the currently selected per-gateway success rate scores (e.g.
-      // Stripe/Adyen) across a reset — only clear the other sim config fields.
-      setGatewaySimConfigs(prev =>
-        Object.fromEntries(
-          Object.entries(prev).map(([gw, cfg]) => [
-            gw,
-            { ...DEFAULT_GW_SIM_CONFIG, successRate: cfg.successRate },
-          ]),
-        ),
-      )
-      setSimulationResults(defaults.simulationResults)
-      setResumableRun(defaults.resumableRun)
-      // Abort any in-flight run and drop the run-start timestamp so the
-      // Autopilot Actions feed (scoped to simulationStartedAtMs) clears back
-      // to its empty state instead of replaying the previous run's events.
-      simulationAbortRef.current = true
-      setSimulationStartedAtMs(null)
-      setIsSimulating(false)
+      // The batch tab's own bar exposes these two separately; "reset the tab" is just both.
+      resetBatchInputs()
+      clearBatchResults()
     } else if (activeTab === 'rule') {
       setRuleResetSignal(n => n + 1)
     } else if (activeTab === 'volume') {
@@ -3238,13 +3348,13 @@ export function DecisionSimulatorPage() {
   }
 
   const resetButtonLabel =
-    activeTab === 'batch'
-      ? 'Reset'
-      : activeTab === 'rule'
-        ? 'Reset Rule Based Routing'
-        : activeTab === 'volume'
-          ? 'Reset Volume Based Routing'
-          : 'Reset Debit Routing'
+    activeTab === 'rule'
+      ? 'Reset Rule Based Routing'
+      : activeTab === 'volume'
+        ? 'Reset Volume Based Routing'
+        : activeTab === 'debit'
+          ? 'Reset Debit Routing'
+          : 'Reset'
 
   return (
     <div className="mx-auto max-w-[1500px] space-y-5">
@@ -3289,17 +3399,71 @@ export function DecisionSimulatorPage() {
           <div className="relative w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl outline-none dark:border-[#2a303a] dark:bg-[#0d1118]">
             <h3 className="text-sm font-semibold text-slate-900 dark:text-white">Add a processor</h3>
             <p className="mt-2 text-sm leading-relaxed text-slate-500 dark:text-[#8a93a6]">
-              Enter a connector name (e.g. <span className="font-medium">braintree</span>,{' '}
-              <span className="font-medium">worldpay</span>). It joins the comparison with its own SR
-              slider — scored on its ingested cost model if it has one, otherwise seed costs.
+              {addableConnectorOptions.length > 0
+                ? 'Pick a processor we can already price, or type any other connector name. It joins the comparison with its own SR slider — scored on its ingested cost model if it has one, otherwise seed costs.'
+                : 'Enter a connector name (e.g. braintree, worldpay). It joins the comparison with its own SR slider — scored on its ingested cost model if it has one, otherwise seed costs.'}
             </p>
+
+            {/* Known processors as pickable options. Selecting one fills the field below rather than
+                adding straight away, so there's a single commit path (and the exact name that will
+                be saved is always visible before you commit). */}
+            {addableConnectorOptions.length > 0 && (
+              <div className="mt-4">
+                <span className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                  Known processors
+                </span>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {addableConnectorOptions.map(({ name, hasCostModel }) => {
+                    const selected = newConnectorName.trim().toLowerCase() === name
+                    return (
+                      <button
+                        key={name}
+                        type="button"
+                        onClick={() => {
+                          setNewConnectorName(name)
+                          setAddConnectorError(null)
+                        }}
+                        onDoubleClick={submitAddConnector}
+                        aria-pressed={selected}
+                        title={
+                          hasCostModel
+                            ? `${name} — has a fitted cost model from ingested reports`
+                            : `${name} — priced from your contract seed rates`
+                        }
+                        className={`rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ${
+                          selected
+                            ? 'border-brand-500/50 bg-brand-500/10 text-brand-600 dark:text-brand-400'
+                            : 'border-slate-200 text-slate-600 hover:bg-slate-50 dark:border-[#2a303a] dark:text-[#9ca7ba] dark:hover:bg-white/5'
+                        }`}
+                      >
+                        {name}
+                        {hasCostModel && (
+                          <span
+                            className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 align-middle"
+                            aria-hidden
+                          />
+                        )}
+                      </button>
+                    )
+                  })}
+                </div>
+                <p className="mt-1.5 text-[11px] text-slate-400">
+                  <span className="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 align-middle" />
+                  has a fitted cost model; the rest use contract seed rates.
+                </p>
+              </div>
+            )}
+
             <input
               autoFocus
               type="text"
               value={newConnectorName}
-              placeholder="Connector name"
+              placeholder={addableConnectorOptions.length > 0 ? 'Or type a connector name' : 'Connector name'}
+              // Connector names are lowercase identifiers everywhere else in the engine, so fold the
+              // case as it's typed — what you see is then exactly what gets saved, and a typed name
+              // still lights up its matching option above.
               onChange={e => {
-                setNewConnectorName(e.target.value)
+                setNewConnectorName(e.target.value.toLowerCase())
                 if (addConnectorError) setAddConnectorError(null)
               }}
               onKeyDown={e => {
@@ -3335,6 +3499,22 @@ export function DecisionSimulatorPage() {
 
       {activeTab === 'batch' && (
         <div className="flex flex-wrap items-start gap-x-6 gap-y-4 rounded-2xl border border-slate-200 bg-white px-5 py-3 dark:border-[#222226] dark:bg-[#0b0b10]">
+            {/* Own row at the container's top-right: `w-full` makes the wrap break after it, which
+                keeps the reset out of the action cluster (whose buttons bottom-align with the input
+                row) instead of absolutely positioning it into that cluster's space. Scoped to the
+                controls in this container — the results below have their own Clear. */}
+            <div className="-mb-2 flex w-full justify-end">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={resetBatchInputs}
+                title="Restore the controls in this panel to their defaults (per-processor success rates are kept). Leaves the results below untouched."
+              >
+                <RefreshCw size={14} />
+                Reset inputs
+              </Button>
+            </div>
+
             {/* One SR slider per eligible connector. In cost mode the eligible set is driven by the
                 merchant's ingested connectors (see the seeding effect), so these follow suit instead
                 of a hardcoded stripe+adyen pair. */}
@@ -3350,10 +3530,11 @@ export function DecisionSimulatorPage() {
                   <div className="flex items-center gap-1.5">
                     <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: color }} />
                     <SurfaceLabel>{label}</SurfaceLabel>
-                    {/* Any connector can be removed (default, ingested or user-added), but keep at
-                        least two so the routing comparison stays meaningful, and don't mutate the
-                        eligible set mid-run. */}
-                    {eligibleGatewaysParsed.length > 2 && !isSimulating && (
+                    {/* Any connector can be removed (default, ingested or user-added), down to a
+                        single one — a one-processor run is a legitimate baseline, so we only stop
+                        you from emptying the eligible set entirely. Hidden mid-run so a simulation
+                        can't have the set pulled out from under it. */}
+                    {eligibleGatewaysParsed.length > 1 && !isSimulating && (
                       <button
                         type="button"
                         onClick={() => removeConnector(key)}
@@ -3500,32 +3681,37 @@ export function DecisionSimulatorPage() {
             {SHOW_AMOUNT_RANGE_SLIDER && (() => {
               const BMIN = SIMULATION_AMOUNT_BOUND_MIN
               const BMAX = SIMULATION_AMOUNT_BOUND_MAX
-              const clamp = (v: number) => Math.max(BMIN, Math.min(BMAX, v))
               // Direct min/max number entry is easier to fine-tune than dragging two
-              // overlapped range thumbs. Cross-clamp on blur so min never exceeds max
-              // (and vice versa) without fighting the user mid-keystroke.
-              const inputCls = 'w-full rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm font-semibold tabular-nums text-slate-800 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0d0d13] dark:text-slate-100'
+              // overlapped range thumbs. Both the bound clamp and the cross-clamp (min never
+              // exceeds max, and vice versa) land on blur so neither fights the user
+              // mid-keystroke — see AmountBoundInput.
+              // Spinners are hidden: at step=5 they're a slow way to cross a 1–100,000 range, and
+              // the pair is narrow enough that two sets of arrows crowd out the digits. Typing (and
+              // ↑/↓, which the spinners only duplicate) still works.
+              const inputCls = 'w-full rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm font-semibold tabular-nums text-slate-800 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0d0d13] dark:text-slate-100 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
               return (
                 <div className="flex w-[220px] flex-col gap-1.5">
                   <SurfaceLabel>
                     <span title="Per-transaction amount range (multi-objective sim). Each payment's amount is drawn uniformly from this range. Smaller amounts make the flat per-txn fee a bigger share of cost. Applies on the next run.">Amount range ({moCurrency})</span>
                   </SurfaceLabel>
                   <div className="flex items-center gap-1.5">
-                    <input
-                      type="number" min={BMIN} max={BMAX} step={5}
-                      aria-label="Minimum amount"
+                    <AmountBoundInput
+                      ariaLabel="Minimum amount"
                       value={simulationConfig.minAmount}
-                      onChange={e => setSimulationConfig(c => ({ ...c, minAmount: e.target.value === '' ? BMIN : clamp(Number(e.target.value)) }))}
-                      onBlur={() => setSimulationConfig(c => ({ ...c, minAmount: Math.min(c.minAmount, c.maxAmount) }))}
+                      min={BMIN}
+                      max={BMAX}
+                      onCommit={next => setSimulationConfig(c => ({ ...c, minAmount: next }))}
+                      onSettle={() => setSimulationConfig(c => ({ ...c, minAmount: Math.min(c.minAmount, c.maxAmount) }))}
                       className={inputCls}
                     />
                     <span className="shrink-0 text-xs text-slate-400">–</span>
-                    <input
-                      type="number" min={BMIN} max={BMAX} step={5}
-                      aria-label="Maximum amount"
+                    <AmountBoundInput
+                      ariaLabel="Maximum amount"
                       value={simulationConfig.maxAmount}
-                      onChange={e => setSimulationConfig(c => ({ ...c, maxAmount: e.target.value === '' ? BMAX : clamp(Number(e.target.value)) }))}
-                      onBlur={() => setSimulationConfig(c => ({ ...c, maxAmount: Math.max(c.minAmount, c.maxAmount) }))}
+                      min={BMIN}
+                      max={BMAX}
+                      onCommit={next => setSimulationConfig(c => ({ ...c, maxAmount: next }))}
+                      onSettle={() => setSimulationConfig(c => ({ ...c, maxAmount: Math.max(c.minAmount, c.maxAmount) }))}
                       className={inputCls}
                     />
                   </div>
@@ -3548,11 +3734,6 @@ export function DecisionSimulatorPage() {
                   <SlidersHorizontal size={14} />
                   {showMoreInputs ? 'Less' : 'More'}
                 </Button>
-
-                <Button size="sm" variant="secondary" onClick={resetCurrentTabState}>
-          <RefreshCw size={14} />
-          {resetButtonLabel}
-        </Button>
 
                 {!isSimulating ? (
                   resumableRun ? (
@@ -4394,6 +4575,14 @@ export function DecisionSimulatorPage() {
                 </Button>
               </>
             )}
+            {/* These tabs are a single form + its response, so one reset for both is the right
+                granularity — the batch tab is the one that splits it in two. */}
+            <div className="flex justify-end">
+              <Button size="sm" variant="ghost" onClick={resetCurrentTabState}>
+                <RefreshCw size={14} />
+                {resetButtonLabel}
+              </Button>
+            </div>
           </div>
         </Card>
         )}
@@ -4402,12 +4591,34 @@ export function DecisionSimulatorPage() {
         <div className={`min-w-0 flex flex-col gap-4 ${activeTab === 'batch' ? 'lg:min-h-0' : ''}`}>
           {activeTab === 'batch' && (
             <div className="flex flex-col justify-center gap-5 rounded-2xl border border-slate-200 bg-white px-5 py-4 dark:border-[#222226] dark:bg-[#0b0b10]">
+              {/* Clears this whole lower half — these stats, the charts and the transaction log — and
+                  nothing in the control bar. Shown whenever there is anything to clear, including
+                  mid-run: clearBatchResults aborts the run first, so it stays coherent, and gating on
+                  !isSimulating stranded the button for the whole run (and forever while a run sat
+                  paused, since a pause keeps isSimulating true).
+
+                  Pulled into the card's own padding on three sides (it's a ghost button, so there's no
+                  background to look clipped) — that tucks it into the corner and collapses the empty
+                  band it would otherwise open up above the first stat row. */}
+              {hasSimulationActivity && (
+                <div className="-mb-3 -mr-2 -mt-2 flex justify-end">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={clearBatchResults}
+                    title="Clear these stats, the charts and the transaction log. Leaves the controls above untouched."
+                  >
+                    <Trash2 size={14} />
+                    Clear
+                  </Button>
+                </div>
+              )}
               {(() => {
                 const ccy = costEconomics.currency || form.currency || 'USD'
                 return (
                   <>
                   {/* Row 1 — auth-rate & realized cost */}
-                    <div className="grid grid-cols-3 gap-4 border-t border-slate-100 pt-4 dark:border-[#1c1c24]">
+                    <div className="grid grid-cols-3 gap-4">
                       <div className="flex flex-col gap-1.5" title="First Attempt Auth Rate — share of decisions charged on the first attempt (first-attempt charges ÷ total decisions).">
                         <StatLabel label="First-attempt auth rate" abbr="FAAR" />
                         <p className="py-1.5 text-lg font-semibold leading-snug tabular-nums text-sky-600 dark:text-sky-400">

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -3558,12 +3558,14 @@ export function DecisionSimulatorPage() {
       )}
 
       {activeTab === 'batch' && (
-        <div className="flex flex-wrap items-start gap-x-6 gap-y-4 rounded-2xl border border-slate-200 bg-white px-5 py-3 dark:border-[#222226] dark:bg-[#0b0b10]">
+        <div className="flex flex-wrap items-start gap-x-6 gap-y-3 rounded-2xl border border-slate-200 bg-white px-5 py-3 dark:border-[#222226] dark:bg-[#0b0b10]">
             {/* Own row at the container's top-right: `w-full` makes the wrap break after it, which
-                keeps the reset out of the action cluster (whose buttons bottom-align with the input
-                row) instead of absolutely positioning it into that cluster's space. Scoped to the
-                controls in this container — the results below have their own Clear. */}
-            <div className="-mb-2 flex w-full justify-end">
+                keeps the reset out of the action cluster instead of absolutely positioning it into
+                that cluster's space. Pulled into the card's padding on three sides (ghost button, so
+                there's no background to look clipped) so it tucks into the corner rather than opening
+                a band above the inputs. Scoped to the controls in this container — the results below
+                have their own Clear. */}
+            <div className="-mb-1 -mr-2 -mt-2 flex w-full justify-end">
               <Button
                 size="sm"
                 variant="ghost"
@@ -3779,12 +3781,11 @@ export function DecisionSimulatorPage() {
               )
             })()}
 
-            {/* Action cluster, pushed to the trailing edge. The invisible spacer matches the
-                SurfaceLabel height (leading-4 = 16px) so the control row lines up with the
-                SR inputs / Card scenario select rather than bottom-aligning under the sliders. */}
-            <div className="flex flex-col gap-1.5 lg:ml-auto">
-              <span className="block h-4" aria-hidden />
-              <div className="flex flex-wrap items-center gap-3">
+            {/* Action cluster, pushed to the trailing edge. `self-end` bottom-aligns it with the
+                input row it shares a line with — the same effect the old invisible SurfaceLabel-height
+                spacer had, but without carrying 22px of dead space above the buttons once the cluster
+                wraps onto a line of its own (where the spacer aligned it with nothing). */}
+            <div className="flex flex-wrap items-center gap-3 self-end lg:ml-auto">
                 <Button
                   size="sm"
                   variant="ghost"
@@ -3838,7 +3839,6 @@ export function DecisionSimulatorPage() {
                     </Button>
                   </>
                 )}
-              </div>
             </div>
           </div>
       )}

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -1194,10 +1194,16 @@ export function DecisionSimulatorPage() {
   const eliminationEnabled = Object.values(gatewaySimConfigs).some(c => c.failureMode === 'timeout')
   const simulationAbortRef = useRef(false)
   useEffect(() => () => { simulationAbortRef.current = true }, [])
-  // Set when the results are cleared out from under a live run. Aborting alone isn't enough: the
-  // run loop owns a local `results` array and flushes it into state as it goes and once more on the
-  // way out, so without this the cleared transaction log would repopulate a moment later.
-  const discardRunResultsRef = useRef(false)
+  /**
+   * Bumped on every run start, and by anything that discards a run outright (Clear results, a
+   * merchant-scope switch). A run captures the value at entry and only touches shared state while it
+   * still matches, which `simulationAbortRef` alone cannot express: the abort flag is reset to false
+   * at the top of the next run, so workers parked in an `await` would wake up, see it cleared and
+   * carry on — two live runs interleaving rows into the same state and both posting real feedback to
+   * the engine. The token can only move forward, so a superseded run can never mistake itself for
+   * the current one.
+   */
+  const runGenerationRef = useRef(0)
 
   const [debitForm, setDebitForm] = useState<DebitRoutingFormState>(initialState.debitForm)
 
@@ -1690,6 +1696,9 @@ export function DecisionSimulatorPage() {
     setSetupPrompt(null)
     setLoading(false)
     simulationAbortRef.current = true
+    // Retire the run as well as aborting it — see runGenerationRef. Without this, a worker parked in
+    // a request would resume once the next run clears the abort flag.
+    runGenerationRef.current++
     setIsSimulating(false)
   }
 
@@ -1740,6 +1749,9 @@ export function DecisionSimulatorPage() {
     setSetupPrompt(null)
     setLoading(false)
     simulationAbortRef.current = true
+    // Retire the run as well as aborting it — see runGenerationRef. Without this, a worker parked in
+    // a request would resume once the next run clears the abort flag.
+    runGenerationRef.current++
     setIsSimulating(false)
   }
 
@@ -2269,7 +2281,10 @@ export function DecisionSimulatorPage() {
     setSetupPrompt(null)
     if (!isResume) setSimulationResults([])
     simulationAbortRef.current = false
-    discardRunResultsRef.current = false
+    // Claim ownership of the shared run state. Any earlier run still unwinding is now superseded and
+    // will drop out of its loop without writing.
+    const runId = ++runGenerationRef.current
+    const isCurrentRun = () => runGenerationRef.current === runId
 
     const gateways = form.eligible_gateways.split(',').map(s => s.trim()).filter(Boolean)
     // Seed from the completed rows on resume so new transactions append rather than replace.
@@ -2448,8 +2463,9 @@ export function DecisionSimulatorPage() {
       // Commit the accumulated rows + refresh the events feed, throttled so a fast loop can't
       // spam re-renders (force=true bypasses the throttle for pause/end-of-run flushes).
       const flushResults = (force: boolean) => {
-        // The user cleared the results mid-run — this run's rows are no longer wanted on screen.
-        if (discardRunResultsRef.current) return
+        // Superseded — the results were cleared, or a newer run owns the screen now. Either way this
+        // run's rows are not wanted.
+        if (!isCurrentRun()) return
         const now = Date.now()
         if (force || now - lastUIUpdate > 150) {
           setSimulationResults([...results])
@@ -2464,14 +2480,17 @@ export function DecisionSimulatorPage() {
 
       const worker = async (): Promise<void> => {
         while (true) {
-          if (simulationAbortRef.current) return
+          // The generation check is what stops a superseded run: a worker parked in `runTxn` misses
+          // the abort flag entirely, and by the time it wakes the next run may have already cleared
+          // that flag — without this it would keep claiming indices and hitting the real API.
+          if (simulationAbortRef.current || !isCurrentRun()) return
           // Idle here while paused — without claiming new work — so the in-flight requests drain
           // and the resume index stays put; a Stop still breaks out. Flush once on the way in so a
           // page-leave/return resumes from exactly the committed rows.
           if (simulationPausedRef.current) {
             runProgressRef.current = results.length
             flushResults(true)
-            while (simulationPausedRef.current && !simulationAbortRef.current) {
+            while (simulationPausedRef.current && !simulationAbortRef.current && isCurrentRun()) {
               await new Promise(resolve => setTimeout(resolve, 120))
             }
             continue
@@ -2497,6 +2516,9 @@ export function DecisionSimulatorPage() {
             await new Promise(resolve => setTimeout(resolve, 300))
           }
 
+          // The row landed after this run was superseded: drop it rather than move the shared resume
+          // point, which now belongs to whichever run replaced this one.
+          if (!isCurrentRun()) return
           // Record the resume point as the committed count and flush on the shared throttle.
           runProgressRef.current = results.length
           flushResults(false)
@@ -2508,16 +2530,23 @@ export function DecisionSimulatorPage() {
       await Promise.all(Array.from({ length: concurrency }, () => worker()))
 
       // If a worker tripped the error threshold (as opposed to a user Stop), surface the failure.
-      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+      // Not ours to report if this run was already discarded.
+      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS && isCurrentRun()) {
         handleRunError(lastError, 'batch', `Simulation stopped after ${MAX_CONSECUTIVE_ERRORS} consecutive errors. Check that the server is running.`)
         return
       }
     } finally {
-      if (!discardRunResultsRef.current) setSimulationResults([...results])
-      setIsSimulating(false)
-      setIsPaused(false)
-      simulationPausedRef.current = false
-      // Final flush: events from the last txns can land just after the loop ends.
+      // A superseded run must not write any of this: its rows are stale, and `isSimulating` /
+      // `isPaused` now describe the run that replaced it — flipping them here is what let the old
+      // run hide a live run's Stop button and re-offer Run simulation.
+      if (isCurrentRun()) {
+        setSimulationResults([...results])
+        setIsSimulating(false)
+        setIsPaused(false)
+        simulationPausedRef.current = false
+      }
+      // Events from the last txns can land just after the loop ends. Safe either way — it only
+      // refetches the feed.
       routingEvents.refresh()
     }
   }
@@ -3290,9 +3319,11 @@ export function DecisionSimulatorPage() {
     // Autopilot Actions feed (scoped to simulationStartedAtMs) clears back
     // to its empty state instead of replaying the previous run's events.
     simulationAbortRef.current = true
-    // Aborted workers still unwind through the loop's final flush, which would put the rows we
-    // just cleared straight back; this tells that run to drop them.
-    discardRunResultsRef.current = true
+    // Retire the run outright. Aborting alone isn't enough on two counts: its workers unwind through
+    // a final flush that would put the rows we just cleared straight back, and the next run resets
+    // the abort flag, which would let any worker still parked in a request resume against a run it
+    // no longer belongs to.
+    runGenerationRef.current++
     setSimulationStartedAtMs(null)
     setIsSimulating(false)
     setIsPaused(false)


### PR DESCRIPTION
## Summary

A batch of UI fixes and tweaks to the Decision Simulator, plus one consistency fix on the SR routing Cost tab. All frontend-only (`website/src/components/pages/`); no API or engine changes.

## SR routing — Cost tab

The Cost tab and the Manual tab each have a left section rail, built separately and drifted apart: Cost used a 184px column with the icon inline with the title, Manual a 220px column with the icon in its own gutter. Cost now matches Manual (column width, gap, icon size and placement), and the nested Data ingestion sub-rail indent was adjusted to keep its divider aligned with the larger icon.

Note: the previous inline-icon layout existed so the live hint line (`3 reports`, `94.2% volume covered`) got the rail's full width. With the icon in a gutter, the longest blurb — Costs' "Effective fees per connector — overrides, learned rates & contract baseline" — wraps to more lines than before. If that reads as too tall, the fix is to shorten that blurb rather than diverge the rails again.

## Decision Simulator

**Removing a processor down to one.** The `x` on a processor's success-rate card was gated on `eligibleGatewaysParsed.length > 2`, so with exactly two present it disappeared entirely. Now `> 1`, hiding only at one so the eligible set can't be emptied. No other change was needed — `removeConnector` was already source-agnostic, so the removal persists instead of being re-seeded.

**Amount range min/max inputs.** These clamped `e.target.value` into state on every keystroke, coercing an empty field to the bound. Clearing `100` re-rendered as `1`, so the next digits landed after it (`5000` became `15000`, then got pulled back by the clamp) — the field could never be empty, which is what made retyping impossible. A new `AmountBoundInput` holds the typed text while focused and only re-syncs to the canonical (clamped, cross-clamped) value on blur. It still commits a clamped number per keystroke, so a run started mid-edit can't draw from a NaN range. The number spinners are also hidden, using the same idiom as `DecisionExplorerPage.tsx`.

**Add-processor modal.** Known processors are now offered as pickable options — the union of the merchant's contract-rate seed PSPs and any connector with a fitted cost model, minus whatever is already in the comparison. A green dot marks the ones with a fitted model. Selecting fills the field rather than adding straight away, so there's a single commit path and the exact name being saved is visible; double-click adds directly. Free text still works, and is folded to lowercase as it's typed (it was already lowercased on save).

**Split reset.** The batch tab's single Reset became two, since wanting one rarely means wanting the other:

- **Reset inputs** (top-right of the control bar) — scenario form, currency, amount range, TPS, total payments, pinned card scenario, the processor set, and the retry toggle. Per-processor success rates are still preserved.
- **Clear** (top-right of the stats container) — simulation results, resumable-run snapshot, run-start timestamp (so the Autopilot Actions feed empties instead of replaying), and the transaction log's column filters, which described rows that no longer existed.

`resetCurrentTabState()`'s batch branch now calls both, so "reset the whole tab" is still expressible.

Clearing is available mid-run, which needed a fix to be correct: the run loop owns a local `results` array and pushes it into state every ~150ms and once more in its `finally`, so a mid-run clear would have wiped the log and had it repopulate as the aborted workers unwound. `discardRunResultsRef` (set by `clearBatchResults`, reset at the top of `runSimulation`) makes both flush points skip. `clearBatchResults` also clears the pause flags, so clearing while paused releases parked workers.

**Reset on the other tabs.** `resetButtonLabel` had branches for "Reset Rule Based Routing" / "Reset Volume Based Routing" / "Reset Debit Routing", but the only Reset button lived inside the batch control bar, so those labels could never render and `resetCurrentTabState`'s non-batch branches were unreachable. Once the batch bar moved to the two scoped buttons, that function had no caller at all (and `noUnusedLocals` rejects that), so it is now surfaced in the single/volume/debit form footer where those labels were clearly meant to go. The label chain is also fixed — it fell through to "Reset Debit Routing" on the single tab. The rule tab's form column is `display: none`, so it still shows no reset; `RuleEvaluationPanel` takes a `resetSignal` of its own.

## Testing

`npx tsc --noEmit` is clean. Not exercised in a running app — the areas most worth a manual look are the Cost rail's blurb wrapping, the spacing of the two relocated buttons, and clear-during-run.
