### PR TITLE
feat(routing): CockroachDB support, payment-audit trace fix, and cost-aware routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,31 @@ Open:
 
 For deployed docs or dashboard environments, use the same paths under your deployed host, e.g. `https://<docs-host>/api-refs/api-ref`.
 
+### CockroachDB
+
+CockroachDB is PostgreSQL wire-protocol compatible, so it runs on the existing `postgres` build,
+`migrations_pg`, and `pg_database` config — no separate feature or backend. The
+`docker-compose.cockroach.yml` overlay swaps the `postgresql` service for a single-node CockroachDB.
+
+Full local dev (the `oneclick.sh` flow), with CockroachDB instead of PostgreSQL:
+
+```bash
+./oneclick.sh --cockroach
+```
+
+The DB is published on host **26257** (CockroachDB's native port) so it coexists with a local
+PostgreSQL on 5432; `--cockroach` points the migrator, seed, and backend there automatically.
+
+Docker-only (app runs in-container against the CockroachDB service):
+
+```bash
+docker compose -f docker-compose.yaml -f docker-compose.cockroach.yml --profile postgres-local up -d
+```
+
+API stays on `http://localhost:8080`; the CockroachDB DB Console is at `http://localhost:8090`. For a
+secure cluster (e.g. CockroachDB Cloud), set `pg_sslmode` (and `pg_ssl_root_cert`) under
+`[pg_database]` in your config.
+
 ### From Source
 
 Prerequisites: Rust 1.85+, MySQL or PostgreSQL, Redis, [`just`](https://just.systems)

--- a/config/development.toml
+++ b/config/development.toml
@@ -204,6 +204,87 @@ tiers = [
 ]
 
 [[hypersense.seed_costs]]
+psp = "dlocal"                                 # Country-specific blended MDR 
+                                              # Varies by Local vs Cross-Border (FX)
+default = { pct_bps = 450.0, fixed = 0.30 }    # fallback = LATAM Local Credit Card 
+                                            # standard (4.50% + $0.30)
+tiers = [
+  # ====================================================================================
+  # LATIN AMERICA (LATAM) - Blended Country Card Footprints
+  # ====================================================================================
+
+  # --- BRAZIL (BR) --------------------------------------------------------------------
+  { card_issuing_country = "br", card_network = "visa",       payment_method_type = "debit",  pct_bps = 490.0, fixed = 0.00, label = "BR Domestic Visa Debit" },
+  { card_issuing_country = "br", card_network = "visa",       payment_method_type = "credit", pct_bps = 490.0, fixed = 0.00, label = "BR Domestic Visa Credit" },
+  { card_issuing_country = "br", card_network = "mastercard", payment_method_type = "debit",  pct_bps = 490.0, fixed = 0.00, label = "BR Domestic MC Debit" },
+  { card_issuing_country = "br", card_network = "mastercard", payment_method_type = "credit", pct_bps = 490.0, fixed = 0.00, label = "BR Domestic MC Credit" },
+  { card_issuing_country = "br", card_network = "elo",        payment_method_type = "credit", pct_bps = 490.0, fixed = 0.00, label = "BR Domestic Elo Card" },
+  { card_issuing_country = "br", card_network = "hipercard",  payment_method_type = "credit", pct_bps = 490.0, fixed = 0.00, label = "BR Domestic Hipercard" },
+
+  # --- ARGENTINA (AR) -----------------------------------------------------------------
+  { card_issuing_country = "ar", card_network = "visa",       payment_method_type = "credit", pct_bps = 650.0, fixed = 0.00, label = "AR Domestic Visa" },
+  { card_issuing_country = "ar", card_network = "mastercard", payment_method_type = "credit", pct_bps = 650.0, fixed = 0.00, label = "AR Domestic MC" },
+
+  # --- CHILE (CL) ---------------------------------------------------------------------
+  { card_issuing_country = "cl", card_network = "visa",       payment_method_type = "credit", pct_bps = 490.0, fixed = 0.00, label = "CL Domestic Visa" },
+  { card_issuing_country = "cl", card_network = "mastercard", payment_method_type = "credit", pct_bps = 490.0, fixed = 0.00, label = "CL Domestic MC" },
+
+  # --- COLOMBIA (CO) ------------------------------------------------------------------
+  { card_issuing_country = "co", card_network = "visa",       payment_method_type = "credit", pct_bps = 650.0, fixed = 0.00, label = "CO Domestic Visa" },
+  { card_issuing_country = "co", card_network = "mastercard", payment_method_type = "credit", pct_bps = 650.0, fixed = 0.00, label = "CO Domestic MC" },
+
+  # --- ECUADOR (EC) - Highest baseline card ceiling in LATAM --------------------------
+  { card_issuing_country = "ec", card_network = "visa",       payment_method_type = "credit", pct_bps = 1200.0, fixed = 0.00, label = "EC Domestic Visa" },
+  { card_issuing_country = "ec", card_network = "mastercard", payment_method_type = "credit", pct_bps = 1200.0, fixed = 0.00, label = "EC Domestic MC" },
+
+
+
+  # --- Mexico (MX) Domestic Cards using your exact Adyen parameters ------------------
+  { transaction_currency = "MXN", card_network = "visa",       payment_method_type = "debit",  pct_bps = 420.0, fixed = 0.00, label = "MX Domestic Visa Debit" },
+  { transaction_currency = "MXN", card_network = "visa",       payment_method_type = "credit", pct_bps = 420.0, fixed = 0.00, label = "MX Domestic Visa Credit" },
+  { transaction_currency = "MXN", card_network = "mastercard", payment_method_type = "debit",  pct_bps = 420.0, fixed = 0.00, label = "MX Domestic MC Debit" },
+  { transaction_currency = "MXN", card_network = "mastercard", payment_method_type = "credit", pct_bps = 420.0, fixed = 0.00, label = "MX Domestic MC Credit" },
+  { transaction_currency = "MXN", card_network = "carnet",    payment_method_type = "debit",  pct_bps = 420.0, fixed = 0.00, label = "MX Carnet Debit" },
+
+
+  # ====================================================================================
+  # ASIA PACIFIC (APAC) - Highly Competitive Dynamic High-Volume Rails
+  # ====================================================================================
+
+  # --- INDIA (IN) ---------------------------------------------------------------------
+  { card_issuing_country = "in", card_network = "rupay",      payment_method_type = "debit",  pct_bps = 90.0,  fixed = 0.00, label = "IN RuPay Local Debit" },
+  { card_issuing_country = "in", card_network = "visa",       payment_method_type = "debit",  pct_bps = 120.0, fixed = 0.00, label = "IN Visa Local Debit" },
+  { card_issuing_country = "in", card_network = "visa",       payment_method_type = "credit", pct_bps = 250.0, fixed = 0.00, label = "IN Visa Local Credit" },
+  { card_issuing_country = "in", card_network = "mastercard", payment_method_type = "credit", pct_bps = 250.0, fixed = 0.00, label = "IN MC Local Credit" },
+
+  # --- INDONESIA (ID) & MALAYSIA (MY) -------------------------------------------------
+  { card_issuing_country = "id", card_network = "visa",       payment_method_type = "credit", pct_bps = 450.0, fixed = 0.00, label = "ID Local Cards" },
+  { card_issuing_country = "my", card_network = "visa",       payment_method_type = "credit", pct_bps = 450.0, fixed = 0.00, label = "MY Local Cards" },
+
+
+  # ====================================================================================
+  # MIDDLE EAST & AFRICA (MEA)
+  # ====================================================================================
+
+  # --- NIGERIA (NG) -------------------------------------------------------------------
+  { card_issuing_country = "ng", card_network = "verve",      payment_method_type = "debit",  pct_bps = 250.0, fixed = 0.00, label = "NG Verve Local Card" },
+  { card_issuing_country = "ng", card_network = "visa",       payment_method_type = "credit", pct_bps = 390.0, fixed = 0.00, label = "NG Domestic Visa" },
+  { card_issuing_country = "ng", card_network = "mastercard", payment_method_type = "credit", pct_bps = 390.0, fixed = 0.00, label = "NG Domestic MC" },
+
+  # --- SOUTH AFRICA (ZA) --------------------------------------------------------------
+  { card_issuing_country = "za", card_network = "visa",       payment_method_type = "credit", pct_bps = 350.0, fixed = 0.00, label = "ZA Domestic Visa" },
+
+  # ====================================================================================
+  # CROSS-BORDER INTERNATIONAL FALLBACK
+  # ====================================================================================
+  # Triggers if a merchant processes inside an emerging market but the shopper uses a 
+  # foreign international card (e.g., US traveler using an American Visa card inside Peru).
+  { card_issuing_country = "intl", card_network = "visa",       payment_method_type = "credit", pct_bps = 650.0, fixed = 0.50, label = "Cross-Border Visa Pay-in" },
+  { card_issuing_country = "intl", card_network = "mastercard", payment_method_type = "credit", pct_bps = 650.0, fixed = 0.50, label = "Cross-Border MC Pay-in" }
+]
+
+
+[[hypersense.seed_costs]]
 psp = "tap"
 default = { interchange_bps = 100.0, scheme_bps = 12.0, markup_bps = 18.0, fixed = 0.30 }
 tiers = [

--- a/diesel_pg_cockroach.toml
+++ b/diesel_pg_cockroach.toml
@@ -1,0 +1,10 @@
+# Diesel CLI config for running the PostgreSQL migrations against CockroachDB.
+#
+# Identical to diesel_pg.toml but WITHOUT the [print_schema] section: after applying migrations,
+# diesel_cli regenerates the schema by reading information_schema, where CockroachDB returns
+# `character_maximum_length` as INT8 while diesel decodes it as i32 — so `diesel migration run`
+# fails with "Received more than 4 bytes while decoding an i32" even though the migrations applied.
+# The committed src/storage/schema_pg.rs (generated from PostgreSQL) is already correct for
+# CockroachDB, so schema regeneration is intentionally skipped here.
+[migrations_directory]
+dir = "migrations_pg"

--- a/docker-compose.cockroach.yml
+++ b/docker-compose.cockroach.yml
@@ -1,0 +1,95 @@
+# CockroachDB overlay for the Decision Engine.
+#
+# CockroachDB speaks the PostgreSQL wire protocol, so it reuses the existing `postgres` build,
+# `migrations_pg`, and the app's `pg_database` config — only the port differs. This CockroachDB build
+# refuses to listen on anything but its native port 26257 (it errors on other ports and on a literal
+# `0.0.0.0` host), so the DB runs on 26257 end to end. That also lets it coexist with a local
+# PostgreSQL on 5432. The in-docker app + migrator are repointed to 26257 here; the `oneclick.sh
+# --cockroach` flow does the same for the host-side tooling via env vars.
+#
+# Usage (mirrors the postgres profiles, e.g. postgres-local / postgres-ghcr / dashboard-*):
+#   docker compose -f docker-compose.yaml -f docker-compose.cockroach.yml --profile postgres-local up -d
+#
+# CockroachDB DB Console: http://localhost:8090
+
+services:
+  # Replace the PostgreSQL server with a single-node CockroachDB. Empty host (`:26257`) binds all
+  # interfaces; the port must be 26257 for this build.
+  postgresql:
+    image: cockroachdb/cockroach:v24.1.5
+    command: >-
+      start-single-node --insecure
+      --listen-addr=:26257
+      --http-addr=:8080
+    # 26257 coexists with a local PostgreSQL on 5432; DB Console on host 8090 stays clear of the app
+    # (8080) and dashboard nginx (8081). `!override` replaces the base service's `5432:5432` mapping
+    # instead of appending to it (which would keep publishing host 5432 and clash with PostgreSQL).
+    ports: !override
+      - "26257:26257"
+      - "8090:8080"
+    # `!override` so we don't also inherit the base service's postgres-data mount.
+    volumes: !override
+      - cockroach-data:/cockroach/cockroach-data
+    healthcheck:
+      test: ["CMD", "cockroach", "sql", "--insecure", "--host=127.0.0.1:26257", "-e", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # Create the database + role the app/migrator connect as. In insecure mode CockroachDB accepts any
+  # password but the role must exist; `public` schema privileges are no longer implicit, so grant them.
+  # The two role settings make CockroachDB match PostgreSQL's integer typing, which schema_pg.rs (and
+  # so the compiled backend) assumes: default_int_size=4 makes INTEGER/INT columns INT4 (CockroachDB
+  # defaults them to INT8), and serial_normalization='sql_sequence' makes SERIAL an INT4 sequence
+  # (CockroachDB's default `rowid` SERIAL is INT8). Set before migrations so tables are created with
+  # the right column widths; they also apply to the backend, which connects as the same role.
+  cockroach-init:
+    image: cockroachdb/cockroach:v24.1.5
+    profiles:
+      - postgres-ghcr
+      - dashboard-postgres-ghcr
+      - postgres-local
+      - dashboard-postgres-local
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        set -e
+        cockroach sql --insecure --host=postgresql:26257 -e "
+          CREATE DATABASE IF NOT EXISTS decision_engine_db;
+          CREATE USER IF NOT EXISTS db_user;
+          GRANT ALL ON DATABASE decision_engine_db TO db_user;
+          ALTER ROLE db_user SET default_int_size = 4;
+          ALTER ROLE db_user SET serial_normalization = 'sql_sequence';
+        "
+        cockroach sql --insecure --host=postgresql:26257 --database=decision_engine_db -e "
+          GRANT ALL ON SCHEMA public TO db_user;
+        "
+    networks:
+      - open-router-network
+
+  # Wait for the database + role to exist, point the migrations at 26257, and use the CockroachDB
+  # diesel config (no [print_schema] — see diesel_pg_cockroach.toml).
+  db-migrator-postgres:
+    depends_on:
+      cockroach-init:
+        condition: service_completed_successfully
+    environment:
+      - DATABASE_URL=postgresql://db_user:db_pass@postgresql:26257/decision_engine_db
+    command: "bash -c 'cargo install diesel_cli --no-default-features --features postgres && diesel migration run --database-url \"$$DATABASE_URL\" --migration-dir /app/migrations_pg --config-file /app/diesel_pg_cockroach.toml'"
+
+  # In-container app connects to CockroachDB on 26257 (config default is 5432). Only used by the
+  # docker-only run; oneclick runs the backend on the host and sets this via env instead.
+  open-router-pg-ghcr:
+    environment:
+      - DECISION_ENGINE__PG_DATABASE__PG_PORT=26257
+  open-router-pg-local:
+    environment:
+      - DECISION_ENGINE__PG_DATABASE__PG_PORT=26257
+
+volumes:
+  cockroach-data:

--- a/oneclick.sh
+++ b/oneclick.sh
@@ -18,18 +18,39 @@ ONECLICK_AUTO_CONFIRM="${ONECLICK_AUTO_CONFIRM:-0}"
 # parsing is ~10x slower, so large settlement uploads crawl. Pass `--release` (or ONECLICK_RELEASE=1)
 # to compile optimized: slower first build, dramatically faster ingestion/decide at runtime.
 ONECLICK_RELEASE="${ONECLICK_RELEASE:-0}"
+# Database engine for the postgres build. Both use the `postgres` feature and migrations_pg —
+# `cockroach` just swaps the dockerized DB (via the docker-compose.cockroach.yml overlay) for a
+# CockroachDB node, since CockroachDB is PostgreSQL wire-protocol compatible.
+ONECLICK_DB="${ONECLICK_DB:-postgres}"
 for arg in "$@"; do
     case "$arg" in
         --release) ONECLICK_RELEASE=1 ;;
         --debug) ONECLICK_RELEASE=0 ;;
+        --cockroach|--crdb) ONECLICK_DB=cockroach ;;
+        --postgres|--pg) ONECLICK_DB=postgres ;;
         -h|--help)
-            echo "Usage: ./oneclick.sh [--release|--debug]"
-            echo "  --release   build the backend optimized (fast runtime; e.g. ~10x faster report parsing)"
-            echo "  --debug     build the backend unoptimized (default; faster compile)"
+            echo "Usage: ./oneclick.sh [--release|--debug] [--cockroach|--postgres]"
+            echo "  --release     build the backend optimized (fast runtime; e.g. ~10x faster report parsing)"
+            echo "  --debug       build the backend unoptimized (default; faster compile)"
+            echo "  --cockroach   use CockroachDB instead of PostgreSQL (same postgres build + migrations)"
+            echo "  --postgres    use PostgreSQL (default)"
             exit 0
             ;;
     esac
 done
+
+# CockroachDB reuses everything (same postgres build, migrations_pg, db_user/db_pass/decision_engine_db);
+# COMPOSE_FILE makes every `docker compose` call below swap the `postgresql` service for CockroachDB.
+# Keep docker-compose.override.yml in the list so its (unrelated) tweaks still apply. The DB is
+# published on host 26257 (its native port) to coexist with a local PostgreSQL on 5432, so the
+# host-side tooling — migrate (DB_PORT), seed (POSTGRES_PORT), backend (pg_database.pg_port) — is
+# pointed there; inside the container CockroachDB still listens on 5432.
+if [ "${ONECLICK_DB}" = "cockroach" ]; then
+    export COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yaml:${SCRIPT_DIR}/docker-compose.override.yml:${SCRIPT_DIR}/docker-compose.cockroach.yml"
+    POSTGRES_PORT="${POSTGRES_PORT:-26257}"
+    export DB_PORT="${DB_PORT:-26257}"
+    export DECISION_ENGINE__PG_DATABASE__PG_PORT="${DECISION_ENGINE__PG_DATABASE__PG_PORT:-26257}"
+fi
 
 if [ "${ONECLICK_RELEASE}" -eq 1 ]; then
     CARGO_PROFILE_FLAG="--release"
@@ -286,8 +307,15 @@ SQL
     fi
 
     if docker compose ps -q postgresql >/dev/null 2>&1; then
+        # The CockroachDB container ships `cockroach sql`, not `psql`.
+        local db_cli
+        if [ "$ONECLICK_DB" = "cockroach" ]; then
+            db_cli=(cockroach sql --insecure --database="$POSTGRES_DB")
+        else
+            db_cli=(psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1)
+        fi
         if echo "$sql" | docker compose exec -T postgresql \
-            psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 >/dev/null 2>&1; then
+            "${db_cli[@]}" >/dev/null 2>&1; then
             echo "Global SR V3 configs seeded."
             echo ""
             return 0
@@ -296,6 +324,39 @@ SQL
 
     echo "  [warn] Could not seed global SR V3 configs (no psql and postgresql container unreachable)."
     echo "         Hedging will not work until these service_configuration rows exist."
+    echo ""
+    return 1
+}
+
+# Create the role + database the migrator/backend connect as. CockroachDB in insecure mode accepts
+# any password but the role must exist, and `public` schema privileges are no longer implicit.
+# Idempotent (IF NOT EXISTS), so it is safe to run on every bring-up.
+ensure_cockroach_db() {
+    echo "Ensuring CockroachDB database and role exist..."
+    if ! docker compose ps -q postgresql >/dev/null 2>&1; then
+        echo "  [warn] postgresql (CockroachDB) container not found — skipping. If a plain Postgres"
+        echo "         is already running on ${POSTGRES_PORT}, stop it and rerun with --cockroach."
+        echo ""
+        return 1
+    fi
+    # default_int_size=4 + serial_normalization='sql_sequence' make CockroachDB's integer typing match
+    # PostgreSQL/schema_pg.rs (INTEGER->INT4, SERIAL->INT4 sequence), so the backend decodes columns
+    # correctly. Set before migrations so tables get the right widths.
+    if docker compose exec -T postgresql cockroach sql --insecure -e "
+        CREATE DATABASE IF NOT EXISTS ${POSTGRES_DB};
+        CREATE USER IF NOT EXISTS ${POSTGRES_USER};
+        GRANT ALL ON DATABASE ${POSTGRES_DB} TO ${POSTGRES_USER};
+        ALTER ROLE ${POSTGRES_USER} SET default_int_size = 4;
+        ALTER ROLE ${POSTGRES_USER} SET serial_normalization = 'sql_sequence';
+    " >/dev/null 2>&1 &&
+       docker compose exec -T postgresql cockroach sql --insecure --database="${POSTGRES_DB}" -e "
+        GRANT ALL ON SCHEMA public TO ${POSTGRES_USER};
+    " >/dev/null 2>&1; then
+        echo "CockroachDB database and role ready."
+        echo ""
+        return 0
+    fi
+    echo "  [warn] Could not initialize CockroachDB (is the container CockroachDB, not Postgres?)."
     echo ""
     return 1
 }
@@ -585,7 +646,17 @@ if ! check_clickhouse_schema; then
 fi
 
 echo "Running Postgres migrations..."
-just migrate-pg
+if [ "${ONECLICK_DB}" = "cockroach" ]; then
+    ensure_cockroach_db
+    # Use the CockroachDB diesel config (no [print_schema]); diesel_cli's schema regeneration reads
+    # information_schema in a way CockroachDB returns as INT8-not-i32 and would fail post-migration.
+    diesel migration run \
+        --database-url "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}" \
+        --migration-dir "${SCRIPT_DIR}/migrations_pg" \
+        --config-file "${SCRIPT_DIR}/diesel_pg_cockroach.toml"
+else
+    just migrate-pg
+fi
 
 seed_global_configs
 
@@ -642,6 +713,11 @@ echo "=========================================="
 echo "  Decision Engine is starting up!"
 echo "=========================================="
 echo ""
+if [ "${ONECLICK_DB}" = "cockroach" ]; then
+    echo "  Database:     CockroachDB (localhost:${POSTGRES_PORT})  Console: http://localhost:8090"
+else
+    echo "  Database:     PostgreSQL (localhost:${POSTGRES_PORT})"
+fi
 echo "  Server:       http://localhost:8080"
 echo "  Dashboard:    http://localhost:5173/"
 echo "  Docs:         $DOCS_HOME_URL"

--- a/src/analytics/clickhouse/filters.rs
+++ b/src/analytics/clickhouse/filters.rs
@@ -110,6 +110,70 @@ pub fn payment_audit_raw_filters(
     filters
 }
 
+/// Filters for a single selected transaction's event timeline.
+///
+/// Unlike [`payment_audit_raw_filters`], this deliberately omits the per-event dimension filters
+/// (status, gateway, route, routing_approach/exclusion, error_code, specific flow_type). Those exist
+/// to *find* matching transactions in the summary list; applied to a single transaction's trace they
+/// fragment it — e.g. a `status=failure` filter drops the `decide_gateway` events (whose status is
+/// `received`/`success`) and leaves only the `update_gateway_score` failure event. Once a transaction
+/// is selected (via `lookup_key`, added by the caller), its full trace should be returned. Only the
+/// scope needed to identify that trace is kept: time window, merchant, and the preview/live flow-type
+/// category (plus the preview route for preview traces).
+pub fn payment_audit_timeline_filters(
+    query: &PaymentAuditQuery,
+    preview_only: bool,
+) -> Vec<FilterClause> {
+    let (start_ms, end_ms) = effective_payment_audit_window_bounds(query);
+    let mut filters = base_window_filters(start_ms, end_ms);
+
+    filters.extend(merchant_filter(&query.merchant_id));
+
+    if preview_only {
+        filters.push(FilterClause::raw(format!(
+            "route = '{}'",
+            AnalyticsRoute::RoutingEvaluate.as_str()
+        )));
+        filters.push(FilterClause::raw(format!(
+            "flow_type IN {}",
+            static_flow_type_in_sql(PAYMENT_AUDIT_PREVIEW_FLOW_TYPES)
+        )));
+    } else {
+        filters.push(FilterClause::raw(format!(
+            "flow_type IN {}",
+            static_flow_type_in_sql(PAYMENT_AUDIT_DYNAMIC_FLOW_TYPES)
+        )));
+    }
+
+    filters
+}
+
+/// Filters for the raw (non-materialized) summary aggregation.
+///
+/// Mirrors the pre-aggregated `finalized_summary_fragment` path: the per-transaction aggregates
+/// (`event_count`, `gateways`, `latest_status`, …) must reflect the transaction's full curated
+/// trace, not just the events matching the list's dimension filters. Applying `status`/`gateway`/etc
+/// inside the aggregation shrinks the count (e.g. a two-event trace shows `1 event` under
+/// `status=failure`). Which transactions appear is instead decided by the outer `has(...)` filters
+/// in `outer_summary_filters`, exactly as the materialized path does. Only scope (window, merchant,
+/// flow-type category) and the routing_approach include/exclude — the reason this raw path is used
+/// at all, since the summary table carries no routing_approach — are applied here.
+pub fn payment_audit_summary_scope_filters(
+    query: &PaymentAuditQuery,
+    preview_only: bool,
+) -> Vec<FilterClause> {
+    let mut filters = payment_audit_timeline_filters(query, preview_only);
+
+    if let Some(routing_approach) = &query.routing_approach {
+        filters.push(routing_approach_match_filter(routing_approach));
+    }
+    if let Some(routing_approach) = &query.exclude_routing_approach {
+        filters.push(routing_approach_exclusion_filter(routing_approach));
+    }
+
+    filters
+}
+
 pub fn payment_audit_summary_bucket_filters(
     query: &PaymentAuditQuery,
     preview_only: bool,
@@ -162,7 +226,7 @@ mod tests {
 
     use super::{
         analytics_dimension_filters, merchant_filter, payment_audit_raw_filters,
-        payment_audit_summary_bucket_filters,
+        payment_audit_summary_bucket_filters, payment_audit_timeline_filters,
     };
 
     fn analytics_query() -> AnalyticsQuery {
@@ -288,6 +352,32 @@ mod tests {
                 && predicate.contains("rankingAlgorithm")
                 && predicate.contains("NTW_BASED_ROUTING")
         }));
+    }
+
+    #[test]
+    fn payment_audit_timeline_filters_omit_per_event_dimension_filters() {
+        // A selected transaction's timeline must show its full trace (decide_gateway +
+        // update_gateway_score), so the list-level dimension filters must NOT be applied per event.
+        let mut query = payment_audit_query();
+        query.status = Some("FAILURE".to_string());
+        query.exclude_routing_approach = Some("NTW_BASED_ROUTING".to_string());
+        query.gateway = Some("adyen".to_string());
+        query.error_code = Some("DECLINED".to_string());
+
+        let predicates = payment_audit_timeline_filters(&query, false)
+            .iter()
+            .map(|filter| filter.predicate().to_string())
+            .collect::<Vec<_>>();
+
+        // Scope filters are kept.
+        assert!(predicates.iter().any(|p| p == "merchant_id = ?"));
+        assert!(predicates.iter().any(|p| p.contains("flow_type IN")));
+        // Per-event dimension filters are dropped. (Check exact predicates, not substrings — the
+        // flow_type IN clause contains gateway/route flow-type names like "decide_gateway_decision".)
+        assert!(!predicates.iter().any(|p| p == "status = ?"));
+        assert!(!predicates.iter().any(|p| p == "gateway = ?"));
+        assert!(!predicates.iter().any(|p| p == "error_code = ?"));
+        assert!(!predicates.iter().any(|p| p.contains("routing_approach")));
     }
 
     #[test]

--- a/src/analytics/clickhouse/metrics/audit_summaries.rs
+++ b/src/analytics/clickhouse/metrics/audit_summaries.rs
@@ -8,7 +8,7 @@ use super::super::common::{
     fetch_all, fetch_one, payment_audit_route_label, payment_audit_stage_label,
     payment_audit_summary_kind, DOMAIN_TABLE, PAYMENT_AUDIT_LOOKUP_SUMMARY_TABLE,
 };
-use super::super::filters::payment_audit_raw_filters;
+use super::super::filters::{payment_audit_summary_scope_filters, payment_audit_timeline_filters};
 use super::super::query::{BindArg, BoundQueryBuilder, FilterClause, OrderClause, SqlFragment};
 use super::super::time::effective_payment_audit_window_bounds;
 
@@ -83,7 +83,7 @@ fn raw_summary_fragment(query: &PaymentAuditQuery, preview_only: bool) -> SqlFra
         "flow_type".to_string(),
         "error_code".to_string(),
     ]);
-    source.extend_filters(payment_audit_raw_filters(query, preview_only));
+    source.extend_filters(payment_audit_summary_scope_filters(query, preview_only));
     source.add_filter(FilterClause::raw("lookup_key IS NOT NULL"));
     source.add_filter(FilterClause::raw("lookup_key != ''"));
 
@@ -296,7 +296,9 @@ pub async fn load_exact(
         "event_stage".to_string(),
         "route".to_string(),
     ]);
-    source.extend_filters(payment_audit_raw_filters(&exact_query, preview_only));
+    // A specific transaction's summary should report its full curated trace (like the timeline),
+    // not just events matching the list's dimension filters.
+    source.extend_filters(payment_audit_timeline_filters(&exact_query, preview_only));
     source.add_filter(exact_lookup_filter(lookup_key));
 
     let source = source.into_fragment();

--- a/src/analytics/clickhouse/metrics/audit_timeline.rs
+++ b/src/analytics/clickhouse/metrics/audit_timeline.rs
@@ -5,7 +5,7 @@ use crate::analytics::models::{PaymentAuditEvent, PaymentAuditQuery};
 use crate::error::ApiError;
 
 use super::super::common::{fetch_all, DOMAIN_TABLE};
-use super::super::filters::payment_audit_raw_filters;
+use super::super::filters::payment_audit_timeline_filters;
 use super::super::query::{BoundQueryBuilder, FilterClause, OrderClause};
 
 #[derive(Debug, Clone, Deserialize, Row)]
@@ -69,7 +69,7 @@ pub async fn load(
         "details".to_string(),
         "created_at_ms".to_string(),
     ]);
-    builder.extend_filters(payment_audit_raw_filters(query, preview_only));
+    builder.extend_filters(payment_audit_timeline_filters(query, preview_only));
     builder.add_filter(FilterClause::eq("lookup_key", lookup_key.to_string()));
     builder.add_order_by(OrderClause::asc("created_at_ms"));
     builder.add_order_by(OrderClause::asc("event_id"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -561,6 +561,13 @@ pub struct PgDatabase {
     pub pg_port: u16,
     pub pg_dbname: String,
     pub pg_pool_size: Option<usize>,
+    /// libpq `sslmode` (e.g. `verify-full`). Leave unset for a plain PostgreSQL / insecure
+    /// CockroachDB node; a secure CockroachDB cluster (CockroachDB Cloud) requires `verify-full`.
+    #[serde(default)]
+    pub pg_sslmode: Option<String>,
+    /// Path to the CA certificate used to verify the server when `pg_sslmode` demands it.
+    #[serde(default)]
+    pub pg_ssl_root_cert: Option<String>,
 }
 
 #[derive(Clone, serde::Deserialize, Debug)]

--- a/src/decider/gatewaydecider/flow_new.rs
+++ b/src/decider/gatewaydecider/flow_new.rs
@@ -267,7 +267,12 @@ pub async fn decider_full_payload_hs_function(
                 variant_arm,
                 Some(decided.decided_gateway.as_str()),
                 mo.and_then(|m| m.cost_saved_bps),
-                mo.and_then(|m| m.chosen.as_ref().and_then(|c| c.cost_bps)),
+                mo.and_then(|m| {
+                    m.ranked
+                        .iter()
+                        .find(|r| r.is_chosen)
+                        .and_then(|r| r.summary.cost_bps)
+                }),
                 mo.map(|m| m.margin),
                 Some(dreq_.payment_info.amount),
             )
@@ -697,13 +702,19 @@ pub async fn run_decider_flow(
                                 margin,
                             )
                             .await;
+                        // Only a cost-driven promotion relabels the approach as multi-objective.
                         if outcome.info.outcome == multi_objective::MultiObjectiveOutcome::CostWon {
                             decider_flow.writer.gwDeciderApproach =
                                 T::GatewayDeciderApproach::SrSelectionMultiObjective;
-                            if let Some(decision) = outcome.cost_decision {
-                                decidedGateway = Some(decision.chosen);
-                                cost_fallbacks_override = Some(decision.fallbacks);
-                            }
+                        }
+                        // Adopt the multi-objective pick whenever it produced one — including
+                        // AUTH_WON, where the chosen PSP is the EV-best SR head. This keeps
+                        // decidedGateway consistent with multi_objective_info and makes tied-score
+                        // selection deterministic and cost-optimal, instead of leaving the earlier
+                        // arbitrary same-score tie-break in place.
+                        if let Some(decision) = outcome.cost_decision {
+                            decidedGateway = Some(decision.chosen);
+                            cost_fallbacks_override = Some(decision.fallbacks);
                         }
                         decider_flow.writer.multi_objective_info = Some(outcome.info);
                     }

--- a/src/decider/gatewaydecider/multi_objective/algorithm.rs
+++ b/src/decider/gatewaydecider/multi_objective/algorithm.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::cluster_key::derive_cluster_key;
 use super::hypersense_client;
 use super::hypersense_client::PspCost;
-use super::{MultiObjectiveInfo, MultiObjectiveOutcome, PspSummary};
+use super::{MultiObjectiveInfo, MultiObjectiveOutcome, PspSummary, RankedPsp};
 use crate::types::card::txn_card_info::TxnCardInfo;
 use crate::types::txn_details::types::TxnDetail;
 
@@ -26,10 +26,7 @@ pub async fn try_apply_multi_objective_post_step(
     margin: f64,
 ) -> ReorderOutcome {
     if score_map.len() < 2 {
-        let sr_head = current_head(score_map);
         return auth_won(
-            sr_head,
-            &HashMap::new(),
             score_map.len(),
             margin,
             "Only one PSP available; nothing to reorder.".to_string(),
@@ -50,14 +47,10 @@ pub fn reorder_for_cost(
     margin: f64,
     costs: &HashMap<String, PspCost>,
 ) -> ReorderOutcome {
-    let sr_head = current_head(score_map);
-
-    let best_auth = match sr_head.as_ref().map(|(_, a)| *a) {
+    let best_auth = match current_head(score_map).map(|(_, a)| a) {
         Some(a) if a.is_finite() => a,
         _ => {
             return auth_won(
-                sr_head,
-                costs,
                 score_map.len(),
                 margin,
                 "SR head has no finite score; cannot evaluate cost.".to_string(),
@@ -83,8 +76,6 @@ pub fn reorder_for_cost(
     // Cost is needed to place the head in the EV ranking; without it we keep the head.
     if !head_cost.is_finite() {
         return auth_won(
-            sr_head,
-            costs,
             score_map.len(),
             margin,
             "No cost data for the SR head; cannot rank it on expected value.".to_string(),
@@ -128,12 +119,24 @@ pub fn reorder_for_cost(
 
     let ev_gap_top2 = top2_gap(ranked_evs);
 
-    let head_summary = head_psp
-        .as_ref()
-        .map(|psp| make_summary(psp.clone(), best_auth, Some(head_cost), costs));
+    // Every EV-rankable candidate (best-EV first), each flagged as the SR head / chosen PSP —
+    // surfaced so callers can see the losing PSPs' auth/cost/EV, not just the head and the pick.
+    let ranked = build_ranked(
+        score_map,
+        &ev,
+        &cost_bps,
+        costs,
+        head_psp.as_deref(),
+        chosen_psp.as_deref(),
+    );
 
-    // Head still wins: it was already the highest-EV PSP.
+    // Head still wins: it was already the highest-EV PSP. Return it as an explicit decision anyway,
+    // so the caller adopts the EV-best PSP deterministically. Otherwise, when SR scores tie, an
+    // earlier arbitrary tie-break can leave a costlier equally-ranked PSP selected while this info
+    // block reports the cheaper head — decided_gateway and multi_objective_info then disagree.
     if chosen_psp == head_psp {
+        let head_name = head_psp.clone().unwrap_or_default();
+        let fallbacks = build_ev_ordered_fallbacks(score_map, &head_name, &ev, &cost_bps);
         return ReorderOutcome {
             head_moved: false,
             info: MultiObjectiveInfo {
@@ -142,14 +145,16 @@ pub fn reorder_for_cost(
                     "SR head retained — it is the highest expected-value PSP ({} ranked on EV).",
                     ranked_count
                 ),
-                sr_head: head_summary.clone(),
-                chosen: head_summary,
                 cost_saved_bps: None,
                 qualified_count: ranked_count,
                 margin,
                 ev_gap_top2,
+                ranked,
             },
-            cost_decision: None,
+            cost_decision: Some(CostDecision {
+                chosen: head_name,
+                fallbacks,
+            }),
         };
     }
 
@@ -170,17 +175,11 @@ pub fn reorder_for_cost(
         info: MultiObjectiveInfo {
             outcome: MultiObjectiveOutcome::CostWon,
             reason,
-            sr_head: head_summary,
-            chosen: Some(make_summary(
-                chosen_name.clone(),
-                chosen_score,
-                Some(chosen_cost),
-                costs,
-            )),
             cost_saved_bps: Some(cost_saved_bps),
             qualified_count: ranked_count,
             margin,
             ev_gap_top2,
+            ranked,
         },
         cost_decision: Some(CostDecision {
             chosen: chosen_name,
@@ -228,39 +227,50 @@ fn current_head(score_map: &HashMap<String, f64>) -> Option<(String, f64)> {
         })
 }
 
-fn auth_won(
-    sr_head: Option<(String, f64)>,
-    costs: &HashMap<String, PspCost>,
-    qualified_count: usize,
-    margin: f64,
-    reason: String,
-) -> ReorderOutcome {
-    let summary = sr_head.map(|(psp, auth_rate)| {
-        let cost_bps = costs.get(&psp).and_then(|c| {
-            if c.available {
-                Some(c.effective_cost_bps)
-            } else {
-                None
-            }
-        });
-        make_summary(psp, auth_rate, cost_bps, costs)
-    });
+fn auth_won(qualified_count: usize, margin: f64, reason: String) -> ReorderOutcome {
     ReorderOutcome {
         head_moved: false,
         info: MultiObjectiveInfo {
             outcome: MultiObjectiveOutcome::AuthWon,
             reason,
-            sr_head: summary.clone(),
-            chosen: summary,
             cost_saved_bps: None,
             qualified_count,
             margin,
-            // These paths bail before any EV ranking (head has no finite score, or no
-            // cost data for the head), so there is no top-two EV gap to report.
+            // These paths bail before any EV ranking (head has no finite score, or no cost data for
+            // the head), so there is no top-two EV gap or ranked list to report. The head PSP is
+            // still derivable by the caller from the gateway_priority_map / decided_gateway.
             ev_gap_top2: None,
+            ranked: Vec::new(),
         },
         cost_decision: None,
     }
+}
+
+/// Every candidate with cost data, as EV-ranked summaries ordered best-EV first, each flagged as
+/// the SR/auth head and/or the chosen PSP.
+fn build_ranked(
+    score_map: &HashMap<String, f64>,
+    ev: &dyn Fn(f64, f64) -> f64,
+    cost_bps: &dyn Fn(&str) -> f64,
+    costs: &HashMap<String, PspCost>,
+    head_psp: Option<&str>,
+    chosen_psp: Option<&str>,
+) -> Vec<RankedPsp> {
+    let mut ranked: Vec<RankedPsp> = score_map
+        .iter()
+        .filter(|(gw, _)| cost_bps(gw).is_finite())
+        .map(|(gw, &score)| {
+            let c = cost_bps(gw);
+            RankedPsp {
+                summary: make_summary(gw.clone(), score, Some(c), costs),
+                ev: ev(score, c),
+                is_sr_head: head_psp == Some(gw.as_str()),
+                is_chosen: chosen_psp == Some(gw.as_str()),
+            }
+        })
+        .collect();
+    ranked.sort_by(|a, b| b.ev.partial_cmp(&a.ev).unwrap_or(std::cmp::Ordering::Equal));
+    ranked
 }
 
 /// Build a `PspSummary`, pulling the cost source and fitted breakdown (pct/fixed/ic_category) from
@@ -355,6 +365,42 @@ mod tests {
         let c = costs(&[("A", 100.0), ("B", 130.0)]); // B pricier -> EV lower
         let out = reorder_for_cost(&s, 0.20, &c);
         assert_eq!(out.info.outcome, MultiObjectiveOutcome::AuthWon);
+    }
+
+    // Tied SR scores: the auth-won head must still be returned as an explicit, deterministic decision
+    // (the cheaper PSP), so the caller doesn't fall back to an arbitrary same-score tie-break.
+    #[test]
+    fn auth_won_returns_deterministic_cheaper_head_on_tie() {
+        // "dlocal" and "adyen" tie on auth; adyen is cheaper -> EV-best. Head = min name = adyen.
+        let s = scores(&[("dlocal", 0.995), ("adyen", 0.995)]);
+        let c = costs(&[("dlocal", 420.0), ("adyen", 194.0)]);
+        let out = reorder_for_cost(&s, 1.0, &c);
+        assert_eq!(out.info.outcome, MultiObjectiveOutcome::AuthWon);
+        let decision = out
+            .cost_decision
+            .expect("auth-won must still return the EV-best head as the decision");
+        assert_eq!(decision.chosen, "adyen", "tie must resolve to the cheaper PSP");
+        assert_eq!(decision.fallbacks, vec!["dlocal".to_string()]);
+    }
+
+    // The ranked list must surface every candidate's cost/EV — including the loser — even on
+    // AUTH_WON, so a decision where sr_head == chosen still explains why the runner-up lost.
+    #[test]
+    fn ranked_lists_every_candidate_best_ev_first() {
+        // dlocal wins on auth+EV; adyen loses despite being cheaper. Its cost must still appear.
+        let s = scores(&[("dlocal", 0.99), ("adyen", 0.97)]);
+        let c = costs(&[("dlocal", 420.0), ("adyen", 234.0)]);
+        let out = reorder_for_cost(&s, 1.0, &c);
+        assert_eq!(out.info.outcome, MultiObjectiveOutcome::AuthWon);
+        assert_eq!(out.info.ranked.len(), 2, "both candidates ranked");
+        assert_eq!(out.info.ranked[0].summary.psp, "dlocal", "best EV first");
+        assert_eq!(out.info.ranked[1].summary.psp, "adyen");
+        // The loser's cost is now visible.
+        assert_eq!(out.info.ranked[1].summary.cost_bps, Some(234.0));
+        assert!(
+            out.info.ranked[0].ev > out.info.ranked[1].ev,
+            "ranked strictly by descending EV"
+        );
     }
 
     // ev_gap_top2 = EV(#1) − EV(#2) over every PSP ranked on EV, reported on both

--- a/src/decider/gatewaydecider/multi_objective/algorithm.rs
+++ b/src/decider/gatewaydecider/multi_objective/algorithm.rs
@@ -27,7 +27,6 @@ pub async fn try_apply_multi_objective_post_step(
 ) -> ReorderOutcome {
     if score_map.len() < 2 {
         return auth_won(
-            score_map.len(),
             margin,
             "Only one PSP available; nothing to reorder.".to_string(),
         );
@@ -51,7 +50,6 @@ pub fn reorder_for_cost(
         Some(a) if a.is_finite() => a,
         _ => {
             return auth_won(
-                score_map.len(),
                 margin,
                 "SR head has no finite score; cannot evaluate cost.".to_string(),
             );
@@ -76,7 +74,6 @@ pub fn reorder_for_cost(
     // Cost is needed to place the head in the EV ranking; without it we keep the head.
     if !head_cost.is_finite() {
         return auth_won(
-            score_map.len(),
             margin,
             "No cost data for the SR head; cannot rank it on expected value.".to_string(),
         );
@@ -227,18 +224,19 @@ fn current_head(score_map: &HashMap<String, f64>) -> Option<(String, f64)> {
         })
 }
 
-fn auth_won(qualified_count: usize, margin: f64, reason: String) -> ReorderOutcome {
+fn auth_won(margin: f64, reason: String) -> ReorderOutcome {
     ReorderOutcome {
         head_moved: false,
         info: MultiObjectiveInfo {
             outcome: MultiObjectiveOutcome::AuthWon,
             reason,
             cost_saved_bps: None,
-            qualified_count,
+            // These paths bail before any EV ranking (fewer than two PSPs, head has no finite score,
+            // or no cost data for the head), so nothing was ranked on EV and there is no top-two EV
+            // gap or ranked list to report. The head PSP is still derivable by the caller from the
+            // gateway_priority_map / decided_gateway.
+            qualified_count: 0,
             margin,
-            // These paths bail before any EV ranking (head has no finite score, or no cost data for
-            // the head), so there is no top-two EV gap or ranked list to report. The head PSP is
-            // still derivable by the caller from the gateway_priority_map / decided_gateway.
             ev_gap_top2: None,
             ranked: Vec::new(),
         },
@@ -269,7 +267,14 @@ fn build_ranked(
             }
         })
         .collect();
-    ranked.sort_by(|a, b| b.ev.partial_cmp(&a.ev).unwrap_or(std::cmp::Ordering::Equal));
+    // Descending EV, with a PSP-name tie-break so equal-EV candidates order deterministically
+    // (HashMap iteration order is not stable across runs).
+    ranked.sort_by(|a, b| {
+        b.ev
+            .partial_cmp(&a.ev)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.summary.psp.cmp(&b.summary.psp))
+    });
     ranked
 }
 

--- a/src/decider/gatewaydecider/multi_objective/algorithm.rs
+++ b/src/decider/gatewaydecider/multi_objective/algorithm.rs
@@ -270,8 +270,7 @@ fn build_ranked(
     // Descending EV, with a PSP-name tie-break so equal-EV candidates order deterministically
     // (HashMap iteration order is not stable across runs).
     ranked.sort_by(|a, b| {
-        b.ev
-            .partial_cmp(&a.ev)
+        b.ev.partial_cmp(&a.ev)
             .unwrap_or(std::cmp::Ordering::Equal)
             .then_with(|| a.summary.psp.cmp(&b.summary.psp))
     });

--- a/src/decider/gatewaydecider/multi_objective/algorithm.rs
+++ b/src/decider/gatewaydecider/multi_objective/algorithm.rs
@@ -379,7 +379,10 @@ mod tests {
         let decision = out
             .cost_decision
             .expect("auth-won must still return the EV-best head as the decision");
-        assert_eq!(decision.chosen, "adyen", "tie must resolve to the cheaper PSP");
+        assert_eq!(
+            decision.chosen, "adyen",
+            "tie must resolve to the cheaper PSP"
+        );
         assert_eq!(decision.fallbacks, vec!["dlocal".to_string()]);
     }
 

--- a/src/decider/gatewaydecider/multi_objective/mod.rs
+++ b/src/decider/gatewaydecider/multi_objective/mod.rs
@@ -21,18 +21,14 @@ pub struct MultiObjectiveInfo {
     pub outcome: MultiObjectiveOutcome,
     /// Human-readable explanation of the decision.
     pub reason: String,
-    /// The PSP the SR scorer would have picked (head of score map before reorder).
-    pub sr_head: Option<PspSummary>,
-    /// The PSP the post-step actually chose. Equals `sr_head` when auth won.
-    pub chosen: Option<PspSummary>,
-    /// Cost saved in bps when outcome == CostWon (== sr_head.cost_bps - chosen.cost_bps).
+    /// Cost saved in bps when outcome == CostWon: the SR head's cost minus the chosen PSP's cost
+    /// (both are rows in `ranked`, flagged `isSrHead` / `isChosen`).
     pub cost_saved_bps: Option<f64>,
     /// Number of PSPs ranked on expected value (i.e. those that had cost data).
     pub qualified_count: usize,
-    /// Merchant margin (fraction of ticket) the decider applied for this txn. Lets
-    /// callers value the auth-rate tradeoff a cost override accepted —
-    /// `(sr_head.auth − chosen.auth) × ticket × margin` — and net it against the fee
-    /// saved, rather than reading the fee saving in isolation.
+    /// Merchant margin (fraction of ticket) the decider applied for this txn. Lets callers value the
+    /// auth-rate tradeoff a cost override accepted — `(srHead.auth − chosen.auth) × ticket × margin`,
+    /// reading those two `ranked` rows — and net it against the fee saved.
     pub margin: f64,
     /// Expected-value gap between the top-two EV-ranked PSPs (every PSP that had cost
     /// data is ranked), as a fraction of
@@ -42,6 +38,28 @@ pub struct MultiObjectiveInfo {
     /// (Serializes as `evGapTop2`.)
     #[serde(default)]
     pub ev_gap_top2: Option<f64>,
+    /// Every candidate PSP the decider ranked on expected value, ordered best-EV first, each with
+    /// its auth, cost, EV, and role flags. This is the "show your work" behind the pick: it surfaces
+    /// the *losing* candidates' costs too, so an `AUTH_WON` decision still explains why the runner-up
+    /// lost. The SR head and the chosen PSP are the rows flagged `isSrHead` / `isChosen` (the same
+    /// row on `AUTH_WON`). Empty when no PSP had the cost data needed to rank on EV.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ranked: Vec<RankedPsp>,
+}
+
+/// One EV-ranked candidate: a `PspSummary`, the expected value it was ranked by, and flags marking
+/// whether it is the SR/auth head and/or the PSP actually chosen.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RankedPsp {
+    #[serde(flatten)]
+    pub summary: PspSummary,
+    /// Expected value used for ranking: `auth·(margin − cost_bps/10_000)`.
+    pub ev: f64,
+    /// The PSP pure success-rate routing would have picked (highest auth, deterministic tie-break).
+    pub is_sr_head: bool,
+    /// The PSP actually chosen — equals `decided_gateway`. Same row as `isSrHead` on `AUTH_WON`.
+    pub is_chosen: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/decider/gatewaydecider/multi_objective/mod.rs
+++ b/src/decider/gatewaydecider/multi_objective/mod.rs
@@ -42,7 +42,8 @@ pub struct MultiObjectiveInfo {
     /// its auth, cost, EV, and role flags. This is the "show your work" behind the pick: it surfaces
     /// the *losing* candidates' costs too, so an `AUTH_WON` decision still explains why the runner-up
     /// lost. The SR head and the chosen PSP are the rows flagged `isSrHead` / `isChosen` (the same
-    /// row on `AUTH_WON`). Empty when no PSP had the cost data needed to rank on EV.
+    /// row on `AUTH_WON`). Empty when EV ranking was not performed at all — fewer than two PSPs, or
+    /// the SR head had no finite score or no cost data.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ranked: Vec<RankedPsp>,
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -193,7 +193,7 @@ fn pg_database_url(database: &PgDatabase, schema: &str) -> String {
     );
     if let Some(sslmode) = database.pg_sslmode.as_deref().filter(|s| !s.is_empty()) {
         url.push_str("&sslmode=");
-        url.push_str(sslmode);
+        url.push_str(&encode_query_value(sslmode));
     }
     if let Some(cert) = database
         .pg_ssl_root_cert
@@ -201,9 +201,26 @@ fn pg_database_url(database: &PgDatabase, schema: &str) -> String {
         .filter(|s| !s.is_empty())
     {
         url.push_str("&sslrootcert=");
-        url.push_str(cert);
+        url.push_str(&encode_query_value(cert));
     }
     url
+}
+
+/// Percent-encode a connection-URL query value (RFC 3986 unreserved set kept, everything else
+/// escaped). An sslrootcert path can contain spaces or reserved characters (`&`, `?`, …) that would
+/// otherwise break the query string — libpq rejects a raw space outright.
+#[cfg(feature = "postgres")]
+fn encode_query_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for &byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
 }
 
 #[cfg(feature = "postgres")]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -195,7 +195,11 @@ fn pg_database_url(database: &PgDatabase, schema: &str) -> String {
         url.push_str("&sslmode=");
         url.push_str(sslmode);
     }
-    if let Some(cert) = database.pg_ssl_root_cert.as_deref().filter(|s| !s.is_empty()) {
+    if let Some(cert) = database
+        .pg_ssl_root_cert
+        .as_deref()
+        .filter(|s| !s.is_empty())
+    {
         url.push_str("&sslrootcert=");
         url.push_str(cert);
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -74,16 +74,7 @@ impl Storage {
         database: &PgDatabase,
         schema: &str,
     ) -> error_stack::Result<Self, error::StorageError> {
-        let database_url = format!(
-            "postgres://{}:{}@{}:{}/{}?application_name={}&options=-c%20search_path%3D{}",
-            database.pg_username,
-            database.pg_password.peek(),
-            database.pg_host,
-            database.pg_port,
-            database.pg_dbname,
-            schema,
-            schema
-        );
+        let database_url = pg_database_url(database, schema);
 
         let config =
             pooled_connection::AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
@@ -180,15 +171,17 @@ pub(crate) trait TestInterface {
     async fn test(&self) -> Result<(), ContainerError<Self::Error>>;
 }
 
+/// Build the `postgres://` connection URL shared by every PostgreSQL pool.
+///
+/// CockroachDB speaks the PostgreSQL wire protocol, so the same URL, `search_path` option, and
+/// Diesel `postgres` backend drive it unchanged. `sslmode`/`sslrootcert` are appended only when
+/// configured — a secure CockroachDB cluster (e.g. CockroachDB Cloud) needs `sslmode=verify-full`,
+/// while a plain PostgreSQL or insecure local CockroachDB node connects with libpq's default.
 #[cfg(feature = "postgres")]
-pub async fn diesel_make_pg_pool(
-    database: &PgDatabase,
-    schema: &str,
-    _test_transaction: bool,
-) -> error_stack::Result<PgPool, error::StorageError> {
+fn pg_database_url(database: &PgDatabase, schema: &str) -> String {
     // Keep the space percent-encoded: libpq 16 rejects a raw one ("unexpected spaces found in ...")
     // and no connection can be opened at all. libpq 14 tolerated it, which is why it went unnoticed.
-    let database_url = format!(
+    let mut url = format!(
         "postgres://{}:{}@{}:{}/{}?application_name={}&options=-c%20search_path%3D{}",
         database.pg_username,
         database.pg_password.peek(),
@@ -198,6 +191,24 @@ pub async fn diesel_make_pg_pool(
         schema,
         schema
     );
+    if let Some(sslmode) = database.pg_sslmode.as_deref().filter(|s| !s.is_empty()) {
+        url.push_str("&sslmode=");
+        url.push_str(sslmode);
+    }
+    if let Some(cert) = database.pg_ssl_root_cert.as_deref().filter(|s| !s.is_empty()) {
+        url.push_str("&sslrootcert=");
+        url.push_str(cert);
+    }
+    url
+}
+
+#[cfg(feature = "postgres")]
+pub async fn diesel_make_pg_pool(
+    database: &PgDatabase,
+    schema: &str,
+    _test_transaction: bool,
+) -> error_stack::Result<PgPool, error::StorageError> {
+    let database_url = pg_database_url(database, schema);
     let manager = async_bb8_diesel::ConnectionManager::<PgConnection>::new(database_url);
     let pool = bb8::Pool::builder()
         .max_size(50)

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -16,7 +16,7 @@ import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
 import { useAuthStore } from '../../store/authStore'
 import { apiErrorStatus, apiPost, fetcher } from '../../lib/api'
 import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
-import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, UpdateScoreResponse } from '../../types/api'
+import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, RankedPsp, UpdateScoreResponse } from '../../types/api'
 import { ROUTING_APPROACH_COLORS } from '../../lib/constants'
 import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
@@ -4429,21 +4429,15 @@ function MultiObjectiveDecisionPanel({ info }: { info: MultiObjectiveInfo }) {
             </div>
           )}
 
-          {(info.srHead || info.chosen) && (
+          {info.ranked && info.ranked.length > 0 && (
             <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              {info.srHead && (
+              {info.ranked.map((candidate) => (
                 <MultiObjectivePspCard
-                  label={isCostWin ? 'SR head (would have picked)' : 'SR head (kept)'}
-                  summary={info.srHead}
+                  key={candidate.psp}
+                  candidate={candidate}
+                  emphasis={candidate.isChosen}
                 />
-              )}
-              {info.chosen && (
-                <MultiObjectivePspCard
-                  label={isCostWin ? 'Chosen by EV' : 'Final pick'}
-                  summary={info.chosen}
-                  emphasis={isCostWin}
-                />
-              )}
+              ))}
             </div>
           )}
 
@@ -4457,12 +4451,10 @@ function MultiObjectiveDecisionPanel({ info }: { info: MultiObjectiveInfo }) {
 }
 
 function MultiObjectivePspCard({
-  label,
-  summary,
+  candidate,
   emphasis = false,
 }: {
-  label: string
-  summary: { psp: string; authRate: number; costBps: number | null }
+  candidate: RankedPsp
   emphasis?: boolean
 }) {
   const borderTone = emphasis
@@ -4470,22 +4462,35 @@ function MultiObjectivePspCard({
     : 'border-slate-200 bg-white dark:border-[#1c1c24] dark:bg-[#0d0d13]'
   return (
     <div className={`rounded-xl border px-3 py-2 ${borderTone}`}>
-      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
-        {label}
-      </p>
+      <div className="flex min-h-[16px] flex-wrap items-center gap-1.5">
+        {candidate.isSrHead && (
+          <span className="inline-flex items-center rounded bg-slate-200 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-700 dark:bg-[#1f1f29] dark:text-slate-200">
+            SR head
+          </span>
+        )}
+        {candidate.isChosen && (
+          <span className="inline-flex items-center rounded bg-cyan-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-cyan-800 dark:bg-cyan-900/40 dark:text-cyan-200">
+            Chosen
+          </span>
+        )}
+      </div>
       <p className="mt-1 font-mono text-sm font-semibold text-slate-900 dark:text-white">
-        {summary.psp}
+        {candidate.psp}
       </p>
-      <div className="mt-1.5 flex gap-3 text-xs text-slate-600 dark:text-slate-300">
+      <div className="mt-1.5 flex flex-wrap gap-3 text-xs text-slate-600 dark:text-slate-300">
         <span>
           <span className="text-slate-400">auth</span>{' '}
-          <span className="font-mono">{(summary.authRate * 100).toFixed(2)}%</span>
+          <span className="font-mono">{(candidate.authRate * 100).toFixed(2)}%</span>
         </span>
         <span>
           <span className="text-slate-400">cost</span>{' '}
           <span className="font-mono">
-            {summary.costBps != null ? `${summary.costBps.toFixed(2)} bps` : '—'}
+            {candidate.costBps != null ? `${candidate.costBps.toFixed(2)} bps` : '—'}
           </span>
+        </span>
+        <span>
+          <span className="text-slate-400">EV</span>{' '}
+          <span className="font-mono">{candidate.ev.toFixed(4)}</span>
         </span>
       </div>
     </div>

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -16,7 +16,7 @@ import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
 import { useAuthStore } from '../../store/authStore'
 import { apiErrorStatus, apiPost, fetcher } from '../../lib/api'
 import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
-import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, RoutingEvent, RoutingEventType, UpdateScoreResponse } from '../../types/api'
+import { DecideGatewayResponse, GatewayConnector, MultiObjectiveInfo, PaymentAuditEvent, PaymentAuditResponse, RankedPsp, RoutingEvent, RoutingEventType, UpdateScoreResponse } from '../../types/api'
 import { ROUTING_APPROACH_COLORS } from '../../lib/constants'
 import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
 import { useDebitRoutingFlag } from '../../hooks/useDebitRoutingFlag'
@@ -2437,8 +2437,8 @@ export function DecisionSimulatorPage() {
         costSavedBps: mo?.costSavedBps ?? null,
         costWon: mo?.outcome === 'COST_WON',
         authWon: mo?.outcome === 'AUTH_WON',
-        headAuthRate: mo?.srHead?.authRate ?? null,
-        chosenAuthRate: mo?.chosen?.authRate ?? null,
+        headAuthRate: mo?.ranked?.find((r) => r.isSrHead)?.authRate ?? null,
+        chosenAuthRate: mo?.ranked?.find((r) => r.isChosen)?.authRate ?? null,
         margin: mo?.margin ?? null,
         evGapTop2: mo?.evGapTop2 ?? null,
         amount,
@@ -6236,21 +6236,15 @@ function MultiObjectiveDecisionPanel({ info }: { info: MultiObjectiveInfo }) {
             </div>
           )}
 
-          {(info.srHead || info.chosen) && (
+          {info.ranked && info.ranked.length > 0 && (
             <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              {info.srHead && (
+              {info.ranked.map((candidate) => (
                 <MultiObjectivePspCard
-                  label={isCostWin ? 'SR head (would have picked)' : 'SR head (kept)'}
-                  summary={info.srHead}
+                  key={candidate.psp}
+                  candidate={candidate}
+                  emphasis={candidate.isChosen}
                 />
-              )}
-              {info.chosen && (
-                <MultiObjectivePspCard
-                  label={isCostWin ? 'Chosen by EV' : 'Final pick'}
-                  summary={info.chosen}
-                  emphasis={isCostWin}
-                />
-              )}
+              ))}
             </div>
           )}
 
@@ -6264,12 +6258,10 @@ function MultiObjectiveDecisionPanel({ info }: { info: MultiObjectiveInfo }) {
 }
 
 function MultiObjectivePspCard({
-  label,
-  summary,
+  candidate,
   emphasis = false,
 }: {
-  label: string
-  summary: { psp: string; authRate: number; costBps: number | null }
+  candidate: RankedPsp
   emphasis?: boolean
 }) {
   const borderTone = emphasis
@@ -6277,22 +6269,35 @@ function MultiObjectivePspCard({
     : 'border-slate-200 bg-white dark:border-[#1c1c24] dark:bg-[#0d0d13]'
   return (
     <div className={`rounded-xl border px-3 py-2 ${borderTone}`}>
-      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
-        {label}
-      </p>
+      <div className="flex min-h-[16px] flex-wrap items-center gap-1.5">
+        {candidate.isSrHead && (
+          <span className="inline-flex items-center rounded bg-slate-200 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-700 dark:bg-[#1f1f29] dark:text-slate-200">
+            SR head
+          </span>
+        )}
+        {candidate.isChosen && (
+          <span className="inline-flex items-center rounded bg-cyan-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-cyan-800 dark:bg-cyan-900/40 dark:text-cyan-200">
+            Chosen
+          </span>
+        )}
+      </div>
       <p className="mt-1 font-mono text-sm font-semibold text-slate-900 dark:text-white">
-        {summary.psp}
+        {candidate.psp}
       </p>
-      <div className="mt-1.5 flex gap-3 text-xs text-slate-600 dark:text-slate-300">
+      <div className="mt-1.5 flex flex-wrap gap-3 text-xs text-slate-600 dark:text-slate-300">
         <span>
           <span className="text-slate-400">auth</span>{' '}
-          <span className="font-mono">{(summary.authRate * 100).toFixed(2)}%</span>
+          <span className="font-mono">{(candidate.authRate * 100).toFixed(2)}%</span>
         </span>
         <span>
           <span className="text-slate-400">cost</span>{' '}
           <span className="font-mono">
-            {summary.costBps != null ? `${summary.costBps.toFixed(2)} bps` : '—'}
+            {candidate.costBps != null ? `${candidate.costBps.toFixed(2)} bps` : '—'}
           </span>
+        </span>
+        <span>
+          <span className="text-slate-400">EV</span>{' '}
+          <span className="font-mono">{candidate.ev.toFixed(4)}</span>
         </span>
       </div>
     </div>

--- a/website/src/types/api.ts
+++ b/website/src/types/api.ts
@@ -50,7 +50,8 @@ export interface MultiObjectiveInfo {
   /// PSPs had the cost data needed to rank on EV.
   evGapTop2?: number | null
   /// Every candidate ranked on EV (best first), each with auth/cost/EV and role flags. Omitted when
-  /// no PSP had the cost data needed to rank. srHead/chosen live here as the flagged rows.
+  /// EV ranking wasn't performed (fewer than two PSPs, or the SR head had no finite score / no cost
+  /// data). srHead/chosen live here as the flagged isSrHead/isChosen rows.
   ranked?: RankedPsp[]
 }
 

--- a/website/src/types/api.ts
+++ b/website/src/types/api.ts
@@ -28,11 +28,17 @@ export interface PspSummary {
   costSource: CostSource | null
 }
 
+// One EV-ranked candidate: a PspSummary plus its EV and role flags. The SR head and the chosen PSP
+// are the rows flagged isSrHead / isChosen (the same row on AUTH_WON).
+export interface RankedPsp extends PspSummary {
+  ev: number
+  isSrHead: boolean
+  isChosen: boolean
+}
+
 export interface MultiObjectiveInfo {
   outcome: MultiObjectiveOutcome
   reason: string
-  srHead: PspSummary | null
-  chosen: PspSummary | null
   costSavedBps: number | null
   /// Number of PSPs ranked on expected value (i.e. those that had cost data).
   qualifiedCount: number
@@ -43,6 +49,9 @@ export interface MultiObjectiveInfo {
   /// ticket) — the margin of victory of the winning pick. Null when fewer than two
   /// PSPs had the cost data needed to rank on EV.
   evGapTop2?: number | null
+  /// Every candidate ranked on EV (best first), each with auth/cost/EV and role flags. Omitted when
+  /// no PSP had the cost data needed to rank. srHead/chosen live here as the flagged rows.
+  ranked?: RankedPsp[]
 }
 
 export type RoutingAlgorithmName =


### PR DESCRIPTION
Bundles three independent changes made together this session. Each is its own commit, so they can be reviewed (or reverted) separately.

## 1. CockroachDB support (`feat(db)`)
CockroachDB is PostgreSQL wire-compatible, so it runs on the existing `postgres` feature and `migrations_pg` unchanged.
- Optional `pg_sslmode` / `pg_ssl_root_cert` on `PgDatabase`, applied through a single shared connection-URL builder in `storage.rs` (secure / CockroachDB Cloud clusters).
- `docker-compose.cockroach.yml` overlay: swaps the `postgresql` service for a single-node CockroachDB on host **26257** (coexists with a local Postgres on 5432), creates the role/DB, and sets `default_int_size=4` + `serial_normalization='sql_sequence'` so `INTEGER`/`SERIAL` typing matches `schema_pg.rs`.
- `diesel_pg_cockroach.toml` (no `[print_schema]`) so `diesel migration run` doesn't fail on CockroachDB's `information_schema` introspection.
- `oneclick.sh --cockroach` flow + README section.

Verified: all `migrations_pg` DDL applies on CockroachDB v24.1.5; column types come out `Int4`/`Int8` correctly; end-to-end `oneclick.sh --cockroach` brings up the stack and serves live traffic.

## 2. Payment-audit trace fix (`fix(analytics)`)
The audit timeline and the raw summary path reused the list-level dimension filters (`status`, `gateway`, `routing_approach`, …), which fragmented a single transaction's trace — e.g. `status=failure` dropped the `decide_gateway` events and left only the `update_gateway_score` failure event, and each match card under-counted events.
- Timeline uses a scope-only filter set, so a selected txn shows both `decide_gateway` and `update_gateway_score`.
- `raw_summary_fragment` / `load_exact` use scope+routing filters, so the per-card event count reflects the full trace (consistent with the materialized path).

Verified against live ClickHouse data + unit tests.

## 3. Cost-aware tie-break + EV-ranked candidates (`feat(routing)`)
- Multi-objective now adopts its EV-best pick on `AUTH_WON` too (not only `COST_WON`), so tied SR scores resolve deterministically to the cheaper PSP instead of an arbitrary same-score tie-break. `decided_gateway` no longer disagrees with `multi_objective_info`.
- Replaced `srHead`/`chosen` with a `ranked` candidate list (auth, cost, EV per PSP, best-EV first) flagged `isSrHead`/`isChosen` — a decision now explains why the runner-up lost (its cost is visible even on `AUTH_WON`). UI panels + the simulator's `authGap` read the flagged rows; `AUTH_WON` collapses to one card instead of two duplicates.
- Config: `dlocal` seed-cost tiers (LATAM/APAC/MEA).

**Breaking API change:** `multi_objective_info.srHead` / `.chosen` are removed; consumers should read the flagged `ranked` rows. All in-repo consumers (backend A/B cost attribution, both UI panels, simulator `authGap`) are updated.

Verified: `cargo build` + `cargo test` (decider + analytics suites) pass; frontend `tsc --noEmit` clean.
