### PR TITLE
fix(website): hold on loader during SSO code exchange so it isn't lost to AuthGuard

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,5 +1,5 @@
 import { Navigate, Route, Routes } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { AnalyticsPage } from './components/pages/AnalyticsPage'
 import { DecisionExplorerPage } from './components/pages/DecisionExplorerPage'
 import { DecisionSimulatorPage } from './components/pages/DecisionSimulatorPage'
@@ -42,11 +42,20 @@ let hsSsoExchangeStarted = false
 export default function App() {
   const setAuth = useAuthStore((s) => s.setAuth)
   const setMerchantId = useMerchantStore((s) => s.setMerchantId)
+  // Hold the app on a loader while an SSO `?code=` is being exchanged. Without this, <Routes>
+  // (and AuthGuard) render immediately; AuthGuard's child effect navigates to /login and strips
+  // the code from the URL before this parent effect can read it, so the exchange never fires.
+  const [exchangingCode, setExchangingCode] = useState(
+    () => new URLSearchParams(window.location.search).has('code'),
+  )
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const code = params.get('code')
-    if (!code || hsSsoExchangeStarted) return
+    if (!code || hsSsoExchangeStarted) {
+      setExchangingCode(false)
+      return
+    }
     hsSsoExchangeStarted = true
 
     const stripCode = () => {
@@ -79,9 +88,18 @@ export default function App() {
         // AuthGuard redirect to login.
       } finally {
         stripCode()
+        setExchangingCode(false)
       }
     })()
   }, [setAuth, setMerchantId])
+
+  if (exchangingCode) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-white text-sm text-slate-600 dark:bg-[#030507] dark:text-[#c7cfdb]">
+        Signing you in…
+      </div>
+    )
+  }
 
   return (
     <Routes>


### PR DESCRIPTION
## Description

The Hyperswitch → Decision Engine dashboard SSO redirect lands the browser on `/decision-engine/<page>?code=<one-time-code>`, and `App` is supposed to exchange that code (`POST /auth/admin/merchant-token/exchange`) for a session before anything else renders.

But `App` rendered `<Routes>` immediately while the exchange ran async in the background. On first mount that means:

1. `<Routes>` → `AuthGuard` (a child) renders; there's no session token yet, so it returns `<Navigate to="/login">`.
2. React runs **child effects before parent effects**, so `Navigate`'s redirect to `/login` fires *first*, rewriting the URL and stripping `?code=`.
3. `App`'s exchange effect (the parent) then runs, reads `window.location.search`, finds no `code`, and returns early — the exchange endpoint is **never called**. The `catch {}` is silent, so the user just lands on the login/signup page.

This is deterministic (effect ordering), so the SSO redirect fails every time on a fresh load.

### Fix

Gate rendering on an `exchangingCode` flag seeded from whether `?code=` is present at mount, and show a "Signing you in…" loader until the exchange settles. While the flag is set, `<Routes>`/`AuthGuard` don't render, so nothing can redirect and clobber the code before the exchange runs. The flag clears in the effect's `finally` (and immediately on the no-code path).

## Motivation and Context

Without this, the entire dashboard SSO handoff is broken on any deployment: the code mints fine but is destroyed before it can be redeemed.

## How did you test it?

Diagnosed on sandbox: DE logs showed the SSO code mint returning `200` but **zero** browser exchange calls reaching DE, and the deployed bundle rendered `<Routes>` with no hold (confirmed the child-before-parent effect race). `tsc --noEmit` clean. With the loader hold, the exchange fires before any route renders and the redirect session is established.



Closes #358
