### PR TITLE
feat(auth): accept x-admin-secret as service-to-service auth on protected routes

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -58,6 +58,23 @@ pub async fn authenticate(
         }
     }
 
+    // Accept the shared admin secret (service-to-service callers such as Hyperswitch, which
+    // has no merchant api-key or dashboard session). Checked before the api-key compat mode so
+    // a wrong secret is always rejected. No AuthContext is inserted — like compat mode, these
+    // callers scope requests off the body/path, and extractors that require an AuthContext
+    // (e.g. analytics) keep rejecting them.
+    if let Some(provided) = req
+        .headers()
+        .get("x-admin-secret")
+        .and_then(|v| v.to_str().ok())
+    {
+        let expected = app_state.global_config.admin_secret.secret.peek();
+        if !expected.is_empty() && provided == expected {
+            return Ok(next.run(req).await);
+        }
+        return Ok((StatusCode::UNAUTHORIZED, "Invalid admin secret").into_response());
+    }
+
     if !app_state.global_config.api_key_auth_enabled {
         return Ok(next.run(req).await);
     }


### PR DESCRIPTION
## Description

Hyperswitch calls the Decision Engine on two auth levels, and an audit of every HS→DE call against this repo's route table shows the protected router is unreachable for it:

| HS calls | DE router | Auth required today |
|---|---|---|
| `decide-gateway`, `update-gateway-score` (payment-time) | protected | merchant api-key / dashboard JWT |
| `routing/evaluate`, `routing/create`, `routing/activate`, `routing/list/*`, `routing/hybrid` | protected | same |
| `rule/create` / `update` / `get` / `delete` | protected | same |
| `merchant-account/{id}` (delete) | protected | same |
| `merchant-account/create` | public | `x-admin-secret` (handler) |
| `auth/admin/merchant-token` | public | `x-admin-secret` (handler) |

Hyperswitch has no merchant api-key or dashboard session, so with `api_key_auth_enabled = true` (as on sandbox) every protected-route call above is rejected with 401 — including the payment-time `decide-gateway` calls.

This PR accepts the shared admin secret — the same credential already required by the admin endpoints — as service-to-service auth in the `authenticate` middleware:

- Checked after Bearer JWT, before the api-key compat-mode bypass, so a present-but-wrong secret is always rejected.
- Only honoured when the configured secret is non-empty.
- No `AuthContext` is inserted: like compat mode, service callers scope requests off the body/path, and extractors that require a context (analytics) continue to reject them.

Companion PR: juspay/hyperswitch#13539 configures Hyperswitch with `open_router.admin_secret` and sends the header on all Decision Engine calls.

## Motivation and Context

Enables `api_key_auth_enabled = true` on environments integrated with Hyperswitch without breaking payment-time routing, rule management, merchant provisioning, or the dashboard SSO redirect.

## How did you test it?

- `cargo check --no-default-features --features postgres` clean.
- Locally: with `api_key_auth_enabled = true` and `[admin_secret] secret = "test_admin"`, a `POST /decide-gateway` with `x-admin-secret: test_admin` passes; with a wrong/missing header it is rejected with 401; dashboard JWT and merchant api-key flows unchanged.



Closes #359
