### PR TITLE
fix(euclid): resolve metadata conditions by field name

### DIFF
--- a/src/euclid/interpreter.rs
+++ b/src/euclid/interpreter.rs
@@ -41,14 +41,15 @@ impl InterpreterBackend {
     ) -> Result<bool, types::InterpreterError> {
         use ast::{ComparisonType::*, ValueType::*};
 
-        let lookup_key = match &comparison.value {
-            MetadataVariant(metadata) => &metadata.key,
-            _ => &comparison.lhs,
+        let (lookup_key, ctx_value) = match &comparison.value {
+            MetadataVariant(metadata) => (
+                &metadata.key,
+                ctx.get(&metadata.key)
+                    .filter(|value| value.as_ref().is_some_and(ast::ValueType::is_metadata))
+                    .or_else(|| ctx.get(&comparison.lhs)),
+            ),
+            _ => (&comparison.lhs, ctx.get(&comparison.lhs)),
         };
-
-        let ctx_value = ctx
-            .get(lookup_key)
-            .or_else(|| ctx.get(&comparison.lhs));
 
         if ctx_value.is_none() {
             crate::logger::debug!(

--- a/src/euclid/interpreter.rs
+++ b/src/euclid/interpreter.rs
@@ -41,10 +41,19 @@ impl InterpreterBackend {
     ) -> Result<bool, types::InterpreterError> {
         use ast::{ComparisonType::*, ValueType::*};
 
-        let ctx_value = ctx.get(&comparison.lhs);
+        let lookup_key = match &comparison.value {
+            MetadataVariant(metadata) => &metadata.key,
+            _ => &comparison.lhs,
+        };
+
+        let ctx_value = ctx
+            .get(lookup_key)
+            .or_else(|| ctx.get(&comparison.lhs));
+
         if ctx_value.is_none() {
             crate::logger::debug!(
-                missing_context_key = %comparison.lhs,
+                missing_context_key = %lookup_key,
+                condition_lhs = %comparison.lhs,
                 "Context key not found while evaluating condition, skipping rule"
             );
             return Ok(false);

--- a/src/euclid/test.rs
+++ b/src/euclid/test.rs
@@ -919,4 +919,134 @@ mod tests {
             );
         }
     }
+
+    mod metadata_conditions {
+        use std::collections::HashMap;
+
+        use crate::euclid::{
+            ast::{
+                Comparison, ComparisonType, ConnectorInfo, MetadataValue, Output, Program, Rule,
+                RoutingType, ValueType,
+            },
+            interpreter::InterpreterBackend,
+            types::Context,
+        };
+
+        fn metadata_value(key: &str, value: &str) -> ValueType {
+            ValueType::MetadataVariant(MetadataValue {
+                key: key.to_string(),
+                value: value.to_string(),
+            })
+        }
+
+        fn gateway(name: &str) -> ConnectorInfo {
+            ConnectorInfo {
+                gateway_name: name.to_string(),
+                gateway_id: None,
+            }
+        }
+
+        fn program_matching(key: &str, value: &str) -> Program {
+            Program {
+                globals: HashMap::new(),
+                default_selection: Output::Priority(vec![gateway("fallback")]),
+                rules: vec![Rule {
+                    name: "metadata_rule".to_string(),
+                    routing_type: RoutingType::Priority,
+                    output: Output::Priority(vec![gateway("matched")]),
+                    statements: vec![crate::euclid::ast::IfStatement {
+                        condition: vec![Comparison {
+                            lhs: "metadata".to_string(),
+                            comparison: ComparisonType::Equal,
+                            value: metadata_value(key, value),
+                            metadata: HashMap::new(),
+                        }],
+                        nested: None,
+                    }],
+                }],
+                metadata: None,
+            }
+        }
+
+        fn matched_rule(program: &Program, ctx: &Context) -> Option<String> {
+            InterpreterBackend::eval_program(program, ctx)
+                .expect("program evaluation failed")
+                .rule_name
+        }
+
+        #[test]
+        fn resolves_field_sent_under_its_own_key() {
+            let ctx = Context::new(HashMap::from([(
+                "customer_id".to_string(),
+                Some(metadata_value("customer_id", "16530688")),
+            )]));
+
+            assert_eq!(
+                matched_rule(&program_matching("customer_id", "16530688"), &ctx),
+                Some("metadata_rule".to_string())
+            );
+        }
+
+        #[test]
+        fn resolves_field_sent_under_the_aggregate_key() {
+            let ctx = Context::new(HashMap::from([(
+                "metadata".to_string(),
+                Some(metadata_value("customer_id", "16530688")),
+            )]));
+
+            assert_eq!(
+                matched_rule(&program_matching("customer_id", "16530688"), &ctx),
+                Some("metadata_rule".to_string())
+            );
+        }
+
+        #[test]
+        fn resolves_every_field_when_several_are_sent() {
+            // The aggregate key can only carry one pair; the per-field entries make the
+            // rest addressable. Each field must be matchable on its own.
+            let ctx = Context::new(HashMap::from([
+                (
+                    "metadata".to_string(),
+                    Some(metadata_value("cohort", "eu-west")),
+                ),
+                (
+                    "cohort".to_string(),
+                    Some(metadata_value("cohort", "eu-west")),
+                ),
+                (
+                    "customer_id".to_string(),
+                    Some(metadata_value("customer_id", "16530688")),
+                ),
+            ]));
+
+            assert_eq!(
+                matched_rule(&program_matching("cohort", "eu-west"), &ctx),
+                Some("metadata_rule".to_string())
+            );
+            assert_eq!(
+                matched_rule(&program_matching("customer_id", "16530688"), &ctx),
+                Some("metadata_rule".to_string())
+            );
+        }
+
+        #[test]
+        fn does_not_match_on_value_mismatch() {
+            let ctx = Context::new(HashMap::from([(
+                "customer_id".to_string(),
+                Some(metadata_value("customer_id", "99999999")),
+            )]));
+
+            assert_eq!(matched_rule(&program_matching("customer_id", "16530688"), &ctx), None);
+        }
+
+        #[test]
+        fn does_not_match_when_field_absent() {
+            let ctx = Context::new(HashMap::from([(
+                "billing_country".to_string(),
+                Some(ValueType::EnumVariant("Canada".to_string())),
+            )]));
+
+            assert_eq!(matched_rule(&program_matching("customer_id", "16530688"), &ctx), None);
+        }
+    }
 }

--- a/src/euclid/test.rs
+++ b/src/euclid/test.rs
@@ -925,8 +925,8 @@ mod tests {
 
         use crate::euclid::{
             ast::{
-                Comparison, ComparisonType, ConnectorInfo, MetadataValue, Output, Program, Rule,
-                RoutingType, ValueType,
+                Comparison, ComparisonType, ConnectorInfo, MetadataValue, Output, Program,
+                RoutingType, Rule, ValueType,
             },
             interpreter::InterpreterBackend,
             types::Context,
@@ -1002,8 +1002,6 @@ mod tests {
 
         #[test]
         fn resolves_every_field_when_several_are_sent() {
-            // The aggregate key can only carry one pair; the per-field entries make the
-            // rest addressable. Each field must be matchable on its own.
             let ctx = Context::new(HashMap::from([
                 (
                     "metadata".to_string(),
@@ -1036,7 +1034,10 @@ mod tests {
                 Some(metadata_value("customer_id", "99999999")),
             )]));
 
-            assert_eq!(matched_rule(&program_matching("customer_id", "16530688"), &ctx), None);
+            assert_eq!(
+                matched_rule(&program_matching("customer_id", "16530688"), &ctx),
+                None
+            );
         }
 
         #[test]
@@ -1046,7 +1047,58 @@ mod tests {
                 Some(ValueType::EnumVariant("Canada".to_string())),
             )]));
 
-            assert_eq!(matched_rule(&program_matching("customer_id", "16530688"), &ctx), None);
+            assert_eq!(
+                matched_rule(&program_matching("customer_id", "16530688"), &ctx),
+                None
+            );
+        }
+
+        #[test]
+        fn falls_back_to_the_aggregate_key_when_the_field_is_null() {
+            let ctx = Context::new(HashMap::from([
+                ("customer_id".to_string(), None),
+                (
+                    "metadata".to_string(),
+                    Some(metadata_value("customer_id", "16530688")),
+                ),
+            ]));
+
+            assert_eq!(
+                matched_rule(&program_matching("customer_id", "16530688"), &ctx),
+                Some("metadata_rule".to_string())
+            );
+        }
+
+        #[test]
+        fn falls_back_when_the_field_name_collides_with_a_standard_parameter() {
+            let ctx = Context::new(HashMap::from([
+                (
+                    "currency".to_string(),
+                    Some(ValueType::EnumVariant("INR".to_string())),
+                ),
+                (
+                    "metadata".to_string(),
+                    Some(metadata_value("currency", "INR")),
+                ),
+            ]));
+
+            assert_eq!(
+                matched_rule(&program_matching("currency", "INR"), &ctx),
+                Some("metadata_rule".to_string())
+            );
+        }
+
+        #[test]
+        fn skips_the_rule_when_a_colliding_parameter_has_no_metadata_to_fall_back_to() {
+            let ctx = Context::new(HashMap::from([(
+                "currency".to_string(),
+                Some(ValueType::EnumVariant("INR".to_string())),
+            )]));
+
+            assert_eq!(
+                matched_rule(&program_matching("currency", "INR"), &ctx),
+                None
+            );
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the interpreter's handling of metadata-based rule matching and adds comprehensive tests to ensure correct behavior. The main changes include improving how context values are resolved for metadata conditions and introducing a suite of tests to verify various scenarios.

### Interpreter logic improvements

* Updated the interpreter to first attempt to resolve context values using the metadata key (when evaluating a `MetadataVariant`), falling back to the original left-hand side key if necessary. This makes metadata-based condition evaluation more robust and flexible.

### Testing enhancements

* Added a new `metadata_conditions` test module in `src/euclid/test.rs` to cover:
  - Matching when the metadata field is present under its own key or an aggregate key.
  - Ensuring each metadata field can be matched individually when multiple fields are present.
  - Verifying that mismatched values or absent fields do not produce false positives.
  
### Testing

<details>
<summary>1. Create Rule</summary>

Request
```
curl --location 'http://localhost:8082/routing/create' \
--header 'Content-Type: application/json' \
--header 'x-admin-secret: test_admin' \
--header 'Accept: */*' \
--data '{
    "name": "customer_id_metadata",
    "description": "metadata = (customer_id, 16530688) -> cid_gw",
    "created_by": "customer_id_probe",
    "algorithm": {
        "type": "advanced",
        "data": {
            "globals": {},
            "default_selection": {
                "priority": [
                    {
                        "gateway_name": "fallback_gw"
                    }
                ]
            },
            "rules": [
                {
                    "name": "customer_id_rule",
                    "routing_type": "priority",
                    "output": {
                        "priority": [
                            {
                                "gateway_name": "cid_gw"
                            }
                        ]
                    },
                    "statements": [
                        {
                            "condition": [
                                {
                                    "lhs": "metadata",
                                    "comparison": "equal",
                                    "value": {
                                        "type": "metadata_variant",
                                        "value": {
                                            "key": "customer_id",
                                            "value": "16530688"
                                        }
                                    },
                                    "metadata": {}
                                }
                            ],
                            "nested": null
                        }
                    ]
                }
            ],
            "metadata": null
        }
    }
}'
```

Response
```
{
    "rule_id": "routing_5efa61dd-92bf-4f8b-819f-4f93a25a7d6b",
    "name": "customer_id_metadata",
    "algorithm_for": "payment",
    "created_at": "2026-08-12 13:10:10.141346",
    "modified_at": "2026-08-12 13:10:10.141346"
}
```
</details>

<details>
<summary>2. Activate Rule</summary>

Request
```
curl --location 'http://localhost:8082/routing/activate' \
--header 'Content-Type: application/json' \
--header 'x-admin-secret: test_admin' \
--header 'Accept: */*' \
--data '{
    "created_by": "customer_id_test",
    "routing_algorithm_id": "routing_5efa61dd-92bf-4f8b-819f-4f93a25a7d6b"
}'
```

</details>

<details>
<summary>3. Evaluate</summary>

Request
```
curl --location 'http://localhost:8082/routing/evaluate' \
--header 'Content-Type: application/json' \
--header 'x-admin-secret: test_admin' \
--header 'Accept: */*' \
--data '{
    "created_by": "customer_id_test",
    "parameters": {
        "customer_id": {
            "type": "metadata_variant",
            "value": {
                "key": "customer_id",
                "value": "16530688"
            }
        },
        "order_source": {
            "type": "metadata_variant",
            "value": {
                "key": "order_source",
                "value": "mobile_app"
            }
        }
    }
}'
```

Response
```
{
    "payment_id": null,
    "status": "success",
    "output": {
        "type": "priority",
        "connectors": [
            {
                "gateway_name": "cid_gw",
                "gateway_id": null
            }
        ]
    },
    "evaluated_output": [
        {
            "gateway_name": "cid_gw",
            "gateway_id": null
        }
    ],
    "eligible_connectors": [
        {
            "gateway_name": "cid_gw",
            "gateway_id": null
        }
    ]
}
```
</details>

<details>
<summary>4. Decide Gateway</summary>

Request
```
curl --location 'http://localhost:8082/routing/hybrid' \
--header 'Content-Type: application/json' \
--header 'x-admin-secret: test_admin' \
--header 'Accept: */*' \
--data '{
  "static_routing_request": {
    "created_by": "customer_id_test",
    "payment_id": "pay_meta_001",
    "parameters": {
      "customer_id":  {"type":"metadata_variant","value":{"key":"customer_id","value":"16530688"}},
      "order_source": {"type":"metadata_variant","value":{"key":"order_source","value":"mobile_app"}}
    }
  },
  "dynamic_routing_request": {
    "merchantId": "customer_id_test",
    "eligibleGatewayList": ["cid_gw", "fallback_gw"],
    "rankingAlgorithm": "SR_BASED_ROUTING",
    "eliminationEnabled": false,
    "paymentInfo": {
      "paymentId": "pay_meta_001",
      "amount": 100.0,
      "currency": "INR",
      "customerId": "16530688",
      "paymentType": "ORDER_PAYMENT",
      "paymentMethodType": "CARD",
      "paymentMethod": "VISA",
      "metadata": "{\"customer_id\":\"16530688\",\"order_source\":\"mobile_app\"}"
    }
  }
}'
```

Response
```
{
    "static_routing": {
        "payment_id": "pay_meta_001",
        "status": "success",
        "output": {
            "type": "priority",
            "connectors": [
                {
                    "gateway_name": "cid_gw",
                    "gateway_id": null
                }
            ]
        },
        "evaluated_output": [
            {
                "gateway_name": "cid_gw",
                "gateway_id": null
            }
        ],
        "eligible_connectors": [
            {
                "gateway_name": "cid_gw",
                "gateway_id": null
            }
        ]
    },
    "dynamic_routing": {
        "status": "fallback",
        "decision": null,
        "fallback_connectors": [
            {
                "gateway_name": "cid_gw",
                "gateway_id": null
            }
        ]
    },
    "evaluated_connectors": [
        {
            "gateway_name": "cid_gw",
            "gateway_id": null
        }
    ]
}
```
</details>

