### PR TITLE
feat(workflow): add flat alias tags to nightly builds for single-repo registry mirroring

### DIFF
--- a/.github/workflows/NIGHTLY_BUILD_README.md
+++ b/.github/workflows/NIGHTLY_BUILD_README.md
@@ -35,6 +35,27 @@ docker pull ghcr.io/juspay/decision-engine/postgres:nightly-latest
 docker pull ghcr.io/juspay/decision-engine/groovy-runner:nightly-latest
 ```
 
+### Flat alias tags (for single-repository registries)
+
+The sub-images are additionally tagged on the **root** image with the sub-image
+name folded into the tag:
+
+```bash
+docker pull ghcr.io/juspay/decision-engine:postgres-nightly-2026.07.21
+docker pull ghcr.io/juspay/decision-engine:groovy-runner-nightly-2026.07.21
+```
+
+These exist for mirroring nightlies into registries that keep everything in a
+single repository (e.g. a central ECR repo). The source and destination
+`repo:tag` are then identical, so an image-copy job needs no name rewriting:
+
+```
+ghcr.io/juspay/decision-engine:postgres-nightly-2026.07.21  <registry>/decision-engine:postgres-nightly-2026.07.21
+```
+
+Note: a tag can never contain `:` — a destination like
+`decision-engine:postgres:nightly-2026.07.21` is an invalid Docker reference.
+
 ## Manual Trigger
 
 You can manually trigger a nightly build from the GitHub Actions UI:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -221,14 +221,21 @@ jobs:
       - name: Create multi-arch manifest
         run: |
           TAG_NAME="${{ needs.create-tag.outputs.tag_name }}"
-          
+
           # Create manifest for nightly tag
           docker buildx imagetools create --tag ghcr.io/${{ github.repository }}/postgres:${TAG_NAME} \
             ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-amd64 \
             ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-arm64
-          
+
           # Create manifest for nightly-latest
           docker buildx imagetools create --tag ghcr.io/${{ github.repository }}/postgres:nightly-latest \
+            ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-amd64 \
+            ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-arm64
+
+          # Flat alias on the root image for single-repository registries
+          # (e.g. a central ECR repo), where the sub-image name has to be
+          # folded into the tag: decision-engine:postgres-<tag>
+          docker buildx imagetools create --tag ghcr.io/${{ github.repository }}:postgres-${TAG_NAME} \
             ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-amd64 \
             ghcr.io/${{ github.repository }}/postgres:${TAG_NAME}-linux-arm64
 
@@ -309,6 +316,16 @@ jobs:
           cache-from: type=gha,scope=nightly-groovy
           cache-to: type=gha,scope=nightly-groovy,mode=max
 
+      - name: Create flat alias tag
+        run: |
+          TAG_NAME="${{ needs.create-tag.outputs.tag_name }}"
+
+          # Flat alias on the root image for single-repository registries
+          # (e.g. a central ECR repo), where the sub-image name has to be
+          # folded into the tag: decision-engine:groovy-runner-<tag>
+          docker buildx imagetools create --tag ghcr.io/${{ github.repository }}:groovy-runner-${TAG_NAME} \
+            ghcr.io/${{ github.repository }}/groovy-runner:${TAG_NAME}
+
   create-release:
     needs: [create-tag, create-postgres-manifest, create-mysql-manifest, build-groovy-image]
     runs-on: ubuntu-latest
@@ -334,8 +351,12 @@ jobs:
             - `ghcr.io/${{ github.repository }}/postgres:${{ needs.create-tag.outputs.tag_name }}`
             - `ghcr.io/${{ github.repository }}:${{ needs.create-tag.outputs.tag_name }}`
             - `ghcr.io/${{ github.repository }}/groovy-runner:${{ needs.create-tag.outputs.tag_name }}`
-            
+
             All images are also available with the `nightly-latest` tag.
+
+            Flat aliases on the root image (for copying into single-repository registries such as ECR, where source and destination `repo:tag` can then be identical):
+            - `ghcr.io/${{ github.repository }}:postgres-${{ needs.create-tag.outputs.tag_name }}`
+            - `ghcr.io/${{ github.repository }}:groovy-runner-${{ needs.create-tag.outputs.tag_name }}`
             
             ### Usage
             ```bash


### PR DESCRIPTION
## Problem

The nightly workflow publishes sub-images under nested GHCR paths (`ghcr.io/juspay/decision-engine/postgres:nightly-YYYY.MM.DD`). Mirroring these into a registry that keeps everything in a **single repository** (e.g. a central ECR repo) requires folding the sub-image name into the tag — and hand-writing that destination invites an invalid reference:

```
decision-engine:postgres:nightly-2026.08.03   ← two colons, tags cannot contain ':'
docker: Error parsing reference: ... invalid reference format
```

This is exactly how the daily nightly→ECR copy has been failing, while manually dash-joined tags (`postgres-v1.4.31`) copy fine.

## Solution

Publish **flat alias tags on the root image** alongside the existing tags, with the sub-image name already dash-folded:

- `ghcr.io/juspay/decision-engine:postgres-nightly-YYYY.MM.DD` (multi-arch, aliases `decision-engine/postgres:nightly-YYYY.MM.DD`)
- `ghcr.io/juspay/decision-engine:groovy-runner-nightly-YYYY.MM.DD` (aliases `decision-engine/groovy-runner:nightly-YYYY.MM.DD`)

A copy job can then use the **identical `repo:tag` on both sides** with no name rewriting:

```
ghcr.io/juspay/decision-engine:postgres-nightly-2026.08.03  <registry>/decision-engine:postgres-nightly-2026.08.03
```

No collision with existing root-repo tags (`nightly-YYYY.MM.DD` / `nightly-latest` for the MySQL variant remain unchanged).

## Changes

- `create-postgres-manifest`: one extra `docker buildx imagetools create` publishing the multi-arch flat alias on the root image
- `build-groovy-image`: new step publishing the groovy-runner flat alias on the root image
- Release notes now list the flat aliases; `NIGHTLY_BUILD_README.md` documents them

## Verification

- Workflow YAML parses cleanly; job/step structure verified
- `docker buildx imagetools create` from an existing pushed manifest is the same mechanism the workflow already uses for `nightly-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #362
