### PR TITLE
fix(email): resolve STS region from the pod environment for SES AssumeRole

### DIFF
--- a/src/email/aws_ses.rs
+++ b/src/email/aws_ses.rs
@@ -1,3 +1,4 @@
+use aws_config::meta::region::RegionProviderChain;
 use aws_config::BehaviorVersion;
 use aws_sdk_sesv2::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_sesv2::types::{Body, Content, Destination, EmailContent, Message};
@@ -22,14 +23,23 @@ impl AwsSesEmailClient {
     ) -> error_stack::Result<Self, EmailError> {
         let region = aws_sdk_sesv2::config::Region::new(config.region.clone());
 
-        // Credential resolution intentionally uses no proxy — STS is reachable via VPC endpoint.
+        // Credential resolution uses no proxy — STS is reached over the VPC endpoint in the
+        // region the pod itself runs in.
         let aws_config = if let (Some(role_arn), Some(session_name)) =
             (&config.email_role_arn, &config.sts_role_session_name)
         {
             // Load a base config to build the STS client, then assume the target role.
             // The resulting credentials are used for all SES calls (cross-account setup).
+            //
+            // The STS client keeps its own region, resolved from the pod environment
+            // (`AWS_REGION`/profile/IMDS) and falling back to the SES region. AssumeRole is
+            // answered identically by every regional STS endpoint, so binding it to the local
+            // region lets the call resolve through the local STS VPC endpoint while SES stays
+            // pinned to `config.region`.
+            let sts_region = RegionProviderChain::default_provider().or_else(region.clone());
+
             let base_config = aws_config::defaults(BehaviorVersion::latest())
-                .region(region.clone())
+                .region(sts_region)
                 .load()
                 .await;
 


### PR DESCRIPTION
## Problem

The STS client used to assume the cross-account SES role inherited the SES region from `DECISION_ENGINE__EMAIL__AWS_SES__REGION`. A deployment running in `eu-west-1` that sends through `us-east-1` SES therefore called `sts.us-east-1.amazonaws.com`.

In a private subnet only the local region's STS VPC endpoint is routable, so that call hung until timeout. Credentials resolve before the SES request is dispatched, so no SES call was ever issued — the failure surfaced as a timeout even with the SES egress proxy correctly configured.

Verified from a `eu-west-1` pod:

- `curl --max-time 5 https://sts.eu-west-1.amazonaws.com/` → resolves to a private VPC address, answers immediately
- `curl --max-time 5 https://sts.us-east-1.amazonaws.com/` → hangs

## Change

The STS client now resolves its own region via `RegionProviderChain::default_provider()` (`AWS_REGION`/`AWS_DEFAULT_REGION` → profile → IMDS), falling back to the configured SES region when none is discoverable. The SES client stays pinned to `config.region`.

`AssumeRole` is answered identically by every regional STS endpoint, so the issued credentials are unchanged — only the endpoint the call travels to differs. Environments where no region is discoverable keep the previous behaviour through the fallback.

## Deployment note

This addresses the credential leg only. Reaching SES itself from a private subnet still requires `DECISION_ENGINE__EMAIL__AWS_SES__PROXY_URL` (added in #286), which is a config-only change.

## Testing

- `cargo check` passes
- `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
