### PR TITLE
feat(card_info): add tenant_id to CardInfoServiceConfig and include in API request headers

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -94,6 +94,7 @@ zstd_compression_filepath = "/tmp/extra-paths/redis-zstd-dictionaries/sbx"
 base_url = "https://integ.hyperswitch.io/api/cards"
 api_key = "hyperswitch_api_key"
 timeout_ms = 2000
+tenant_id = "public"
 
 [cost_ingestion]
 # Drain webhook-enqueued jobs in this process. Off by default so only a dedicated ingest

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,7 @@ pub struct CardInfoServiceConfig {
     pub base_url: String,
     pub api_key: masking::Secret<String>,
     pub timeout_ms: u64,
+    pub tenant_id: String,
 }
 
 impl Default for CardInfoServiceConfig {
@@ -86,6 +87,7 @@ impl Default for CardInfoServiceConfig {
             base_url: "https://integ.hyperswitch.io/api/cards".to_string(),
             api_key: masking::Secret::new(String::new()),
             timeout_ms: 2_000,
+            tenant_id: "public".to_string(),
         }
     }
 }
@@ -165,7 +167,7 @@ where
     impl<'de> serde::de::Visitor<'de> for StringOrSeq {
         type Value = Vec<String>;
 
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             formatter.write_str("a list of strings or a comma-separated string")
         }
 

--- a/src/types/card/card_info_api.rs
+++ b/src/types/card/card_info_api.rs
@@ -87,6 +87,7 @@ pub async fn get_card_info_by_bin(card_bin: Option<String>) -> Option<CardInfo> 
     let fut = client()
         .get(&url)
         .header("api-key", cfg.api_key.peek().as_str())
+        .header("x-tenant-id", cfg.tenant_id.as_str())
         .send();
 
     let response = match tokio::time::timeout(Duration::from_millis(cfg.timeout_ms), fut).await {
@@ -112,11 +113,14 @@ pub async fn get_card_info_by_bin(card_bin: Option<String>) -> Option<CardInfo> 
     };
 
     if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
         logger::warn!(
             tag = "cardInfoApi",
-            "non-2xx for bin {}: {}",
+            "non-2xx for bin {}: {} - {}",
             bin,
-            response.status()
+            status,
+            body
         );
         return None;
     }

--- a/src/types/card/card_info_api.rs
+++ b/src/types/card/card_info_api.rs
@@ -113,14 +113,11 @@ pub async fn get_card_info_by_bin(card_bin: Option<String>) -> Option<CardInfo> 
     };
 
     if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
         logger::warn!(
             tag = "cardInfoApi",
-            "non-2xx for bin {}: {} - {}",
+            "non-2xx for bin {}: {}",
             bin,
-            status,
-            body
+            response.status()
         );
         return None;
     }


### PR DESCRIPTION
This pull request adds support for specifying a `tenant_id` when making requests to the Card Info API, improves logging for non-successful API responses, and includes a minor code style fix. The main changes are grouped below by theme:

**Card Info API configuration and usage:**

* Added a new `tenant_id` field to the `CardInfoServiceConfig` struct and its default implementation, allowing the tenant ID to be configured in both code and the `development.toml` config file. (`src/config.rs`, `config/development.toml`) [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR81) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR90) [[3]](diffhunk://#diff-eeba5fd66f2753499ebdfe068ce07b9712c29d509dbd25e20eae2df0648c5c4eR97)
* Updated the Card Info API request to include the `x-tenant-id` header, using the configured `tenant_id` value. (`src/types/card/card_info_api.rs`)

**Logging improvements:**

* Enhanced logging for non-2xx responses from the Card Info API to include both the HTTP status and the response body, making debugging easier. (`src/types/card/card_info_api.rs`)

**Code style:**

* Fixed the signature of the `expecting` method in a serde visitor implementation for clarity and correctness. (`src/config.rs`)


req
```
curl --location 'http://localhost:8080/decide-gateway' \
--header 'Content-Type: application/json' \
--header 'x-api-key: DE_47c4cedc8bb8401d836bd8e20c02f89533852c2c1e0e45b7bca6df1487af0fb5' \
--data '{
    "paymentInfo": {
    "paymentId": "pay_123456789",
    "amount": 90,
    "currency": "USD",
    "country": null,
    "customerId": null,
    "udfs": null,
    "preferredGateway": null,
    "paymentType": "ORDER_PAYMENT",
    "metadata": null,
    "internalMetadata": null,
    "isEmi": null,
    "emiBank": null,
    "emiTenure": null,
    "paymentMethodType": "DEBIT",
    "paymentMethod": "card",
    "paymentSource": null,
    
    "cardIssuerBankName": null,
    "cardIsin": "40342151",
    "cardType": null,
    "cardSwitchProvider": null,
    "cardProgram": null,
    "cardIssuerCountry": null,
    "channel": "ecom"
  },
    "merchantId": "test_merchant_123456789",
    "eligibleGatewayList": [
        "stripe",
        "adyen"
    ],
    "rankingAlgorithm": "SR_BASED_ROUTING",
    "eliminationEnabled": false,
    "enableMultiObjective": true
}'
```

res
```
{
    "decided_gateway": "adyen",
    "fallback_gateways": [
        "stripe"
    ],
    "gateway_priority_map": {
        "adyen": 1.0,
        "stripe": 1.0
    },
    "filter_wise_gateways": null,
    "priority_logic_tag": null,
    "routing_approach": "SR_SELECTION_V3_ROUTING",
    "gateway_before_evaluation": "adyen",
    "priority_logic_output": {
        "isEnforcement": false,
        "gws": [
            "stripe",
            "adyen"
        ],
        "priorityLogicTag": null,
        "gatewayReferenceIds": {},
        "primaryLogic": null,
        "fallbackLogic": null
    },
    "debit_routing_output": null,
    "reset_approach": "NO_RESET",
    "routing_dimension": "ORDER_PAYMENT, DEBIT, card",
    "routing_dimension_level": "PM_LEVEL",
    "is_scheduled_outage": false,
    "is_dynamic_mga_enabled": false,
    "gateway_mga_id_map": null,
    "is_rust_based_decider": true,
    "latency": 215,
    "multi_objective_info": {
        "outcome": "AUTH_WON",
        "reason": "SR head retained — it is the highest expected-value PSP (2 ranked on EV).",
        "costSavedBps": null,
        "qualifiedCount": 2,
        "margin": 1.0,
        "evGapTop2": 0.010266666666666646,
        "ranked": [
            {
                "psp": "adyen",
                "authRate": 1.0,
                "costBps": 220.66666666666666,
                "costSource": "SEED",
                "costModel": {
                    "brand": "visa",
                    "ccy": "USD",
                    "pctBps": 194.0,
                    "fixedFee": 0.24
                },
                "ev": 0.9779333333333333,
                "isSrHead": true,
                "isChosen": true
            },
            {
                "psp": "stripe",
                "authRate": 1.0,
                "costBps": 323.3333333333333,
                "costSource": "SEED",
                "costModel": {
                    "brand": "visa",
                    "ccy": "USD",
                    "pctBps": 290.0,
                    "fixedFee": 0.3
                },
                "ev": 0.9676666666666667,
                "isSrHead": false,
                "isChosen": false
            }
        ]
    }
}
```