### PR TITLE
fix(hybrid_routing): prioritize evaluated connectors in evaluate_output

### DIFF
--- a/src/decider/gatewaydecider/ab_test/preview.rs
+++ b/src/decider/gatewaydecider/ab_test/preview.rs
@@ -48,7 +48,7 @@ pub async fn evaluate_arm(
                 ))
             })?;
         let out_enum = Output::Single(chosen.clone());
-        let (_, evaluated) = evaluate_output(&out_enum).map_err(|_| {
+        let evaluated = evaluate_output(&out_enum).map_err(|_| {
             ContainerError::from(EuclidErrors::FailedToEvaluateOutput(
                 "ab_test sr routing arm evaluation".into(),
             ))
@@ -83,7 +83,7 @@ pub async fn evaluate_arm(
     let (output, evaluated_output, rule_name) = match arm_algorithm_data {
         StaticRoutingAlgorithm::Single(conn) => {
             let out_enum = Output::Single(*conn.clone());
-            let (_, eval) = evaluate_output(&out_enum).map_err(|_| {
+            let eval = evaluate_output(&out_enum).map_err(|_| {
                 ContainerError::from(EuclidErrors::FailedToEvaluateOutput(format!(
                     "ab_test arm single: {}",
                     conn.gateway_name
@@ -97,7 +97,7 @@ pub async fn evaluate_arm(
         }
         StaticRoutingAlgorithm::Priority(connectors) => {
             let out_enum = Output::Priority(connectors.clone());
-            let (_, eval) = evaluate_output(&out_enum).map_err(|_| {
+            let eval = evaluate_output(&out_enum).map_err(|_| {
                 ContainerError::from(EuclidErrors::FailedToEvaluateOutput(
                     "ab_test arm priority".into(),
                 ))
@@ -106,7 +106,7 @@ pub async fn evaluate_arm(
         }
         StaticRoutingAlgorithm::VolumeSplit(splits) => {
             let out_enum = Output::VolumeSplit(splits.clone());
-            let (_, eval) = evaluate_output(&out_enum).map_err(|_| {
+            let eval = evaluate_output(&out_enum).map_err(|_| {
                 ContainerError::from(EuclidErrors::FailedToEvaluateOutput(
                     "ab_test arm volume_split".into(),
                 ))
@@ -125,7 +125,7 @@ pub async fn evaluate_arm(
                 if let Some(fallback) = payload.fallback_output.clone() {
                     ir.rule_name = Some("default_fallback".to_string());
                     ir.output = Output::Priority(fallback.clone());
-                    ir.evaluated_output = vec![fallback.into_iter().next().unwrap_or_default()];
+                    ir.evaluated_output = fallback;
                 }
             }
             (ir.output, ir.evaluated_output, ir.rule_name)

--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -643,7 +643,7 @@ pub async fn routing_evaluate(
                         StaticRoutingAlgorithm::Single(conn.clone())
                     ))
                 }) {
-                    Ok((_, eval)) => (out_enum, eval, Some("straight_through_rule".into())),
+                    Ok(eval) => (out_enum, eval, Some("straight_through_rule".into())),
                     Err(e) => return fail_preview(e.into(), "preview_output_evaluation_failed"),
                 }
             }
@@ -656,7 +656,7 @@ pub async fn routing_evaluate(
                         StaticRoutingAlgorithm::Priority(connectors.clone())
                     ))
                 }) {
-                    Ok((_, eval)) => (out_enum, eval, Some("priority_rule".into())),
+                    Ok(eval) => (out_enum, eval, Some("priority_rule".into())),
                     Err(e) => return fail_preview(e.into(), "preview_output_evaluation_failed"),
                 }
             }
@@ -669,7 +669,7 @@ pub async fn routing_evaluate(
                         StaticRoutingAlgorithm::VolumeSplit(splits.clone())
                     ))
                 }) {
-                    Ok((_, eval)) => (out_enum, eval, Some("volume_split_rule".into())),
+                    Ok(eval) => (out_enum, eval, Some("volume_split_rule".into())),
                     Err(e) => return fail_preview(e.into(), "preview_output_evaluation_failed"),
                 }
             }
@@ -692,8 +692,7 @@ pub async fn routing_evaluate(
                             if let Some(fallback_connector) = payload.fallback_output.clone() {
                                 ir.rule_name = Some("default_fallback".to_string());
                                 ir.output = Output::Priority(fallback_connector.clone());
-                                ir.evaluated_output =
-                                    vec![fallback_connector.first().cloned().unwrap_or_default()];
+                                ir.evaluated_output = fallback_connector;
                             }
                         }
                         (ir.output, ir.evaluated_output, ir.rule_name)
@@ -752,6 +751,9 @@ pub async fn routing_evaluate(
         &parameters,
         &connectors_for_eligibility,
     );
+
+    let evaluated_output =
+        narrow_evaluated_output_to_eligible(evaluated_output, &eligible_connectors);
 
     let response = RoutingEvaluateResponse {
         payment_id: payload.payment_id.clone(),
@@ -1498,6 +1500,16 @@ pub(crate) fn apply_pm_filter_eligibility(
     };
 
     pm_filter_graph::filter_eligible_connectors(bundle, parameters, eligible_connectors)
+}
+
+pub(crate) fn narrow_evaluated_output_to_eligible(
+    evaluated_output: Vec<ConnectorInfo>,
+    eligible_connectors: &[ConnectorInfo],
+) -> Vec<ConnectorInfo> {
+    evaluated_output
+        .into_iter()
+        .filter(|connector| eligible_connectors.contains(connector))
+        .collect()
 }
 
 pub(crate) fn extract_connectors_for_eligibility(output: &Output) -> Vec<ConnectorInfo> {

--- a/src/euclid/interpreter.rs
+++ b/src/euclid/interpreter.rs
@@ -245,15 +245,15 @@ pub fn perform_volume_split(
 pub fn perform_volume_split_priority(
     splits: Vec<VolumeSplit<Vec<ConnectorInfo>>>,
 ) -> RoutingResult<Vec<ConnectorInfo>> {
-    let mut ordered: Vec<ConnectorInfo> = Vec::new();
-    for connectors in sample_split_winner_first(splits)? {
-        for connector in connectors {
+    Ok(sample_split_winner_first(splits)?
+        .into_iter()
+        .flatten()
+        .fold(Vec::new(), |mut ordered, connector| {
             if !ordered.contains(&connector) {
                 ordered.push(connector);
             }
-        }
-    }
-    Ok(ordered)
+            ordered
+        }))
 }
 
 pub fn evaluate_output(output: &Output) -> RoutingResult<Vec<ConnectorInfo>> {

--- a/src/euclid/interpreter.rs
+++ b/src/euclid/interpreter.rs
@@ -220,9 +220,7 @@ impl fmt::Display for RoutingError {
 impl Error for RoutingError {}
 type RoutingResult<T> = Result<T, RoutingError>;
 
-pub fn perform_volume_split(
-    mut splits: Vec<VolumeSplit<ConnectorInfo>>,
-) -> RoutingResult<Vec<ConnectorInfo>> {
+fn sample_split_winner_first<T>(mut splits: Vec<VolumeSplit<T>>) -> RoutingResult<Vec<T>> {
     let weights: Vec<u8> = splits.iter().map(|sp| sp.split).collect();
     let weighted_index =
         WeightedIndex::new(weights).map_err(|_| RoutingError::VolumeSplitFailed)?;
@@ -238,24 +236,18 @@ pub fn perform_volume_split(
     Ok(splits.into_iter().map(|split| split.output).collect())
 }
 
-pub fn perform_volume_split_priority(
-    mut splits: Vec<VolumeSplit<Vec<ConnectorInfo>>>,
+pub fn perform_volume_split(
+    splits: Vec<VolumeSplit<ConnectorInfo>>,
 ) -> RoutingResult<Vec<ConnectorInfo>> {
-    let weights: Vec<u8> = splits.iter().map(|sp| sp.split).collect();
-    let weighted_index =
-        WeightedIndex::new(weights).map_err(|_| RoutingError::VolumeSplitFailed)?;
-    let mut rng = rand::thread_rng();
-    let idx = weighted_index.sample(&mut rng);
+    sample_split_winner_first(splits)
+}
 
-    if idx >= splits.len() {
-        return Err(RoutingError::VolumeSplitFailed);
-    }
-    let winner = splits.remove(idx);
-    splits.insert(0, winner);
-
+pub fn perform_volume_split_priority(
+    splits: Vec<VolumeSplit<Vec<ConnectorInfo>>>,
+) -> RoutingResult<Vec<ConnectorInfo>> {
     let mut ordered: Vec<ConnectorInfo> = Vec::new();
-    for split in splits {
-        for connector in split.output {
+    for connectors in sample_split_winner_first(splits)? {
+        for connector in connectors {
             if !ordered.contains(&connector) {
                 ordered.push(connector);
             }

--- a/src/euclid/interpreter.rs
+++ b/src/euclid/interpreter.rs
@@ -174,7 +174,7 @@ impl InterpreterBackend {
             let res = Self::eval_rule(rule, ctx, &program.globals)?;
 
             if res {
-                let (_, evaluated_output) =
+                let evaluated_output =
                     evaluate_output(&rule.output).map_err(|e| types::InterpreterError {
                         error_type: types::InterpreterErrorType::OutputEvaluationFailed(format!(
                             "{:?}",
@@ -191,7 +191,7 @@ impl InterpreterBackend {
         }
 
         // If no rule matched, evaluate default selection
-        let (_, evaluated_output) =
+        let evaluated_output =
             evaluate_output(&program.default_selection).map_err(|e| types::InterpreterError {
                 error_type: types::InterpreterErrorType::OutputEvaluationFailed(format!("{:?}", e)),
                 metadata: HashMap::new(),
@@ -221,50 +221,54 @@ impl Error for RoutingError {}
 type RoutingResult<T> = Result<T, RoutingError>;
 
 pub fn perform_volume_split(
-    splits: Vec<VolumeSplit<ConnectorInfo>>,
-) -> RoutingResult<ConnectorInfo> {
-    let weights: Vec<u8> = splits.iter().map(|sp| sp.split).collect();
-    let weighted_index =
-        WeightedIndex::new(weights).map_err(|_| RoutingError::VolumeSplitFailed)?;
-    let mut rng = rand::thread_rng();
-    let idx = weighted_index.sample(&mut rng);
-    splits
-        .get(idx)
-        .map(|split| split.output.clone())
-        .ok_or(RoutingError::VolumeSplitFailed)
-}
-
-pub fn perform_volume_split_priority(
-    splits: Vec<VolumeSplit<Vec<ConnectorInfo>>>,
+    mut splits: Vec<VolumeSplit<ConnectorInfo>>,
 ) -> RoutingResult<Vec<ConnectorInfo>> {
     let weights: Vec<u8> = splits.iter().map(|sp| sp.split).collect();
     let weighted_index =
         WeightedIndex::new(weights).map_err(|_| RoutingError::VolumeSplitFailed)?;
     let mut rng = rand::thread_rng();
     let idx = weighted_index.sample(&mut rng);
-    splits
-        .get(idx)
-        .map(|split| split.output.clone())
-        .ok_or(RoutingError::VolumeSplitFailed)
+
+    if idx >= splits.len() {
+        return Err(RoutingError::VolumeSplitFailed);
+    }
+    let winner = splits.remove(idx);
+    splits.insert(0, winner);
+
+    Ok(splits.into_iter().map(|split| split.output).collect())
 }
 
-pub fn evaluate_output(output: &Output) -> RoutingResult<(Vec<ConnectorInfo>, Vec<ConnectorInfo>)> {
+pub fn perform_volume_split_priority(
+    mut splits: Vec<VolumeSplit<Vec<ConnectorInfo>>>,
+) -> RoutingResult<Vec<ConnectorInfo>> {
+    let weights: Vec<u8> = splits.iter().map(|sp| sp.split).collect();
+    let weighted_index =
+        WeightedIndex::new(weights).map_err(|_| RoutingError::VolumeSplitFailed)?;
+    let mut rng = rand::thread_rng();
+    let idx = weighted_index.sample(&mut rng);
+
+    if idx >= splits.len() {
+        return Err(RoutingError::VolumeSplitFailed);
+    }
+    let winner = splits.remove(idx);
+    splits.insert(0, winner);
+
+    let mut ordered: Vec<ConnectorInfo> = Vec::new();
+    for split in splits {
+        for connector in split.output {
+            if !ordered.contains(&connector) {
+                ordered.push(connector);
+            }
+        }
+    }
+    Ok(ordered)
+}
+
+pub fn evaluate_output(output: &Output) -> RoutingResult<Vec<ConnectorInfo>> {
     match output {
-        Output::Single(connector) => Ok((vec![connector.clone()], vec![connector.clone()])),
-        Output::Priority(connectors) => {
-            let first_connector = connectors.first().cloned();
-            Ok((
-                connectors.clone(),
-                vec![first_connector.unwrap_or_default()],
-            ))
-        }
-        Output::VolumeSplit(splits) => {
-            let selected_connector = perform_volume_split(splits.clone())?;
-            Ok((vec![selected_connector.clone()], vec![selected_connector]))
-        }
-        Output::VolumeSplitPriority(splits) => {
-            let selected_list = perform_volume_split_priority(splits.clone())?;
-            Ok((selected_list.clone(), selected_list))
-        }
+        Output::Single(connector) => Ok(vec![connector.clone()]),
+        Output::Priority(connectors) => Ok(connectors.clone()),
+        Output::VolumeSplit(splits) => perform_volume_split(splits.clone()),
+        Output::VolumeSplitPriority(splits) => perform_volume_split_priority(splits.clone()),
     }
 }

--- a/src/routes/hybrid_routing.rs
+++ b/src/routes/hybrid_routing.rs
@@ -63,7 +63,21 @@ fn log_serializable_response<T: Serialize>(label: &str, value: &T) {
 fn extract_static_eligible_gateways(
     response: &crate::euclid::types::RoutingEvaluateResponse,
 ) -> Vec<ConnectorInfo> {
-    response.eligible_connectors.clone()
+    let eligible = &response.eligible_connectors;
+    let mut ordered = Vec::with_capacity(eligible.len());
+
+    for connector in response
+        .evaluated_output
+        .iter()
+        .filter(|evaluated| eligible.contains(evaluated))
+        .chain(eligible)
+    {
+        if !ordered.contains(connector) {
+            ordered.push(connector.clone());
+        }
+    }
+
+    ordered
 }
 
 fn extract_gateway_names(connectors: &[ConnectorInfo]) -> Vec<String> {

--- a/src/routes/hybrid_routing.rs
+++ b/src/routes/hybrid_routing.rs
@@ -56,28 +56,16 @@ fn log_serializable_response<T: Serialize>(label: &str, value: &T) {
     }
 }
 
-/// Extracts ordered connector blobs from static routing output.
+/// The client-facing connector list for a static routing result. A straight clone of
+/// `evaluated_output`, which is already the routing answer — selection at the head, eligible
+/// fallbacks behind it (see `routing_evaluate`).
 ///
-/// Order is preserved intentionally because static routing can return
-/// connector priority, and dynamic routing consumes this as candidate order.
+/// Not `eligible_connectors`, which is what the rule *could* pick, in declaration order, not what
+/// it *chose*.
 fn extract_static_eligible_gateways(
     response: &crate::euclid::types::RoutingEvaluateResponse,
 ) -> Vec<ConnectorInfo> {
-    let eligible = &response.eligible_connectors;
-    let mut ordered = Vec::with_capacity(eligible.len());
-
-    for connector in response
-        .evaluated_output
-        .iter()
-        .filter(|evaluated| eligible.contains(evaluated))
-        .chain(eligible)
-    {
-        if !ordered.contains(connector) {
-            ordered.push(connector.clone());
-        }
-    }
-
-    ordered
+    response.evaluated_output.clone()
 }
 
 fn extract_gateway_names(connectors: &[ConnectorInfo]) -> Vec<String> {


### PR DESCRIPTION
This pull request refactors how evaluated outputs are handled throughout the routing evaluation logic, simplifying the interface of `evaluate_output` and related functions. Now, `evaluate_output` returns only the evaluated connectors (instead of a tuple), and the code consistently uses this new interface across different routing strategies. Additionally, the handling of fallback connectors and eligible connectors is improved for clarity and correctness.

The most important changes are:

**Refactoring evaluated output handling:**
- Refactored `evaluate_output` to return only a `Vec<ConnectorInfo>` instead of a tuple, and updated all call sites to use the new return type. This affects routing evaluation in both static and dynamic routing paths (`src/decider/gatewaydecider/ab_test/preview.rs`, `src/euclid/handlers/routing_rules.rs`, `src/euclid/interpreter.rs`). [[1]](diffhunk://#diff-8bf6437c4b27c6e6c276ca386ffe3bd8d897621fd81848306610bf0209376e7cL51-R51) [[2]](diffhunk://#diff-8bf6437c4b27c6e6c276ca386ffe3bd8d897621fd81848306610bf0209376e7cL86-R86) [[3]](diffhunk://#diff-8bf6437c4b27c6e6c276ca386ffe3bd8d897621fd81848306610bf0209376e7cL100-R100) [[4]](diffhunk://#diff-8bf6437c4b27c6e6c276ca386ffe3bd8d897621fd81848306610bf0209376e7cL109-R109) [[5]](diffhunk://#diff-30fc6f0577563f2ccaf5c8588b6ef5cde3749cb1b3e4000b37341d2699d85764L646-R646) [[6]](diffhunk://#diff-30fc6f0577563f2ccaf5c8588b6ef5cde3749cb1b3e4000b37341d2699d85764L659-R659) [[7]](diffhunk://#diff-30fc6f0577563f2ccaf5c8588b6ef5cde3749cb1b3e4000b37341d2699d85764L672-R672) [[8]](diffhunk://#diff-b17de44b27254e12c49c50ff50dd7a4447269269599e62109450b0980a5daaf3L177-R177) [[9]](diffhunk://#diff-b17de44b27254e12c49c50ff50dd7a4447269269599e62109450b0980a5daaf3L194-R194)

- Simplified the fallback connector handling: now, when a fallback is used, the evaluated output is set directly to the fallback list, rather than wrapping it in an extra vector. This ensures the evaluated output accurately reflects the connectors that will be tried. [[1]](diffhunk://#diff-8bf6437c4b27c6e6c276ca386ffe3bd8d897621fd81848306610bf0209376e7cL128-R128) [[2]](diffhunk://#diff-30fc6f0577563f2ccaf5c8588b6ef5cde3749cb1b3e4000b37341d2699d85764L695-R695)

**Routing logic improvements:**
- Added a helper function `narrow_evaluated_output_to_eligible` to filter the evaluated output by eligible connectors, ensuring only eligible connectors are returned in responses. [[1]](diffhunk://#diff-30fc6f0577563f2ccaf5c8588b6ef5cde3749cb1b3e4000b37341d2699d85764R755-R757) [[2]](diffhunk://#diff-30fc6f0577563f2ccaf5c8588b6ef5cde3749cb1b3e4000b37341d2699d85764R1505-R1514)

**Volume split logic changes:**
- Updated `perform_volume_split` and `perform_volume_split_priority` to return an ordered list of connectors, with the selected connector(s) at the head, instead of just a single connector. This provides more context for downstream consumers.

**API and documentation clarity:**
- Updated the documentation and implementation of `extract_static_eligible_gateways` to return the actual evaluated output (the routing answer), improving clarity for consumers of this API.

---

## Test cases

### 1. Priority rule — the full chain is returned, not just the head

**POST** `{{base_url}}/routing/create` — Body → raw (JSON)

```json
{
  "name": "priority_rule",
  "description": "Test Rule",
  "created_by": "{{merchant_id}}",
  "algorithm_for": "payment",
  "algorithm": {
    "type": "priority",
    "data": [
      { "gateway_name": "stripe",   "gateway_id": "mca_stripe" },
      { "gateway_name": "razorpay", "gateway_id": "mca_razorpay" },
      { "gateway_name": "adyen",    "gateway_id": "mca_adyen" }
    ]
  },
  "metadata": {}
}
```


```json
{
  "rule_id": "routing_0c0721f0-cd30-435f-acb5-e74fb3e73c2e",
  "name": "priority_rule",
  "algorithm_for": "payment",
  "created_at": "2026-08-18 22:59:08.278418",
  "modified_at": "2026-08-18 22:59:08.278418"
}
```

**POST** `{{base_url}}/routing/activate` — Body → raw (JSON)

```json
{ "created_by": "{{merchant_id}}", "routing_algorithm_id": "{{rule_id}}" }
```


**POST** `{{base_url}}/routing/evaluate` — Body → raw (JSON)

```json
{
  "created_by": "{{merchant_id}}",
  "parameters": {
    "payment_method": { "type": "enum_variant", "value": "card" },
    "amount": { "type": "number", "value": 100 }
  }
}
```


```json
{
  "payment_id": null,
  "status": "success",
  "output": {
    "type": "priority",
    "connectors": [
      { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
      { "gateway_name": "razorpay", "gateway_id": "mca_razorpay" },
      { "gateway_name": "adyen", "gateway_id": "mca_adyen" }
    ]
  },
  "evaluated_output": [
    { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
    { "gateway_name": "razorpay", "gateway_id": "mca_razorpay" },
    { "gateway_name": "adyen", "gateway_id": "mca_adyen" }
  ],
  "eligible_connectors": [
    { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
    { "gateway_name": "razorpay", "gateway_id": "mca_razorpay" },
    { "gateway_name": "adyen", "gateway_id": "mca_adyen" }
  ]
}
```

`evaluated_output` was `[stripe]` before this PR.

---

### 2. Volume split rule — 70/30, winner at the head, losing arm retained

**POST** `{{base_url}}/routing/create` — Body → raw (JSON)

```json
{
  "name": "volume_split_rule",
  "description": "Test Rule",
  "created_by": "{{merchant_id}}",
  "algorithm_for": "payment",
  "algorithm": {
    "type": "volume_split",
    "data": [
      { "split": 70, "output": { "gateway_name": "stripe", "gateway_id": "mca_stripe" } },
      { "split": 30, "output": { "gateway_name": "paytm",  "gateway_id": "mca_paytm" } }
    ]
  },
  "metadata": {}
}
```


```json
{
  "rule_id": "routing_05d1330c-21c6-4049-a5e6-fdff2c09f7c2",
  "name": "volume_split_rule",
  "algorithm_for": "payment",
  "created_at": "2026-08-18 22:59:08.347473",
  "modified_at": "2026-08-18 22:59:08.347473"
}
```

**POST** `{{base_url}}/routing/evaluate` — same body as case 1


```json
{
  "payment_id": null,
  "status": "success",
  "output": {
    "type": "volume_split",
    "splits": [
      { "connector": { "gateway_name": "stripe", "gateway_id": "mca_stripe" }, "split": 70 },
      { "connector": { "gateway_name": "paytm",  "gateway_id": "mca_paytm" },  "split": 30 }
    ]
  },
  "evaluated_output": [
    { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
    { "gateway_name": "paytm",  "gateway_id": "mca_paytm" }
  ],
  "eligible_connectors": [
    { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
    { "gateway_name": "paytm",  "gateway_id": "mca_paytm" }
  ]
}
```

Real weights mean one response can't prove the behaviour, so the same request was replayed 200 times:

```
head of evaluated_output:
  129 stripe   (64.5% , declared 70%)
   71 paytm    (35.5% , declared 30%)

```

Both arms are present on every one of the 200 responses — before this PR the losing arm was dropped
and only the sampled connector came back.

---

### 3. `volume_split_priority` output — 60/40, winning list first, deduped

`adyen` is deliberately declared in both arms.

**POST** `{{base_url}}/routing/create` — Body → raw (JSON)

```json
{
  "name": "vsp_rule",
  "description": "Test Rule",
  "created_by": "{{merchant_id}}",
  "algorithm_for": "payment",
  "algorithm": {
    "type": "advanced",
    "data": {
      "globals": {},
      "default_selection": { "priority": [ { "gateway_name": "adyen", "gateway_id": "mca_adyen" } ] },
      "rules": [{
        "name": "card_rule",
        "routing_type": "volume_split_priority",
        "output": {
          "volume_split_priority": [
            { "split": 60, "output": [ { "gateway_name": "stripe",   "gateway_id": "mca_stripe" },
                                       { "gateway_name": "adyen",    "gateway_id": "mca_adyen" } ] },
            { "split": 40, "output": [ { "gateway_name": "checkout", "gateway_id": "mca_checkout" },
                                       { "gateway_name": "adyen",    "gateway_id": "mca_adyen" } ] }
          ]
        },
        "statements": [{ "condition": [
          { "lhs": "payment_method", "comparison": "equal",
            "value": { "type": "enum_variant", "value": "card" }, "metadata": {} }
        ]}]
      }]
    }
  },
  "metadata": {}
}
```


**POST** `{{base_url}}/routing/evaluate` — same body as case 1


```json
{
  "payment_id": null,
  "status": "success",
  "output": {
    "type": "volume_split_priority",
    "splits": [
      { "connectors": [ { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
                        { "gateway_name": "adyen",  "gateway_id": "mca_adyen" } ], "split": 60 },
      { "connectors": [ { "gateway_name": "checkout", "gateway_id": "mca_checkout" },
                        { "gateway_name": "adyen",    "gateway_id": "mca_adyen" } ], "split": 40 }
    ]
  },
  "evaluated_output": [
    { "gateway_name": "stripe",   "gateway_id": "mca_stripe" },
    { "gateway_name": "adyen",    "gateway_id": "mca_adyen" },
    { "gateway_name": "checkout", "gateway_id": "mca_checkout" }
  ],
  "eligible_connectors": [
    { "gateway_name": "stripe",   "gateway_id": "mca_stripe" },
    { "gateway_name": "adyen",    "gateway_id": "mca_adyen" },
    { "gateway_name": "checkout", "gateway_id": "mca_checkout" }
  ]
}
```

100 replays produce exactly two orderings, each 3 entries long — the 4 declared connector slots
collapse to 3 because `adyen` is deduped across arms:

```
  65 stripe,adyen,checkout   (65% , declared 60%)
  35 checkout,adyen,stripe   (35% , declared 40%)
```

---

### 4. Advanced rule falling through to `fallback_output`

The rule matches `card`; the request sends `upi`, so the interpreter lands on `default_selection`
and the caller's `fallback_output` takes over.

**POST** `{{base_url}}/routing/create` — Body → raw (JSON)

```json
{
  "name": "fallback_rule",
  "description": "Test Rule",
  "created_by": "{{merchant_id}}",
  "algorithm_for": "payment",
  "algorithm": {
    "type": "advanced",
    "data": {
      "globals": {},
      "default_selection": { "priority": [ { "gateway_name": "adyen", "gateway_id": "mca_adyen" } ] },
      "rules": [{
        "name": "card_rule",
        "routing_type": "priority",
        "output": { "priority": [ { "gateway_name": "checkout", "gateway_id": "mca_checkout" } ] },
        "statements": [{ "condition": [
          { "lhs": "payment_method", "comparison": "equal",
            "value": { "type": "enum_variant", "value": "card" }, "metadata": {} }
        ]}]
      }]
    }
  },
  "metadata": {}
}
```


**POST** `{{base_url}}/routing/evaluate` — Body → raw (JSON)

```json
{
  "created_by": "{{merchant_id}}",
  "parameters": {
    "payment_method": { "type": "enum_variant", "value": "upi" },
    "amount": { "type": "number", "value": 10 }
  },
  "fallback_output": [
    { "gateway_name": "stripe",   "gateway_id": "mca_stripe" },
    { "gateway_name": "razorpay", "gateway_id": "mca_razorpay" }
  ]
}
```


```json
{
  "payment_id": null,
  "status": "default_selection",
  "output": {
    "type": "priority",
    "connectors": [
      { "gateway_name": "stripe",   "gateway_id": "mca_stripe" },
      { "gateway_name": "razorpay", "gateway_id": "mca_razorpay" }
    ]
  },
  "evaluated_output": [
    { "gateway_name": "stripe",   "gateway_id": "mca_stripe" },
    { "gateway_name": "razorpay", "gateway_id": "mca_razorpay" }
  ],
  "eligible_connectors": [
    { "gateway_name": "stripe",   "gateway_id": "mca_stripe" },
    { "gateway_name": "razorpay", "gateway_id": "mca_razorpay" }
  ]
}
```

`evaluated_output` was `[stripe]` before — the rest of the caller's fallback list was dropped.

---

### 5. `/routing/hybrid` — evaluated order drives `evaluated_connectors`

Against the 70/30 volume split rule from case 2.

**POST** `{{base_url}}/routing/hybrid` — Body → raw (JSON)

```json
{
  "static_routing_request": {
    "created_by": "{{merchant_id}}",
    "parameters": {
      "payment_method": { "type": "enum_variant", "value": "card" },
      "amount": { "type": "number", "value": 100 }
    },
    "fallback_output": [ { "gateway_name": "adyen", "gateway_id": "mca_adyen" } ]
  }
}
```


```json
{
  "static_routing": {
    "payment_id": null,
    "status": "success",
    "output": {
      "type": "volume_split",
      "splits": [
        { "connector": { "gateway_name": "stripe", "gateway_id": "mca_stripe" }, "split": 70 },
        { "connector": { "gateway_name": "paytm",  "gateway_id": "mca_paytm" },  "split": 30 }
      ]
    },
    "evaluated_output": [
      { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
      { "gateway_name": "paytm",  "gateway_id": "mca_paytm" }
    ],
    "eligible_connectors": [
      { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
      { "gateway_name": "paytm",  "gateway_id": "mca_paytm" }
    ]
  },
  "evaluated_connectors": [
    { "gateway_name": "stripe", "gateway_id": "mca_stripe" },
    { "gateway_name": "paytm",  "gateway_id": "mca_paytm" }
  ]
}
```

100 replays, head of `evaluated_connectors`:

```
  68 stripe   (68% , declared 70%)
  32 paytm    (32% , declared 30%)
```

The head now tracks the arm the split actually chose. Before this PR `evaluated_connectors` was
`eligible_connectors`, so it was pinned to declaration order and `stripe` led all 100 times. With a
`dynamic_routing_request` that omits `eligible_gateway_list`, this same list seeds the dynamic
decider's candidates.

