### PR TITLE
feat(auth): platform super-admin view of any merchant

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -83,6 +83,7 @@ api_key_auth_enabled = true
 jwt_secret = "change_me_in_production_use_32chars!!"
 jwt_expiry_seconds = 86400
 email_verification_enabled = false
+super_admin_emails = []
 
 [admin_secret]
 secret = "test_admin"

--- a/config/development.toml
+++ b/config/development.toml
@@ -961,6 +961,7 @@ jwt_secret = "change_me_in_production_use_32chars!!"
 jwt_expiry_seconds = 86400
 email_verification_enabled = false
 signup_requires_admin_secret = false
+super_admin_emails = []
 
 [admin_secret]
 secret = "test_admin"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1883,6 +1883,110 @@
         }
       }
     },
+    "/auth/super-admin/enter-merchant": {
+      "post": {
+        "operationId": "superAdminEnterMerchant",
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Super-admin: enter a merchant",
+        "description": "Platform super-admin only (email on `user_auth.super_admin_emails`). From a standard session, mint a `super_admin_view` token scoped to any existing merchant — regardless of membership — while keeping the caller's own identity. Returns 403 if the caller is not a rostered super-admin, 404 if the merchant does not exist.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnterMerchantRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session scoped to the target merchant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/super-admin/exit": {
+      "post": {
+        "operationId": "superAdminExit",
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Super-admin: exit merchant view",
+        "description": "Ends a `super_admin_view` session and returns the admin to their own standard session. Requires a valid super-admin-view token; the roster is re-checked.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The admin's own standard session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/super-admin/lookup": {
+      "post": {
+        "operationId": "superAdminLookupMerchants",
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Super-admin: look up merchants",
+        "description": "Platform super-admin only. Find merchants by a single query matched (case-insensitive substring) against member email and merchant name, plus an exact merchant-id match. Capped at 25 results; a query shorter than 2 characters returns an empty list.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MerchantLookupRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Matching merchants with their members",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MerchantLookupResult"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/config-sr-dimension": {
       "post": {
         "operationId": "configSrDimension",
@@ -5782,6 +5886,64 @@
           }
         }
       },
+      "EnterMerchantRequest": {
+        "type": "object",
+        "required": [
+          "merchant_id"
+        ],
+        "properties": {
+          "merchant_id": {
+            "type": "string",
+            "example": "merchant_demo",
+            "description": "The merchant whose dashboard to enter."
+          }
+        }
+      },
+      "MerchantLookupRequest": {
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "properties": {
+          "query": {
+            "type": "string",
+            "example": "acme",
+            "description": "Matched against member email and merchant name (substring, case-insensitive) or an exact merchant id. Minimum 2 characters."
+          }
+        }
+      },
+      "MerchantMember": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": "operator@example.com"
+          },
+          "role": {
+            "type": "string",
+            "example": "admin"
+          }
+        }
+      },
+      "MerchantLookupResult": {
+        "type": "object",
+        "properties": {
+          "merchant_id": {
+            "type": "string",
+            "example": "merchant_demo"
+          },
+          "merchant_name": {
+            "type": "string",
+            "example": "Acme Inc"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MerchantMember"
+            }
+          }
+        }
+      },
       "CreateApiKeyRequest": {
         "type": "object",
         "required": [
@@ -6883,6 +7045,16 @@
           "email_verified": {
             "type": "boolean",
             "example": true
+          },
+          "is_super_admin": {
+            "type": "boolean",
+            "example": false,
+            "description": "This user's email is on the platform super-admin roster (may enter any merchant by ID)."
+          },
+          "is_super_admin_view": {
+            "type": "boolean",
+            "example": false,
+            "description": "The current session is a super-admin viewing another merchant's dashboard."
           },
           "merchants": {
             "type": "array",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
+import { SUPER_ADMIN_EMAIL } from './tests/fixtures/super-admin'
 
 /**
  * Playwright config for Decision Engine e2e.
@@ -38,6 +39,14 @@ const webServer = process.env.PW_NO_WEBSERVER
         timeout: 180_000,
         stdout: 'pipe' as const,
         stderr: 'pipe' as const,
+        // Inject the super-admin roster for the super-admin-view spec, so the test identity lives
+        // with the tests instead of in shipped config. Config parses this comma-separated list via
+        // `.with_list_parse_key("user_auth.super_admin_emails")` (src/config.rs). Merged over
+        // process.env, so CI's other DECISION_ENGINE__ overrides still apply.
+        env: {
+          ...(process.env as Record<string, string>),
+          DECISION_ENGINE__USER_AUTH__SUPER_ADMIN_EMAILS: SUPER_ADMIN_EMAIL,
+        },
       },
       {
         command: 'npm --prefix website run dev',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,9 +40,9 @@ const webServer = process.env.PW_NO_WEBSERVER
         stdout: 'pipe' as const,
         stderr: 'pipe' as const,
         // Inject the super-admin roster for the super-admin-view spec, so the test identity lives
-        // with the tests instead of in shipped config. Config parses this comma-separated list via
-        // `.with_list_parse_key("user_auth.super_admin_emails")` (src/config.rs). Merged over
-        // process.env, so CI's other DECISION_ENGINE__ overrides still apply.
+        // with the tests instead of in shipped config. A custom serde deserializer on
+        // UserAuthConfig.super_admin_emails (src/config.rs) accepts this comma-separated string.
+        // Merged over process.env, so CI's other DECISION_ENGINE__ overrides still apply.
         env: {
           ...(process.env as Record<string, string>),
           DECISION_ENGINE__USER_AUTH__SUPER_ADMIN_EMAILS: SUPER_ADMIN_EMAIL,

--- a/src/app.rs
+++ b/src/app.rs
@@ -626,6 +626,18 @@ where
             post(routes::user_auth::switch_merchant),
         )
         .route(
+            "/auth/super-admin/enter-merchant",
+            post(routes::user_auth::enter_merchant),
+        )
+        .route(
+            "/auth/super-admin/exit",
+            post(routes::user_auth::exit_merchant),
+        )
+        .route(
+            "/auth/super-admin/lookup",
+            post(routes::user_auth::lookup_merchants),
+        )
+        .route(
             "/onboarding/merchant",
             post(routes::user_auth::create_merchant),
         )

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -50,6 +50,10 @@ pub struct JwtClaims {
 
 pub const TOKEN_TYPE_STANDARD: &str = "standard";
 pub const TOKEN_TYPE_HS_REDIRECT: &str = "hs_redirect";
+/// A platform super-admin viewing another merchant's dashboard. Carries the real admin's identity
+/// (`user_id`/`email`) with `merchant_id` pointing at the target, so actions stay attributable. It
+/// is a cross-merchant session, not a full account session — identity/account operations reject it.
+pub const TOKEN_TYPE_SUPER_ADMIN_VIEW: &str = "super_admin_view";
 
 pub fn generate_jwt(
     user_id: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,6 +139,63 @@ pub struct UserAuthConfig {
     pub email_verification_enabled: bool,
     #[serde(default = "default_true")]
     pub signup_requires_admin_secret: bool,
+    /// Emails granted platform super-admin: they may enter any merchant's dashboard by pasting its
+    /// ID. Compared case-insensitively against the JWT's `email` claim at the moment of the action,
+    /// so config is the single source of truth — a grant/revoke takes effect on redeploy. Kept in
+    /// config (not the DB) on purpose: the roster is small, rarely changes, and every change goes
+    /// through code review + the deploy pipeline. Relies on `users.email` being immutable — there is
+    /// no change-email flow today; revisit this key if one is ever added.
+    ///
+    /// Accepts either a TOML array or a comma-separated string, so it can be set from a config file
+    /// (`["a@x.com", "b@x.com"]`) or the environment
+    /// (`DECISION_ENGINE__USER_AUTH__SUPER_ADMIN_EMAILS=a@x.com,b@x.com`) — env values arrive as a
+    /// single string, which the config crate won't split into a sequence on its own.
+    #[serde(default, deserialize_with = "deserialize_comma_separated_or_seq")]
+    pub super_admin_emails: Vec<String>,
+}
+
+/// Deserialize a `Vec<String>` from either a sequence (TOML array) or a single comma-separated
+/// string (how an environment override arrives). Blank entries are dropped and whitespace trimmed.
+fn deserialize_comma_separated_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct StringOrSeq;
+
+    impl<'de> serde::de::Visitor<'de> for StringOrSeq {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a list of strings or a comma-separated string")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value
+                .split(',')
+                .map(|entry| entry.trim().to_string())
+                .filter(|entry| !entry.is_empty())
+                .collect())
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut out = Vec::new();
+            while let Some(entry) = seq.next_element::<String>()? {
+                let entry = entry.trim().to_string();
+                if !entry.is_empty() {
+                    out.push(entry);
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_any(StringOrSeq)
 }
 
 fn default_true() -> bool {
@@ -183,6 +240,7 @@ impl Default for UserAuthConfig {
             hs_redirect_jwt_expiry_seconds: default_hs_redirect_jwt_expiry(),
             email_verification_enabled: false,
             signup_requires_admin_secret: true,
+            super_admin_emails: Vec::new(),
         }
     }
 }

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -1675,6 +1675,11 @@ pub struct MerchantLookupResult {
 /// Cap on lookup results — this is a "find the ID to enter" helper, not a full directory dump.
 const MERCHANT_LOOKUP_LIMIT: usize = 25;
 
+/// Minimum query length. A 1-character substring (e.g. "a" or "@") matches nearly every user and
+/// merchant, and `generic_find_all` has no DB-side LIMIT — so require a couple of characters to keep
+/// a broad match from loading a huge row set. (Pushing a SQL LIMIT down is a follow-up.)
+const MERCHANT_LOOKUP_MIN_QUERY_LEN: usize = 2;
+
 /// Escape the LIKE/ILIKE wildcards so a user's `%` or `_` is matched literally rather than acting as
 /// a wildcard. The default escape character is `\` on both MySQL and Postgres.
 fn escape_like(s: &str) -> String {
@@ -1710,7 +1715,7 @@ pub async fn lookup_merchants(
     }
 
     let query = payload.query.trim().to_string();
-    if query.is_empty() {
+    if query.chars().count() < MERCHANT_LOOKUP_MIN_QUERY_LEN {
         return Ok(Json(vec![]));
     }
 

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -1,5 +1,5 @@
 use crate::app::{get_tenant_app_state, APP_STATE};
-use crate::auth::{self, TOKEN_TYPE_HS_REDIRECT, TOKEN_TYPE_STANDARD};
+use crate::auth::{self, TOKEN_TYPE_HS_REDIRECT, TOKEN_TYPE_STANDARD, TOKEN_TYPE_SUPER_ADMIN_VIEW};
 use crate::error::{self, ContainerError, ResultContainerExt, UserAuthError};
 use crate::storage::types::{
     MerchantAccountNew, NewUser, NewUserMerchant, User, UserEmailVerifiedUpdate, UserMerchant,
@@ -81,6 +81,11 @@ pub struct MeResponse {
     pub role: String,
     pub email_verified: bool,
     pub merchants: Vec<MerchantInfo>,
+    /// This user's email is on the platform super-admin roster, so the dashboard should offer the
+    /// "enter any merchant" control. UX hint only — the backend re-authorizes on every action.
+    pub is_super_admin: bool,
+    /// The current session is a super-admin viewing another merchant (drives the banner + Exit).
+    pub is_super_admin_view: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -436,9 +441,10 @@ pub async fn create_merchant(
 
     let claims = verify_jwt_not_revoked(token, global_config.user_auth.jwt_secret.peek()).await?;
 
-    // HS-redirect sessions are scoped to the routing view — they have no real user row, so
-    // creating a merchant would attach it to a phantom user. Refuse.
-    if claims.token_type == TOKEN_TYPE_HS_REDIRECT {
+    // Only a full standard account session may create a merchant. HS-redirect sessions have no
+    // real user row (would attach to a phantom user); super-admin-view sessions are scoped to
+    // viewing someone else's merchant and must not mint merchants under the admin's own account.
+    if claims.token_type != TOKEN_TYPE_STANDARD {
         return Err(error::ContainerError::from(
             UserAuthError::UnsupportedOperation,
         ));
@@ -555,7 +561,10 @@ pub async fn switch_merchant(
 
     let claims = verify_jwt_not_revoked(token, global_config.user_auth.jwt_secret.peek()).await?;
 
-    if claims.token_type == TOKEN_TYPE_HS_REDIRECT {
+    // switch-merchant is membership-scoped and only valid for a full standard session. A
+    // super-admin-view session must Exit back to its own session before switching, so its
+    // single-level return token isn't overwritten.
+    if claims.token_type != TOKEN_TYPE_STANDARD {
         return Err(error::ContainerError::from(
             UserAuthError::UnsupportedOperation,
         ));
@@ -614,7 +623,9 @@ pub async fn change_password(
 
     let claims = verify_jwt_not_revoked(token, global_config.user_auth.jwt_secret.peek()).await?;
 
-    if claims.token_type == TOKEN_TYPE_HS_REDIRECT {
+    // Account management requires a full standard session. A super-admin-view session acts on
+    // another merchant's dashboard and must never touch the admin's own credentials from there.
+    if claims.token_type != TOKEN_TYPE_STANDARD {
         return Err(error::ContainerError::from(
             UserAuthError::UnsupportedOperation,
         ));
@@ -722,9 +733,10 @@ pub async fn invite_member(
 
     let claims = verify_jwt_not_revoked(token, global_config.user_auth.jwt_secret.peek()).await?;
 
-    // HS-redirect sessions must not manage identity — otherwise a leaked short-lived token
-    // could mint persistent real user accounts.
-    if claims.token_type == TOKEN_TYPE_HS_REDIRECT {
+    // Only a full standard session may manage identity. HS-redirect tokens could otherwise mint
+    // persistent real accounts from a leaked short-lived token; a super-admin-view session must not
+    // add members to a merchant it is merely inspecting.
+    if claims.token_type != TOKEN_TYPE_STANDARD {
         return Err(error::ContainerError::from(
             UserAuthError::UnsupportedOperation,
         ));
@@ -1050,6 +1062,8 @@ pub async fn me(
             role: claims.role,
             email_verified: true,
             merchants: vec![],
+            is_super_admin: false,
+            is_super_admin_view: false,
         }));
     }
 
@@ -1067,6 +1081,10 @@ pub async fn me(
 
     Ok(Json(MeResponse {
         user_id: user.user_id,
+        // Roster is keyed off the signed `email` claim, not the DB row, so the check matches the
+        // identity the rest of this session authorizes against.
+        is_super_admin: is_super_admin(&global_config, &claims.email),
+        is_super_admin_view: claims.token_type == TOKEN_TYPE_SUPER_ADMIN_VIEW,
         email: user.email,
         merchant_id: claims.merchant_id,
         role: user.role,
@@ -1076,6 +1094,18 @@ pub async fn me(
         email_verified: user.email_verified,
         merchants,
     }))
+}
+
+/// Whether `email` is on the platform super-admin roster. Compared case-insensitively (emails are
+/// not case-sensitive) and empty emails never match — so HS-redirect sessions, which carry an empty
+/// email, can never be mistaken for a super admin.
+fn is_super_admin(global_config: &crate::config::GlobalConfig, email: &str) -> bool {
+    !email.is_empty()
+        && global_config
+            .user_auth
+            .super_admin_emails
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(email))
 }
 
 async fn fetch_user_merchants(
@@ -1497,4 +1527,351 @@ pub async fn exchange_merchant_token(
         role: "admin".to_string(),
         merchants: vec![],
     }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EnterMerchantRequest {
+    pub merchant_id: String,
+}
+
+/// Platform super-admin → view any merchant's dashboard by pasting its ID. The caller must present a
+/// full standard session whose email is on the config roster. Mints a `super_admin_view` token
+/// scoped to the target merchant while keeping the admin's own identity, so actions stay
+/// attributable and the roster check on later actions still matches this admin.
+#[axum::debug_handler]
+pub async fn enter_merchant(
+    headers: HeaderMap,
+    Json(payload): Json<EnterMerchantRequest>,
+) -> Result<Json<AuthResponse>, error::ContainerError<UserAuthError>> {
+    let token = extract_bearer_token(&headers)?;
+    let global_config = APP_STATE
+        .get()
+        .map(|s| s.global_config.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    let claims = verify_jwt_not_revoked(token, global_config.user_auth.jwt_secret.peek()).await?;
+
+    // Entry is only from a full standard session. A view session must Exit first — re-entering from
+    // one would strand the admin with no way back to their own session.
+    if claims.token_type != TOKEN_TYPE_STANDARD {
+        return Err(error::ContainerError::from(
+            UserAuthError::UnsupportedOperation,
+        ));
+    }
+
+    // Authorize live against the config roster (the source of truth), by email.
+    if !is_super_admin(&global_config, &claims.email) {
+        return Err(error::ContainerError::from(UserAuthError::Forbidden));
+    }
+
+    // A typo'd or unknown ID is a clean 404, not a token scoped to a merchant that isn't there.
+    load_merchant_by_merchant_id(payload.merchant_id.clone())
+        .await
+        .ok_or_else(|| error::ContainerError::from(UserAuthError::MerchantNotFound))?;
+
+    let new_token = auth::generate_jwt(
+        &claims.user_id,
+        &claims.email,
+        &payload.merchant_id,
+        "admin",
+        TOKEN_TYPE_SUPER_ADMIN_VIEW,
+        global_config.user_auth.jwt_secret.peek(),
+        global_config.user_auth.jwt_expiry_seconds,
+    )
+    .change_context(UserAuthError::TokenGenerationFailed)?;
+
+    Ok(Json(AuthResponse {
+        token: new_token,
+        user_id: claims.user_id,
+        email: claims.email,
+        merchant_id: payload.merchant_id,
+        role: "admin".to_string(),
+        merchants: vec![],
+    }))
+}
+
+/// Ends a super-admin-view session and returns the admin to their own standard session. Obtainable
+/// only from a valid `super_admin_view` token — itself minted from a rostered standard session — and
+/// the roster is re-checked so a since-revoked admin can't mint a fresh standard session from it.
+/// This grants nothing the admin couldn't get by logging in again; it just avoids a re-login.
+#[axum::debug_handler]
+pub async fn exit_merchant(
+    headers: HeaderMap,
+) -> Result<Json<AuthResponse>, error::ContainerError<UserAuthError>> {
+    let token = extract_bearer_token(&headers)?;
+    let global_config = APP_STATE
+        .get()
+        .map(|s| s.global_config.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    let claims = verify_jwt_not_revoked(token, global_config.user_auth.jwt_secret.peek()).await?;
+
+    if claims.token_type != TOKEN_TYPE_SUPER_ADMIN_VIEW {
+        return Err(error::ContainerError::from(
+            UserAuthError::UnsupportedOperation,
+        ));
+    }
+    if !is_super_admin(&global_config, &claims.email) {
+        return Err(error::ContainerError::from(UserAuthError::Forbidden));
+    }
+
+    let app_state = get_tenant_app_state().await;
+
+    let mut users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+        &app_state.db,
+        dsl::user_id.eq(claims.user_id.clone()),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+    let user = users.pop().ok_or(UserAuthError::UserNotFound)?;
+
+    let merchants = fetch_user_merchants(&app_state, &user.user_id).await?;
+    let home_merchant_id = user.merchant_id.clone().unwrap_or_else(|| {
+        merchants
+            .first()
+            .map(|m| m.merchant_id.clone())
+            .unwrap_or_default()
+    });
+
+    let new_token = auth::generate_jwt(
+        &user.user_id,
+        &user.email,
+        &home_merchant_id,
+        &user.role,
+        TOKEN_TYPE_STANDARD,
+        global_config.user_auth.jwt_secret.peek(),
+        global_config.user_auth.jwt_expiry_seconds,
+    )
+    .change_context(UserAuthError::TokenGenerationFailed)?;
+
+    Ok(Json(AuthResponse {
+        token: new_token,
+        user_id: user.user_id,
+        email: user.email,
+        merchant_id: home_merchant_id,
+        role: user.role,
+        merchants,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LookupRequest {
+    pub query: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MerchantMember {
+    pub email: String,
+    pub role: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MerchantLookupResult {
+    pub merchant_id: String,
+    pub merchant_name: String,
+    pub members: Vec<MerchantMember>,
+}
+
+/// Cap on lookup results — this is a "find the ID to enter" helper, not a full directory dump.
+const MERCHANT_LOOKUP_LIMIT: usize = 25;
+
+/// Escape the LIKE/ILIKE wildcards so a user's `%` or `_` is matched literally rather than acting as
+/// a wildcard. The default escape character is `\` on both MySQL and Postgres.
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+}
+
+/// Super-admin merchant lookup: one query string matched (case-insensitively, substring) against
+/// both user email and merchant name, plus an exact merchant-id match. Returns the matching
+/// merchants with their members so a super-admin can find the ID to enter from a person or company
+/// name. Same gate as `enter_merchant` — a rostered standard session.
+#[axum::debug_handler]
+pub async fn lookup_merchants(
+    headers: HeaderMap,
+    Json(payload): Json<LookupRequest>,
+) -> Result<Json<Vec<MerchantLookupResult>>, error::ContainerError<UserAuthError>> {
+    let token = extract_bearer_token(&headers)?;
+    let global_config = APP_STATE
+        .get()
+        .map(|s| s.global_config.clone())
+        .ok_or(UserAuthError::StorageError)?;
+
+    let claims = verify_jwt_not_revoked(token, global_config.user_auth.jwt_secret.peek()).await?;
+
+    if claims.token_type != TOKEN_TYPE_STANDARD {
+        return Err(error::ContainerError::from(
+            UserAuthError::UnsupportedOperation,
+        ));
+    }
+    if !is_super_admin(&global_config, &claims.email) {
+        return Err(error::ContainerError::from(UserAuthError::Forbidden));
+    }
+
+    let query = payload.query.trim().to_string();
+    if query.is_empty() {
+        return Ok(Json(vec![]));
+    }
+
+    #[cfg(feature = "mysql")]
+    use crate::storage::schema::merchant_account::dsl as ma_dsl;
+    #[cfg(feature = "postgres")]
+    use crate::storage::schema_pg::merchant_account::dsl as ma_dsl;
+
+    // `.like`/`.ilike` live on different traits and only one backend has ILIKE, so the substring
+    // predicates below are cfg-split; everything else is shared.
+    #[cfg(feature = "mysql")]
+    use diesel::TextExpressionMethods;
+    #[cfg(feature = "postgres")]
+    use diesel::PgTextExpressionMethods;
+
+    use crate::storage::types::MerchantAccount;
+
+    let app_state = get_tenant_app_state().await;
+    let pattern = format!("%{}%", escape_like(&query));
+
+    // 1. Users whose email matches → the merchants they belong to.
+    #[cfg(feature = "mysql")]
+    let matched_users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+        &app_state.db,
+        dsl::email.like(pattern.clone()),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+    #[cfg(feature = "postgres")]
+    let matched_users = crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+        &app_state.db,
+        dsl::email.ilike(pattern.clone()),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+
+    let matched_user_ids: Vec<String> = matched_users.into_iter().map(|u| u.user_id).collect();
+
+    let people_memberships = if matched_user_ids.is_empty() {
+        Vec::new()
+    } else {
+        crate::generics::generic_find_all::<<UserMerchant as HasTable>::Table, _, UserMerchant>(
+            &app_state.db,
+            um_dsl::user_id.eq_any(matched_user_ids),
+        )
+        .await
+        .change_error(UserAuthError::StorageError)?
+    };
+
+    // 2. Merchants whose name matches, or whose ID is exactly the query.
+    #[cfg(feature = "mysql")]
+    let matched_merchants = crate::generics::generic_find_all::<
+        <MerchantAccount as HasTable>::Table,
+        _,
+        MerchantAccount,
+    >(
+        &app_state.db,
+        ma_dsl::merchant_name
+            .like(pattern.clone())
+            .or(ma_dsl::merchant_id.eq(Some(query.clone()))),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+    #[cfg(feature = "postgres")]
+    let matched_merchants = crate::generics::generic_find_all::<
+        <MerchantAccount as HasTable>::Table,
+        _,
+        MerchantAccount,
+    >(
+        &app_state.db,
+        ma_dsl::merchant_name
+            .ilike(pattern.clone())
+            .or(ma_dsl::merchant_id.eq(Some(query.clone()))),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+
+    // Merge into an order-preserving, deduped id list: direct merchant matches first, then merchants
+    // reached via a matching person. Capped so a broad query can't return an unbounded set.
+    let mut ordered_ids: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for merchant_id in matched_merchants
+        .into_iter()
+        .filter_map(|m| m.merchant_id)
+        .chain(people_memberships.iter().map(|m| m.merchant_id.clone()))
+    {
+        if seen.insert(merchant_id.clone()) {
+            ordered_ids.push(merchant_id);
+            if ordered_ids.len() >= MERCHANT_LOOKUP_LIMIT {
+                break;
+            }
+        }
+    }
+
+    if ordered_ids.is_empty() {
+        return Ok(Json(vec![]));
+    }
+
+    // 3. Names for the result merchants, and the full membership of each (not just the matched
+    // person) so the super-admin can confirm the target.
+    let name_rows = crate::generics::generic_find_all::<
+        <MerchantAccount as HasTable>::Table,
+        _,
+        MerchantAccount,
+    >(
+        &app_state.db,
+        ma_dsl::merchant_id.eq_any(ordered_ids.iter().cloned().map(Some).collect::<Vec<_>>()),
+    )
+    .await
+    .change_error(UserAuthError::StorageError)?;
+    let name_by_id: std::collections::HashMap<String, String> = name_rows
+        .into_iter()
+        .filter_map(|m| m.merchant_id.clone().map(|id| (id, m.merchant_name.unwrap_or_default())))
+        .collect();
+
+    let memberships =
+        crate::generics::generic_find_all::<<UserMerchant as HasTable>::Table, _, UserMerchant>(
+            &app_state.db,
+            um_dsl::merchant_id.eq_any(ordered_ids.clone()),
+        )
+        .await
+        .change_error(UserAuthError::StorageError)?;
+
+    let member_user_ids: Vec<String> =
+        memberships.iter().map(|m| m.user_id.clone()).collect::<std::collections::HashSet<_>>().into_iter().collect();
+    let member_users = if member_user_ids.is_empty() {
+        Vec::new()
+    } else {
+        crate::generics::generic_find_all::<<User as HasTable>::Table, _, User>(
+            &app_state.db,
+            dsl::user_id.eq_any(member_user_ids),
+        )
+        .await
+        .change_error(UserAuthError::StorageError)?
+    };
+    let email_by_user_id: std::collections::HashMap<String, String> =
+        member_users.into_iter().map(|u| (u.user_id, u.email)).collect();
+
+    let results = ordered_ids
+        .into_iter()
+        .map(|merchant_id| {
+            let members = memberships
+                .iter()
+                .filter(|m| m.merchant_id == merchant_id)
+                .filter_map(|m| {
+                    email_by_user_id.get(&m.user_id).map(|email| MerchantMember {
+                        email: email.clone(),
+                        role: m.role.clone(),
+                    })
+                })
+                .collect();
+            let merchant_name = name_by_id
+                .get(&merchant_id)
+                .cloned()
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| merchant_id.clone());
+            MerchantLookupResult {
+                merchant_id,
+                merchant_name,
+                members,
+            }
+        })
+        .collect();
+
+    Ok(Json(results))
 }

--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -1678,7 +1678,9 @@ const MERCHANT_LOOKUP_LIMIT: usize = 25;
 /// Escape the LIKE/ILIKE wildcards so a user's `%` or `_` is matched literally rather than acting as
 /// a wildcard. The default escape character is `\` on both MySQL and Postgres.
 fn escape_like(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 /// Super-admin merchant lookup: one query string matched (case-insensitively, substring) against
@@ -1719,10 +1721,10 @@ pub async fn lookup_merchants(
 
     // `.like`/`.ilike` live on different traits and only one backend has ILIKE, so the substring
     // predicates below are cfg-split; everything else is shared.
-    #[cfg(feature = "mysql")]
-    use diesel::TextExpressionMethods;
     #[cfg(feature = "postgres")]
     use diesel::PgTextExpressionMethods;
+    #[cfg(feature = "mysql")]
+    use diesel::TextExpressionMethods;
 
     use crate::storage::types::MerchantAccount;
 
@@ -1821,7 +1823,11 @@ pub async fn lookup_merchants(
     .change_error(UserAuthError::StorageError)?;
     let name_by_id: std::collections::HashMap<String, String> = name_rows
         .into_iter()
-        .filter_map(|m| m.merchant_id.clone().map(|id| (id, m.merchant_name.unwrap_or_default())))
+        .filter_map(|m| {
+            m.merchant_id
+                .clone()
+                .map(|id| (id, m.merchant_name.unwrap_or_default()))
+        })
         .collect();
 
     let memberships =
@@ -1832,8 +1838,12 @@ pub async fn lookup_merchants(
         .await
         .change_error(UserAuthError::StorageError)?;
 
-    let member_user_ids: Vec<String> =
-        memberships.iter().map(|m| m.user_id.clone()).collect::<std::collections::HashSet<_>>().into_iter().collect();
+    let member_user_ids: Vec<String> = memberships
+        .iter()
+        .map(|m| m.user_id.clone())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
     let member_users = if member_user_ids.is_empty() {
         Vec::new()
     } else {
@@ -1844,8 +1854,10 @@ pub async fn lookup_merchants(
         .await
         .change_error(UserAuthError::StorageError)?
     };
-    let email_by_user_id: std::collections::HashMap<String, String> =
-        member_users.into_iter().map(|u| (u.user_id, u.email)).collect();
+    let email_by_user_id: std::collections::HashMap<String, String> = member_users
+        .into_iter()
+        .map(|u| (u.user_id, u.email))
+        .collect();
 
     let results = ordered_ids
         .into_iter()
@@ -1854,10 +1866,12 @@ pub async fn lookup_merchants(
                 .iter()
                 .filter(|m| m.merchant_id == merchant_id)
                 .filter_map(|m| {
-                    email_by_user_id.get(&m.user_id).map(|email| MerchantMember {
-                        email: email.clone(),
-                        role: m.role.clone(),
-                    })
+                    email_by_user_id
+                        .get(&m.user_id)
+                        .map(|email| MerchantMember {
+                            email: email.clone(),
+                            role: m.role.clone(),
+                        })
                 })
                 .collect();
             let merchant_name = name_by_id

--- a/tests/api/auth/super-admin-view.spec.ts
+++ b/tests/api/auth/super-admin-view.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect, factory } from '../../fixtures/test'
+import type { ApiClient } from '../../fixtures/api-client'
+import { SUPER_ADMIN_EMAIL, SUPER_ADMIN_PASSWORD } from '../../fixtures/super-admin'
+
+/**
+ * Platform super-admin: viewing ANY merchant's dashboard, plus the merchant lookup.
+ *
+ * Shape: a super-admin is a real (standard-session) user whose email is on the config roster
+ * (`user_auth.super_admin_emails`). From that session they can mint a `super_admin_view` token for
+ * any merchant — regardless of membership — that keeps their own identity, and later `exit` back to a
+ * normal session. A view session is deliberately NOT a full account session (it cannot switch/create
+ * merchants). Lookup lets them find a merchant id from an email or merchant name.
+ *
+ * Roster dependency: the API under test must have SUPER_ADMIN_EMAIL on its super-admin roster.
+ * playwright.config.ts injects it via DECISION_ENGINE__USER_AUTH__SUPER_ADMIN_EMAILS into the API
+ * server it starts, so nothing is hardcoded in shipped config. The per-test `merchant` fixture's own
+ * admin session is a standard session that is NOT on the roster, so it doubles as the negative
+ * (non-super-admin) case.
+ */
+
+const bearer = (token: string) => ({ headers: { Authorization: `Bearer ${token}` } })
+
+/**
+ * A standard-session token for the rostered super-admin. Login-first so repeated runs reuse the
+ * global user; create it on the very first run, tolerating a concurrent creator from another worker.
+ */
+async function superAdminToken(api: ApiClient): Promise<string> {
+  const login = await api.raw('POST', '/auth/login', {
+    failOnStatusCode: false,
+    body: { email: SUPER_ADMIN_EMAIL, password: SUPER_ADMIN_PASSWORD },
+  })
+  if (login.status === 200 && login.body?.token) return login.body.token
+
+  const signup = await api.raw('POST', '/auth/signup', {
+    failOnStatusCode: false,
+    body: { email: SUPER_ADMIN_EMAIL, password: SUPER_ADMIN_PASSWORD },
+  })
+  if (signup.status === 200 && signup.body?.token) return signup.body.token
+
+  // Lost a creation race with another worker — the account now exists, so login succeeds.
+  const retry = await api.raw('POST', '/auth/login', {
+    body: { email: SUPER_ADMIN_EMAIL, password: SUPER_ADMIN_PASSWORD },
+  })
+  return retry.body.token
+}
+
+test.describe('Super-admin merchant view (API)', () => {
+  test('a rostered super-admin can enter any merchant, keeping their own identity', async ({ api, merchant }) => {
+    const superToken = await superAdminToken(api)
+
+    // The super-admin is not a member of this merchant — entry is by roster, not membership.
+    const entered = await api.raw('POST', '/auth/super-admin/enter-merchant', {
+      failOnStatusCode: false,
+      ...bearer(superToken),
+      body: { merchant_id: merchant.id },
+    })
+
+    expect(entered.status).toBe(200)
+    expect(typeof entered.body.token).toBe('string')
+    expect(entered.body.merchant_id).toBe(merchant.id)
+    expect(entered.body.role).toBe('admin')
+    // Real identity is preserved — not a synthetic hs_ redirect user.
+    expect(entered.body.user_id).not.toMatch(/^hs_/)
+
+    // /auth/me on the view token reports it as a super-admin view of the target merchant.
+    const me = await api.raw('GET', '/auth/me', { failOnStatusCode: false, ...bearer(entered.body.token) })
+    expect(me.status).toBe(200)
+    expect(me.body.merchant_id).toBe(merchant.id)
+    expect(me.body.is_super_admin).toBe(true)
+    expect(me.body.is_super_admin_view).toBe(true)
+  })
+
+  test('a standard session that is not on the roster is forbidden', async ({ api, merchant }) => {
+    // `api` carries the merchant's own admin session — a standard session, but not a super-admin.
+    const r = await api.raw('POST', '/auth/super-admin/enter-merchant', {
+      failOnStatusCode: false,
+      body: { merchant_id: merchant.id },
+    })
+
+    expect(r.status).toBe(403)
+  })
+
+  test('entering an unknown merchant is rejected', async ({ api }) => {
+    const superToken = await superAdminToken(api)
+
+    const r = await api.raw('POST', '/auth/super-admin/enter-merchant', {
+      failOnStatusCode: false,
+      ...bearer(superToken),
+      body: { merchant_id: factory.merchantId('sa_missing') },
+    })
+
+    expect(r.status).toBe(404)
+  })
+
+  test('a view session cannot switch merchant, and exit returns a full session', async ({ api, merchant }) => {
+    const superToken = await superAdminToken(api)
+    const entered = await api.raw('POST', '/auth/super-admin/enter-merchant', {
+      ...bearer(superToken),
+      body: { merchant_id: merchant.id },
+    })
+    const viewToken = entered.body.token
+
+    // A view session is scoped to viewing — not a full account session.
+    const switched = await api.raw('POST', '/auth/switch-merchant', {
+      failOnStatusCode: false,
+      ...bearer(viewToken),
+      body: { merchant_id: merchant.id },
+    })
+    expect(switched.status).toBe(403)
+
+    // Exit re-mints a standard session for the same admin.
+    const exited = await api.raw('POST', '/auth/super-admin/exit', { failOnStatusCode: false, ...bearer(viewToken) })
+    expect(exited.status).toBe(200)
+    expect(typeof exited.body.token).toBe('string')
+
+    const me = await api.raw('GET', '/auth/me', { failOnStatusCode: false, ...bearer(exited.body.token) })
+    expect(me.status).toBe(200)
+    expect(me.body.is_super_admin).toBe(true)
+    expect(me.body.is_super_admin_view).toBe(false)
+  })
+
+  test('exit is rejected for a normal (non-view) session', async ({ api }) => {
+    const superToken = await superAdminToken(api)
+
+    // The super-admin's own standard token is not a view session — nothing to exit from.
+    const r = await api.raw('POST', '/auth/super-admin/exit', { failOnStatusCode: false, ...bearer(superToken) })
+    expect(r.status).toBe(403)
+  })
+})
+
+test.describe('Super-admin merchant lookup (API)', () => {
+  test('finds a merchant by its id and lists its members', async ({ api, merchant }) => {
+    const superToken = await superAdminToken(api)
+
+    const r = await api.raw('POST', '/auth/super-admin/lookup', {
+      failOnStatusCode: false,
+      ...bearer(superToken),
+      body: { query: merchant.id },
+    })
+
+    expect(r.status).toBe(200)
+    expect(Array.isArray(r.body)).toBe(true)
+    const hit = r.body.find((m: any) => m.merchant_id === merchant.id)
+    expect(hit, `expected ${merchant.id} in lookup results`).toBeTruthy()
+    // The merchant's signing-up admin shows up as a member.
+    expect(hit.members.some((mem: any) => mem.email === `${merchant.id}@example.com`)).toBe(true)
+  })
+
+  test('finds a merchant by a member email', async ({ api, merchant }) => {
+    const superToken = await superAdminToken(api)
+
+    const r = await api.raw('POST', '/auth/super-admin/lookup', {
+      failOnStatusCode: false,
+      ...bearer(superToken),
+      body: { query: `${merchant.id}@example.com` },
+    })
+
+    expect(r.status).toBe(200)
+    expect(r.body.some((m: any) => m.merchant_id === merchant.id)).toBe(true)
+  })
+
+  test('lookup requires a super-admin', async ({ api, merchant }) => {
+    // Uses the merchant's own admin session — a standard session, not on the roster.
+    const r = await api.raw('POST', '/auth/super-admin/lookup', {
+      failOnStatusCode: false,
+      body: { query: merchant.id },
+    })
+
+    expect(r.status).toBe(403)
+  })
+
+  test('an empty query returns no results', async ({ api }) => {
+    const superToken = await superAdminToken(api)
+
+    const r = await api.raw('POST', '/auth/super-admin/lookup', {
+      failOnStatusCode: false,
+      ...bearer(superToken),
+      body: { query: '   ' },
+    })
+
+    expect(r.status).toBe(200)
+    expect(r.body).toEqual([])
+  })
+})

--- a/tests/fixtures/super-admin.ts
+++ b/tests/fixtures/super-admin.ts
@@ -1,0 +1,13 @@
+/**
+ * The platform super-admin identity used by the super-admin-view spec.
+ *
+ * The roster is config-only by design (there's no runtime API to grant super-admin), so a test of
+ * the positive path needs one known identity in the loaded roster. Rather than shipping it in
+ * config/development.toml, playwright.config.ts injects this email into the API server it starts via
+ * `DECISION_ENGINE__USER_AUTH__SUPER_ADMIN_EMAILS` — so the test identity lives with the tests.
+ *
+ * Single source of truth: both playwright.config.ts (the injected roster) and the spec (the login it
+ * performs) import from here, so they can never drift apart.
+ */
+export const SUPER_ADMIN_EMAIL = 'superadmin@example.com'
+export const SUPER_ADMIN_PASSWORD = 'Password123!'

--- a/website/src/components/layout/AppShell.tsx
+++ b/website/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom'
 import { RoutingEventsProvider } from '../../hooks/useRoutingEvents'
 import { Sidebar } from './Sidebar'
 import { TopBar } from './TopBar'
+import { SuperAdminBanner } from './SuperAdminBanner'
 
 export function AppShell() {
   return (
@@ -11,6 +12,7 @@ export function AppShell() {
         <div className="aurora-top" />
         <Sidebar />
         <div className="flex-1 flex flex-col overflow-hidden relative z-10">
+          <SuperAdminBanner />
           <TopBar />
           <main className="relative flex-1 overflow-y-auto px-4 py-5 sm:px-5 sm:py-6 lg:px-6 lg:py-7 xl:px-8">
             {/* No horizontal padding here — `main` already owns the page gutter, and padding both

--- a/website/src/components/layout/AuthGuard.tsx
+++ b/website/src/components/layout/AuthGuard.tsx
@@ -13,6 +13,8 @@ interface MeResponse {
   merchant_id: string
   role: string
   email_verified: boolean
+  is_super_admin: boolean
+  is_super_admin_view: boolean
   merchants: Array<{
     merchant_id: string
     merchant_name: string
@@ -81,7 +83,7 @@ export function AuthGuard() {
   useEffect(() => {
     if (!me || !token) return
     const activeMerchantId = me.merchant_id || me.merchants[0]?.merchant_id || ''
-    setAuth(token, { userId: me.user_id, email: me.email, merchantId: activeMerchantId, role: me.role, isRedirectSession: me.user_id.startsWith('hs_') }, me.merchants)
+    setAuth(token, { userId: me.user_id, email: me.email, merchantId: activeMerchantId, role: me.role, isRedirectSession: me.user_id.startsWith('hs_'), isSuperAdmin: me.is_super_admin, isSuperAdminView: me.is_super_admin_view }, me.merchants)
     setMerchantId(activeMerchantId)
   }, [me, token, setAuth, setMerchantId])
 

--- a/website/src/components/layout/SuperAdminBanner.tsx
+++ b/website/src/components/layout/SuperAdminBanner.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { ShieldCheck, LogOut } from 'lucide-react'
+import { useAuthStore } from '../../store/authStore'
+import { useMerchantStore } from '../../store/merchantStore'
+import { apiFetch } from '../../lib/api'
+
+interface ExitResponse {
+  token: string
+  user_id: string
+  email: string
+  merchant_id: string
+  role: string
+  merchants: { merchant_id: string; merchant_name: string; role: string }[]
+}
+
+// Shown only during a super-admin view session. Makes it unmistakable that the dashboard belongs to
+// another merchant, and offers the one way back to the admin's own session.
+export function SuperAdminBanner() {
+  const { user, setAuth } = useAuthStore()
+  const { setMerchantId } = useMerchantStore()
+  const [exiting, setExiting] = useState(false)
+
+  if (!user?.isSuperAdminView) return null
+
+  async function handleExit() {
+    if (exiting) return
+    setExiting(true)
+    try {
+      const res = await apiFetch<ExitResponse>('/auth/super-admin/exit', { method: 'POST' })
+      setAuth(
+        res.token,
+        {
+          userId: res.user_id,
+          email: res.email,
+          merchantId: res.merchant_id,
+          role: res.role,
+          isRedirectSession: false,
+          isSuperAdmin: true,
+          isSuperAdminView: false,
+        },
+        res.merchants,
+      )
+      setMerchantId(res.merchant_id)
+    } catch {
+      // Leave the user in the view session; they can retry Exit.
+    } finally {
+      setExiting(false)
+    }
+  }
+
+  return (
+    <div className="flex h-9 shrink-0 items-center justify-center gap-3 bg-amber-500 px-4 text-[12.5px] font-medium text-amber-950">
+      <span className="flex items-center gap-1.5">
+        <ShieldCheck size={14} className="shrink-0" />
+        Viewing <span className="font-semibold">{user.merchantId}</span> as platform super admin
+      </span>
+      <button
+        onClick={handleExit}
+        disabled={exiting}
+        className="flex items-center gap-1.5 rounded-md bg-amber-950/15 px-2.5 py-1 hover:bg-amber-950/25 disabled:opacity-60 transition-colors"
+      >
+        <LogOut size={12} />
+        {exiting ? 'Exiting…' : 'Exit'}
+      </button>
+    </div>
+  )
+}

--- a/website/src/components/layout/TopBar.tsx
+++ b/website/src/components/layout/TopBar.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '../../store/authStore'
 import { useMerchantStore } from '../../store/merchantStore'
 import { apiFetch } from '../../lib/api'
-import { ChevronDown, Building2, Check, Plus } from 'lucide-react'
+import { ChevronDown, Building2, Check, Plus, ShieldCheck, ArrowRight } from 'lucide-react'
 import { NotificationBell } from './NotificationBell'
 import { GlobalSearch } from './GlobalSearch'
 
@@ -14,23 +14,113 @@ interface SwitchMerchantResponse {
   merchants: { merchant_id: string; merchant_name: string; role: string }[]
 }
 
+interface EnterMerchantResponse {
+  token: string
+  user_id: string
+  email: string
+  merchant_id: string
+  role: string
+}
+
+interface LookupMember {
+  email: string
+  role: string
+}
+
+interface LookupResult {
+  merchant_id: string
+  merchant_name: string
+  members: LookupMember[]
+}
+
 export function TopBar() {
   const navigate = useNavigate()
-  const { user, merchants, updateMerchant } = useAuthStore()
+  const { user, merchants, updateMerchant, setAuth } = useAuthStore()
   const { setMerchantId } = useMerchantStore()
   const [merchantOpen, setMerchantOpen] = useState(false)
   const [switching, setSwitching] = useState<string | null>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const [superAdminOpen, setSuperAdminOpen] = useState(false)
+  const [enterId, setEnterId] = useState('')
+  const [entering, setEntering] = useState(false)
+  const [enterError, setEnterError] = useState<string | null>(null)
+  const [lookupQuery, setLookupQuery] = useState('')
+  const [lookupResults, setLookupResults] = useState<LookupResult[]>([])
+  const [searching, setSearching] = useState(false)
+  const superAdminRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
         setMerchantOpen(false)
       }
+      if (superAdminRef.current && !superAdminRef.current.contains(e.target as Node)) {
+        setSuperAdminOpen(false)
+      }
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
+
+  // Debounced lookup by email or merchant name while the popover is open.
+  useEffect(() => {
+    if (!superAdminOpen) return
+    const q = lookupQuery.trim()
+    if (!q) { setLookupResults([]); setSearching(false); return }
+    let cancelled = false
+    setSearching(true)
+    const timer = setTimeout(async () => {
+      try {
+        const res = await apiFetch<LookupResult[]>('/auth/super-admin/lookup', {
+          method: 'POST',
+          body: JSON.stringify({ query: q }),
+        })
+        if (!cancelled) setLookupResults(res)
+      } catch {
+        if (!cancelled) setLookupResults([])
+      } finally {
+        if (!cancelled) setSearching(false)
+      }
+    }, 300)
+    return () => { cancelled = true; clearTimeout(timer) }
+  }, [lookupQuery, superAdminOpen])
+
+  async function handleEnterMerchant(merchantId: string) {
+    if (!merchantId || entering) return
+    setEntering(true)
+    setEnterError(null)
+    try {
+      const res = await apiFetch<EnterMerchantResponse>('/auth/super-admin/enter-merchant', {
+        method: 'POST',
+        body: JSON.stringify({ merchant_id: merchantId }),
+      })
+      // Optimistically flag the session as a super-admin view; AuthGuard's /auth/me revalidation
+      // (triggered by the token change) confirms it.
+      setAuth(
+        res.token,
+        {
+          userId: res.user_id,
+          email: res.email,
+          merchantId: res.merchant_id,
+          role: res.role,
+          isRedirectSession: false,
+          isSuperAdmin: true,
+          isSuperAdminView: true,
+        },
+        [],
+      )
+      setMerchantId(res.merchant_id)
+      setSuperAdminOpen(false)
+      setEnterId('')
+      setLookupQuery('')
+      setLookupResults([])
+    } catch (err) {
+      const status = (err as { status?: number }).status
+      setEnterError(status === 404 ? 'No merchant with that ID.' : 'Could not enter that merchant.')
+    } finally {
+      setEntering(false)
+    }
+  }
 
   async function handleSwitchMerchant(merchantId: string) {
     if (merchantId === user?.merchantId || switching) return
@@ -67,8 +157,90 @@ export function TopBar() {
       <div className="flex flex-1 items-center justify-end gap-2">
         <NotificationBell />
 
+        {/* Super-admin: enter any merchant by ID. Hidden inside a view session — Exit first (via the
+            banner) so the single-level session model stays intact. */}
+        {user?.isSuperAdmin && !user?.isSuperAdminView && (
+          <div className="relative" ref={superAdminRef}>
+            <button
+              onClick={() => setSuperAdminOpen((v) => !v)}
+              className="flex items-center gap-2 h-8 px-3 rounded-lg border border-amber-300/70 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 hover:bg-amber-100 dark:hover:bg-amber-500/20 transition-colors text-amber-700 dark:text-amber-300"
+            >
+              <ShieldCheck size={13} className="shrink-0" />
+              <span className="text-[12px] font-medium">Super admin</span>
+              <ChevronDown size={12} className="shrink-0" />
+            </button>
+
+            {superAdminOpen && (
+              <div className="absolute right-0 top-10 w-80 bg-white dark:bg-[#0c0c10] border border-[#e6e6ee] dark:border-[#1a1a24] rounded-lg shadow-lg p-3 z-50">
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-2">
+                  View a merchant dashboard
+                </p>
+
+                {/* Search by person or company */}
+                <input
+                  value={lookupQuery}
+                  onChange={(e) => setLookupQuery(e.target.value)}
+                  placeholder="Search by email or merchant name"
+                  autoFocus
+                  className="w-full h-8 px-2.5 rounded-md border border-[#e6e6ee] dark:border-[#1a1a24] bg-white dark:bg-[#121218] text-[13px] text-slate-700 dark:text-slate-200 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
+                />
+
+                {lookupQuery.trim() && (
+                  <div className="mt-2 max-h-64 overflow-y-auto">
+                    {searching && lookupResults.length === 0 ? (
+                      <p className="px-1 py-2 text-[12px] text-slate-400">Searching…</p>
+                    ) : lookupResults.length === 0 ? (
+                      <p className="px-1 py-2 text-[12px] text-slate-400">No matches.</p>
+                    ) : (
+                      lookupResults.map((m) => (
+                        <button
+                          key={m.merchant_id}
+                          onClick={() => handleEnterMerchant(m.merchant_id)}
+                          disabled={entering}
+                          className="w-full text-left px-2 py-2 rounded-md hover:bg-slate-50 dark:hover:bg-[#13131a] transition-colors disabled:opacity-50"
+                        >
+                          <p className="text-[13px] font-medium text-slate-700 dark:text-slate-200 truncate">
+                            {m.merchant_name}
+                          </p>
+                          <p className="text-[11px] text-slate-400 truncate">{m.merchant_id}</p>
+                          {m.members.length > 0 && (
+                            <p className="text-[11px] text-slate-400 truncate">
+                              {m.members.map((mem) => mem.email).join(', ')}
+                            </p>
+                          )}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                )}
+
+                {/* Fallback: enter an exact ID */}
+                <div className="mt-2 pt-2 border-t border-[#e6e6ee] dark:border-[#1a1a24]">
+                  <input
+                    value={enterId}
+                    onChange={(e) => { setEnterId(e.target.value); setEnterError(null) }}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleEnterMerchant(enterId.trim()) }}
+                    placeholder="…or paste an exact merchant ID"
+                    className="w-full h-8 px-2.5 rounded-md border border-[#e6e6ee] dark:border-[#1a1a24] bg-white dark:bg-[#121218] text-[13px] text-slate-700 dark:text-slate-200 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
+                  />
+                  {enterError && (
+                    <p className="mt-1.5 text-[11px] text-red-500">{enterError}</p>
+                  )}
+                  <button
+                    onClick={() => handleEnterMerchant(enterId.trim())}
+                    disabled={!enterId.trim() || entering}
+                    className="mt-2 w-full flex items-center justify-center gap-1.5 h-8 rounded-md bg-amber-600 hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-[13px] font-medium text-white"
+                  >
+                    {entering ? 'Entering…' : (<>Enter dashboard <ArrowRight size={13} /></>)}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Merchant switcher */}
-        {merchants.length > 0 && (
+        {!user?.isSuperAdminView && merchants.length > 0 && (
           <div className="relative" ref={dropdownRef}>
             <button
               onClick={() => setMerchantOpen((v) => !v)}

--- a/website/src/components/pages/SRRoutingPage.tsx
+++ b/website/src/components/pages/SRRoutingPage.tsx
@@ -165,79 +165,6 @@ interface EliminationConfigResponse {
   }
 }
 
-function CurrentConfigDetails({ config }: { config: SRConfigResponse['config'] }) {
-  return (
-    <div className="text-xs text-slate-600 dark:text-[#b2bdd1] space-y-4">
-      <div className="border-b border-slate-200 pb-3 dark:border-[#222226]">
-        <h3 className="font-medium text-slate-700 mb-2 dark:text-slate-200">Default settings</h3>
-        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-          <div>
-            <span className="text-slate-500">Bucket size</span>
-            <p className="font-medium">{config.data.defaultBucketSize}</p>
-          </div>
-          <div>
-            <span className="text-slate-500">Success rate</span>
-            <p className="font-medium">{config.data.defaultSuccessRate ?? 'Not set'}</p>
-          </div>
-          <div>
-            <span className="text-slate-500">Hedging %</span>
-            <p className="font-medium">{config.data.defaultHedgingPercent ?? 'Not set'}</p>
-          </div>
-          <div>
-            <span className="text-slate-500">Feedback latency window</span>
-            <p className="font-medium">{config.data.defaultLatencyThreshold ?? 'Not set'} s</p>
-          </div>
-          <div>
-            <span className="text-slate-500">Margin</span>
-            <p className="font-medium">{config.data.margin != null ? `${config.data.margin * 100}%` : 'Not set (100%)'}</p>
-          </div>
-        </div>
-      </div>
-
-      {config.data.subLevelInputConfig && config.data.subLevelInputConfig.length > 0 ? (
-        <div>
-          <h3 className="font-medium text-slate-700 mb-2 dark:text-slate-200">Sub-level configurations</h3>
-          <div className="space-y-2">
-            {config.data.subLevelInputConfig.map((subConfig, idx) => (
-              <div key={idx} className="bg-slate-50 dark:bg-[#151518] rounded-lg p-3">
-                <div className="grid grid-cols-2 gap-2 text-xs md:grid-cols-5">
-                  <div>
-                    <span className="text-slate-500">Payment Type:</span>
-                    <p className="font-medium capitalize">{subConfig.paymentMethodType}</p>
-                  </div>
-                  <div>
-                    <span className="text-slate-500">Payment Method:</span>
-                    <p className="font-medium">{subConfig.paymentMethod}</p>
-                  </div>
-                  <div>
-                    <span className="text-slate-500">Bucket size</span>
-                    <p className="font-medium">{subConfig.bucketSize}</p>
-                  </div>
-                  <div>
-                    <span className="text-slate-500">Hedging %</span>
-                    <p className="font-medium">{subConfig.hedgingPercent ?? 'Default'}</p>
-                  </div>
-                  <div>
-                    <span className="text-slate-500">Feedback latency window</span>
-                    <p className="font-medium">{subConfig.latencyThreshold ?? 'Default'} s</p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      <div className="border-t border-slate-200 pt-3 dark:border-[#222226]">
-        <h3 className="font-medium text-slate-700 mb-2 dark:text-slate-200">Raw Configuration (JSON)</h3>
-        <pre className="max-h-64 overflow-auto rounded-lg border border-slate-200/80 bg-slate-50/90 p-3 font-mono text-xs leading-6 text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),0_16px_30px_-28px_rgba(15,23,42,0.18)] dark:border-[#2a303a] dark:bg-[#0b1017] dark:text-[#d8e1ef] dark:shadow-none">
-          {JSON.stringify(config, null, 2)}
-        </pre>
-      </div>
-    </div>
-  )
-}
-
 type SRTab = 'autopilot' | 'manual' | 'flags' | 'cost'
 const SR_TABS: readonly SRTab[] = ['autopilot', 'manual', 'flags', 'cost']
 /** Tabs laid out as a left rail + content pane, which need the full page width to breathe. */
@@ -327,11 +254,7 @@ export function SRRoutingPage() {
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [saveSuccess, setSaveSuccess] = useState(false)
-  const [showCurrentConfig, setShowCurrentConfig] = useState(false)
   const [showSubLevelOverrides, setShowSubLevelOverrides] = useState(false)
-  const [deleting, setDeleting] = useState(false)
-  const [deleteError, setDeleteError] = useState<string | null>(null)
-  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null)
 
   // Shares the SWR key used by OverviewPage/RoutingHubPage so all three surfaces
   // read (and invalidate) the same cached config.
@@ -440,7 +363,6 @@ export function SRRoutingPage() {
           },
         },
       })
-      setLastSavedAt(new Date().toISOString())
       setSaveSuccess(true)
       mutate()
     } catch (err: unknown) {
@@ -449,24 +371,6 @@ export function SRRoutingPage() {
       setSaving(false)
     }
   }
-
-  async function handleDelete() {
-    if (!merchantId) return
-    setDeleting(true); setDeleteError(null)
-    try {
-      await apiPost('/rule/delete', { merchant_id: merchantId, algorithm: 'successRate' })
-      setLastSavedAt(null)
-      mutate(undefined, { revalidate: false })
-    } catch (err: unknown) {
-      setDeleteError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setDeleting(false)
-    }
-  }
-
-  const lastModifiedAt = existing?.modified_at ?? lastSavedAt
-  const lastModifiedDate = lastModifiedAt ? new Date(lastModifiedAt) : null
-  const hasLastModified = Boolean(lastModifiedDate && !Number.isNaN(lastModifiedDate.getTime()))
 
   const tabClass = (tab: SRTab) =>
     `px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
@@ -481,32 +385,11 @@ export function SRRoutingPage() {
     // single-column tabs (Autopilot, Flags) still read better constrained.
     <div className={`space-y-6 ${WIDE_TABS.includes(activeTab) ? 'w-full' : 'max-w-4xl'}`}>
       {/* Page header */}
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h1 className="text-lg font-semibold text-slate-900 dark:text-white">Multi Objective Routing</h1>
-          <p className="mt-0.5 text-[13px] leading-relaxed text-slate-500 dark:text-slate-400">
-            Dynamic gateway scoring based on real-time success rates.
-          </p>
-        </div>
-        {merchantId && !isLoading && existing?.config?.data && (
-          <div className="flex items-center gap-2">
-            <Badge variant="green">Active</Badge>
-            {hasLastModified && lastModifiedDate && (
-              <span className="text-xs text-slate-400">
-                Saved {lastModifiedDate.toLocaleString()}
-              </span>
-            )}
-            <Button type="button" variant="ghost" size="sm" onClick={() => setShowCurrentConfig(v => !v)}>
-              <Eye size={14} className="mr-1" />{showCurrentConfig ? 'Hide config' : 'View config'}
-            </Button>
-            <Button
-              type="button" variant="secondary" size="sm" disabled={deleting}
-              onClick={() => { if (confirm('Clear the Success Rate configuration? This disables SR-based routing.')) handleDelete() }}
-            >
-              <Trash2 size={14} className="mr-1" />{deleting ? 'Clearing…' : 'Clear'}
-            </Button>
-          </div>
-        )}
+      <div>
+        <h1 className="text-lg font-semibold text-slate-900 dark:text-white">Multi Objective Routing</h1>
+        <p className="mt-0.5 text-[13px] leading-relaxed text-slate-500 dark:text-slate-400">
+          Dynamic gateway scoring based on real-time success rates.
+        </p>
       </div>
 
       {!merchantId && (
@@ -514,16 +397,6 @@ export function SRRoutingPage() {
           Set a Merchant ID in the top bar to load and save configuration.
         </div>
       )}
-
-      {/* Expanded config view */}
-      {showCurrentConfig && existing?.config?.data && (
-        <Card>
-          <CardBody>
-            <CurrentConfigDetails config={existing.config} />
-          </CardBody>
-        </Card>
-      )}
-      {deleteError && <p className="text-xs text-red-500">{deleteError}</p>}
 
       {/* Tab navigation */}
       <div className="border-b border-slate-200 dark:border-[#1c1c23]">

--- a/website/src/store/authStore.ts
+++ b/website/src/store/authStore.ts
@@ -14,6 +14,10 @@ export interface AuthUser {
   merchantId: string
   role: string
   isRedirectSession: boolean
+  // This user's email is on the platform super-admin roster (may enter any merchant by ID).
+  isSuperAdmin?: boolean
+  // The current session is a super-admin viewing another merchant's dashboard.
+  isSuperAdminView?: boolean
 }
 
 interface AuthStore {


### PR DESCRIPTION
## What & why

Adds a config-gated **platform super-admin** capability: listed operators can view **any** merchant's dashboard by pasting (or searching for) its ID, without being a member of that merchant. Built for support/ops access; a follow-up can flip these sessions to read-only.

## Design

- **Roster lives in config, not the DB.** `[user_auth].super_admin_emails`, matched case-insensitively against the JWT `email` claim *at the moment of each action* (config is the single source of truth; grant/revoke via redeploy). The field accepts a TOML array **or** a comma-separated string, so it can also be set from the environment: `DECISION_ENGINE__USER_AUTH__SUPER_ADMIN_EMAILS=a@x.com,b@x.com`.
- **New `super_admin_view` token type on the standard-session path** — keeps the admin's *real* identity (`user_id`/`email`) with `merchant_id` pointing at the target, so actions stay attributable. Distinct from the HS-redirect SSO path, which is untouched.
- **Endpoints** (public router, self-verifying like the other `/auth/*` routes):
  - `POST /auth/super-admin/enter-merchant` — rostered standard session → view token for any existing merchant.
  - `POST /auth/super-admin/exit` — view token → fresh standard session (re-checks the roster).
  - `POST /auth/super-admin/lookup` — one query matched (substring, case-insensitive) against member email **and** merchant name, plus exact merchant id; reuses `users`/`user_merchants`/`merchant_account`, no new schema. Capped at 25, LIKE/ILIKE cfg-split per backend, wildcards escaped.
- **Guard tightening:** `switch/create-merchant`, `invite-member`, `change-password` now require a full **standard** session, rejecting both view and hs-redirect tokens.
- **Dashboard:** `is_super_admin` / `is_super_admin_view` on `/auth/me`; a super-admin search + enter control in the top bar (hidden while viewing) and a persistent amber "viewing as super admin · Exit" banner.

## Not in scope (deferred)

- **Read-only enforcement** — the `super_admin_view` token type is the hook; enforce at the `authenticate` middleware later (note: many DE reads are POST, so annotate mutating routes rather than keying off HTTP method).
- Audit log / merchant-visible notice — intentionally omitted for now.

## Tests

- `tests/api/auth/super-admin-view.spec.ts` (Playwright `api` project): enter any merchant + `me` flags; non-super-admin → 403; unknown merchant → 404; view session can't switch-merchant; exit; lookup by id/email; lookup gate; empty query.
- The test identity is **not** shipped in config — `playwright.config.ts` injects the roster into the API server it boots via the env override, single-sourced in `tests/fixtures/super-admin.ts`. `config/development.toml` stays `[]`.

## Verification

- `cargo check` — both `mysql` (default) and `--no-default-features --features postgres`.
- `npm ci && npm run typecheck` — clean.
- Full flow validated end-to-end against a throwaway instance with the roster set **only** via env (enter/me/exit/lookup all correct, no-token → 401).