### PR TITLE
feat: gate sample report behind app environment

### DIFF
--- a/website/src/components/pages/ManualReportUpload.tsx
+++ b/website/src/components/pages/ManualReportUpload.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../hooks/useCostRouting'
 import { Field, UPLOAD_CONNECTORS, inputClass } from './CostRoutingShared'
 import { ColumnMappingPanel } from './ColumnMappingPanel'
+import { sampleReportEnabled } from '../../lib/appConfig'
 
 type IngestMode = 'upload' | 'sample'
 
@@ -34,7 +35,7 @@ export function ManualReportUpload({ merchantId }: { merchantId?: string }) {
   const fileRef = useRef<HTMLInputElement>(null)
   // Sample-first: a merchant landing here usually has no report file to hand, so the default is the
   // path that works with nothing — run a curated sample end to end, then switch to a real upload.
-  const [mode, setMode] = useState<IngestMode>('sample')
+  const [mode, setMode] = useState<IngestMode>(sampleReportEnabled ? 'sample' : 'upload')
   const [connector, setConnector] = useState('adyen')
   const [account, setAccount] = useState('')
   const [file, setFile] = useState<File | null>(null)
@@ -207,34 +208,36 @@ export function ManualReportUpload({ merchantId }: { merchantId?: string }) {
       </CardHeader>
       <CardBody className="space-y-4">
         {/* Choose between a real file upload and a curated sample, for merchants without a report. */}
-        <div className="inline-flex rounded-lg border border-slate-200 p-0.5 dark:border-[#2a3344]">
-          {(
-            [
-              ['sample', 'Use a sample file'],
-              ['upload', 'Upload a file'],
-            ] as [IngestMode, string][]
-          ).map(([value, label]) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => {
-                setMode(value)
-                setError(null)
-              }}
-              className={
-                'rounded-md px-3 py-1.5 text-sm font-medium transition-colors ' +
-                (mode === value
-                  ? 'bg-brand-500 text-white'
-                  : 'text-slate-500 hover:text-slate-700 dark:text-[#9ca7ba] dark:hover:text-white')
-              }
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        {sampleReportEnabled && (
+          <div className="inline-flex rounded-lg border border-slate-200 p-0.5 dark:border-[#2a3344]">
+            {(
+              [
+                ['sample', 'Use a sample file'],
+                ['upload', 'Upload a file'],
+              ] as [IngestMode, string][]
+            ).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => {
+                  setMode(value)
+                  setError(null)
+                }}
+                className={
+                  'rounded-md px-3 py-1.5 text-sm font-medium transition-colors ' +
+                  (mode === value
+                    ? 'bg-brand-500 text-white'
+                    : 'text-slate-500 hover:text-slate-700 dark:text-[#9ca7ba] dark:hover:text-white')
+                }
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
         <p className="text-sm text-slate-500 dark:text-[#9ca7ba]">
           {mode === 'upload'
-            ? "Upload a settlement report file directly — no webhook needed. Processing runs in the background (the upload won't hang on large files); watch progress below and in the history."
+            ? "Upload a settlement report file directly - no webhook needed. Processing runs in the background (the upload won't hang on large files). Watch progress below and in the history."
             : `No report file? Run a curated ${connectorLabel} sample report through the exact same fit, so you can see the ingest → cost-coverage flow end to end. Progress shows below and in the history.`}
         </p>
         <Field label="Connector">

--- a/website/src/lib/appConfig.ts
+++ b/website/src/lib/appConfig.ts
@@ -7,3 +7,5 @@ export const isProduction = APP_ENV === 'production'
 export const signupEnabled = !isProduction
 
 export const simulatorEnabled = !isProduction
+
+export const sampleReportEnabled = !isProduction


### PR DESCRIPTION
This pull request updates the manual report upload flow to conditionally enable the sample report feature based on environment configuration. Now, the sample report option is only available in non-production environments, improving the user experience for production users and making the feature toggleable via configuration.

**Feature gating and environment-based configuration:**

* Added a new `sampleReportEnabled` export to `website/src/lib/appConfig.ts` to control the availability of the sample report feature based on environment (`!isProduction`).
* Updated the default ingest mode in `ManualReportUpload` to use `'sample'` only if `sampleReportEnabled` is true; otherwise, it defaults to `'upload'`.
* Conditionally rendered the sample/upload mode selection UI in `ManualReportUpload` only when `sampleReportEnabled` is true.
* Minor text update for clarity in the upload instructions.

**Imports and code organization:**

* Imported `sampleReportEnabled` in `ManualReportUpload.tsx` to support the new conditional logic.

### Screenshots

<img width="1728" height="995" alt="image" src="https://github.com/user-attachments/assets/2d89dbc6-26df-45d3-8855-c9fbadd38b31" />
