### PR TITLE
feat(routing): redesign rule-based and volume split routing pages

### DIFF
--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -570,12 +570,14 @@ pub async fn switch_merchant(
 
     let claims = verify_jwt_not_revoked(token, global_config.user_auth.jwt_secret.peek()).await?;
 
-    // A standard session moves within its DE memberships; a handed-over one moves within the
-    // Hyperswitch node it was granted. A super-admin-view session must Exit back to its own session
-    // before switching, so its single-level return token isn't overwritten.
+    // A standard session moves within its DE memberships; a handed-over or super-admin-view one
+    // moves within the node it was granted. Exit is unaffected by switching: it rebuilds the
+    // admin's own session from the user id and the roster, neither of which a switch changes.
     match claims.token_type.as_str() {
         TOKEN_TYPE_STANDARD => switch_within_memberships(claims, payload, &global_config).await,
-        TOKEN_TYPE_HS_REDIRECT => switch_within_grant(claims, payload, &global_config).await,
+        TOKEN_TYPE_HS_REDIRECT | TOKEN_TYPE_SUPER_ADMIN_VIEW => {
+            switch_within_grant(claims, payload, &global_config).await
+        }
         _ => Err(error::ContainerError::from(
             UserAuthError::UnsupportedOperation,
         )),
@@ -640,7 +642,9 @@ async fn switch_within_grant(
         &claims.email,
         &payload.merchant_id,
         &claims.role,
-        TOKEN_TYPE_HS_REDIRECT,
+        // Kept as it was, so a super-admin view stays one — and stays able to Exit — rather than
+        // turning into a handed-over session by moving inside itself.
+        &claims.token_type,
         Some(&grant),
         // Carried forward, so a limited session cannot switch its way into more.
         claims.perms.as_deref(),
@@ -1159,7 +1163,13 @@ pub async fn me(
     .change_error(UserAuthError::StorageError)?;
 
     let user = users.pop().ok_or(UserAuthError::UserNotFound)?;
-    let merchants = fetch_user_merchants(&app_state, &user.user_id).await?;
+    // A session carrying a grant lists what that grant reaches; one without lists the user's own
+    // memberships. A super-admin view is the first case — its own memberships are the admin's
+    // home account, which is not where the session is and not what it can move between.
+    let merchants = match claims.grant.as_ref() {
+        Some(grant) => granted_merchants(grant, &user.role).await,
+        None => fetch_user_merchants(&app_state, &user.user_id).await?,
+    };
     let hierarchy = hierarchy_of_scope(&claims.merchant_id).await;
 
     Ok(Json(MeResponse {
@@ -1193,6 +1203,29 @@ async fn hierarchy_of_scope(
         crate::types::merchant::merchant_account::load_merchant_by_merchant_id(scope_id.to_owned())
             .await?;
     crate::types::merchant::hierarchy::of_account(&account)
+}
+
+/// What a super-admin view session may move between, once inside.
+///
+/// The organization of the scope entered, so the admin can reach its sibling profiles without
+/// returning to look each one up by ID. This widens the session rather than narrowing it: entry
+/// is authorized by the roster and reaches any merchant at all, and lookup still does, so the
+/// grant decides only what the switcher offers from here — not what the admin can enter.
+///
+/// A scope with no ancestry has no organization to name. That is every DE-native merchant, and
+/// every scope Hyperswitch has not synced yet, so it is the ordinary case rather than an error:
+/// the session stays on the one scope, which is what a view session was before grants existed.
+fn view_grant(
+    scope_id: &str,
+    hierarchy: Option<&crate::types::merchant::hierarchy::Hierarchy>,
+) -> ScopeGrant {
+    match hierarchy {
+        Some(hierarchy) => ScopeGrant {
+            level: GrantLevel::Org,
+            id: hierarchy.hs_org_id.clone(),
+        },
+        None => ScopeGrant::profile(scope_id),
+    }
 }
 
 /// Whether `claims` belongs to a platform super admin.
@@ -1818,12 +1851,21 @@ pub async fn enter_merchant(
         .await
         .ok_or_else(|| error::ContainerError::from(UserAuthError::MerchantNotFound))?;
 
-    let new_token = auth::generate_jwt(
+    let grant = view_grant(
+        &payload.merchant_id,
+        hierarchy_of_scope(&payload.merchant_id).await.as_ref(),
+    );
+
+    let new_token = auth::generate_scoped_jwt(
         &claims.user_id,
         &claims.email,
         &payload.merchant_id,
         "admin",
         TOKEN_TYPE_SUPER_ADMIN_VIEW,
+        Some(&grant),
+        // Named rather than left absent, exactly as `generate_jwt` does, so the reading never
+        // depends on the explicit-permissions flag for a session Decision Engine issued.
+        Some(auth::KNOWN_PERMISSIONS),
         global_config.user_auth.jwt_secret.peek(),
         global_config.user_auth.jwt_expiry_seconds,
     )
@@ -2237,6 +2279,34 @@ mod tests {
         assert_eq!(grant, ScopeGrant::profile("pro_abc"));
         assert_eq!(perms, None, "an old code names no permissions");
         assert_eq!(email, None, "an old code names no user");
+    }
+
+    #[test]
+    fn entering_a_synced_scope_grants_its_organization() {
+        // The point of the grant: an admin who entered one profile can reach the others beside it
+        // without going back to look each one up.
+        let hierarchy = crate::types::merchant::hierarchy::Hierarchy {
+            v: 1,
+            hs_org_id: "org_N1B6LBS3ufzHriAwZSAmd".to_string(),
+            hs_org_name: None,
+            hs_merchant_id: "merchant_1681193734270".to_string(),
+            hs_merchant_name: Some("Test".to_string()),
+            profile_name: None,
+            synced_at: None,
+        };
+        let grant = view_grant("pro_E7pM8kGERopEKEhqwfWQ", Some(&hierarchy));
+        assert_eq!(grant.level, GrantLevel::Org);
+        assert_eq!(grant.id, "org_N1B6LBS3ufzHriAwZSAmd");
+    }
+
+    #[test]
+    fn entering_a_scope_with_no_ancestry_stays_on_that_scope() {
+        // A DE-native merchant, or one Hyperswitch has not synced. There is no organization to
+        // name, and inventing one would let the switcher offer scopes the tree never placed
+        // together — so the session stays where it is, as it did before grants existed.
+        let grant = view_grant("merchant_385bd763d034", None);
+        assert_eq!(grant.level, GrantLevel::Profile);
+        assert_eq!(grant.id, "merchant_385bd763d034");
     }
 
     #[test]

--- a/tests/api/auth/super-admin-view.spec.ts
+++ b/tests/api/auth/super-admin-view.spec.ts
@@ -8,8 +8,9 @@ import { SUPER_ADMIN_EMAIL, SUPER_ADMIN_PASSWORD } from '../../fixtures/super-ad
  * Shape: a super-admin is a real (standard-session) user whose email is on the config roster
  * (`user_auth.super_admin_emails`). From that session they can mint a `super_admin_view` token for
  * any merchant — regardless of membership — that keeps their own identity, and later `exit` back to a
- * normal session. A view session is deliberately NOT a full account session (it cannot switch/create
- * merchants). Lookup lets them find a merchant id from an email or merchant name.
+ * normal session. The view token carries a scope grant — the entered scope's organization when
+ * Hyperswitch has synced its ancestry, otherwise the scope alone — and switching moves within that
+ * grant. Lookup lets them find a merchant id from an email or merchant name.
  *
  * Roster dependency: the API under test must have SUPER_ADMIN_EMAIL on its super-admin roster.
  * playwright.config.ts injects it via DECISION_ENGINE__USER_AUTH__SUPER_ADMIN_EMAILS into the API
@@ -92,7 +93,7 @@ test.describe('Super-admin merchant view (API)', () => {
     expect(r.status).toBe(404)
   })
 
-  test('a view session cannot switch merchant, and exit returns a full session', async ({ api, merchant }) => {
+  test('a view session switches within its grant, and exit returns a full session', async ({ api, merchant }) => {
     const superToken = await superAdminToken(api)
     const entered = await api.raw('POST', '/auth/super-admin/enter-merchant', {
       ...bearer(superToken),
@@ -100,16 +101,34 @@ test.describe('Super-admin merchant view (API)', () => {
     })
     const viewToken = entered.body.token
 
-    // A view session is scoped to viewing — not a full account session.
+    // The fixture merchant is DE-native, so it has no synced ancestry and the grant is the scope
+    // itself — switching reaches that one scope and stays a view session.
     const switched = await api.raw('POST', '/auth/switch-merchant', {
       failOnStatusCode: false,
       ...bearer(viewToken),
       body: { merchant_id: merchant.id },
     })
-    expect(switched.status).toBe(403)
+    expect(switched.status).toBe(200)
+    expect(typeof switched.body.token).toBe('string')
 
-    // Exit re-mints a standard session for the same admin.
-    const exited = await api.raw('POST', '/auth/super-admin/exit', { failOnStatusCode: false, ...bearer(viewToken) })
+    const inView = await api.raw('GET', '/auth/me', { failOnStatusCode: false, ...bearer(switched.body.token) })
+    expect(inView.status).toBe(200)
+    expect(inView.body.is_super_admin_view).toBe(true)
+
+    // A scope the grant does not cover stays out of reach — entry is by roster, movement is not.
+    const outside = await api.raw('POST', '/auth/switch-merchant', {
+      failOnStatusCode: false,
+      ...bearer(viewToken),
+      body: { merchant_id: factory.merchantId('sa_outside') },
+    })
+    expect(outside.status).toBe(403)
+
+    // Switching does not cost the session its way back: exit re-mints a standard session for the
+    // same admin from the post-switch token.
+    const exited = await api.raw('POST', '/auth/super-admin/exit', {
+      failOnStatusCode: false,
+      ...bearer(switched.body.token),
+    })
     expect(exited.status).toBe(200)
     expect(typeof exited.body.token).toBe('string')
 

--- a/tests/e2e/routing/rules/euclid-builder.spec.ts
+++ b/tests/e2e/routing/rules/euclid-builder.spec.ts
@@ -146,9 +146,7 @@ test.describe('Rule Builder — UI interactions', () => {
       await block.getByRole('button', { name: 'Add condition' }).click()
 
       await expect(block.getByText('AND', { exact: true }).first()).toBeVisible()
-      await expect(
-        block.locator('.rounded-lg.border').first().locator('[class*="divide-y"] > div'),
-      ).toHaveCount(3)
+      await expect(block.locator('[data-testid="condition-row"]')).toHaveCount(3)
     })
 
     test('removes a condition when there are multiple', async () => {
@@ -190,7 +188,7 @@ test.describe('Rule Builder — UI interactions', () => {
         expect(label.trim(), 'field labels should be humanised, not raw snake_case').not.toMatch(/_/)
       }
 
-      await sharedPage.locator('body').click({ force: true })
+      await euclid.dismissDropdown()
     })
 
     test('shows human-readable labels in the enum value dropdown', async ({ sharedPage }) => {
@@ -203,7 +201,7 @@ test.describe('Rule Builder — UI interactions', () => {
         expect(label.trim(), 'enum labels should be humanised').not.toMatch(/_/)
       }
 
-      await sharedPage.locator('body').click({ force: true })
+      await euclid.dismissDropdown()
     })
 
     test('can select a different field and choose a value', async ({ sharedPage }) => {
@@ -217,7 +215,7 @@ test.describe('Rule Builder — UI interactions', () => {
         await sharedPage.locator('button[data-value]:not(.cond-select)').count(),
       ).toBeGreaterThan(1)
 
-      await sharedPage.locator('body').click({ force: true })
+      await euclid.dismissDropdown()
     })
   })
 

--- a/tests/e2e/routing/rules/euclid-builder.spec.ts
+++ b/tests/e2e/routing/rules/euclid-builder.spec.ts
@@ -4,9 +4,9 @@ import { EuclidRuleBuilder } from '../../../pages/euclid-page'
 /**
  * Port of cypress/e2e/ui/euclid-rules-builder.cy.js.
  *
- * The rule builder FORM only: page rendering, rule blocks, conditions, OR groups, gateways, the JSON
- * preview, and client-side validation. No rule reaches the backend — the one Create Rule click is the
- * empty-name case, which is blocked before it submits.
+ * The rule builder FORM only: page rendering, rule blocks, conditions, OR groups, gateways, Clear, and
+ * client-side validation. No rule reaches the backend — every Create Rule click here is the empty-name
+ * case, which is blocked before it submits.
  *
  * Because nothing here mutates merchant state, these run against the worker-scoped `sharedMerchant`
  * (one signup per worker rather than one per test). Do not add a test to this file that creates a rule.
@@ -19,26 +19,31 @@ test.describe('Rule Builder — UI interactions', () => {
 
   test.beforeEach(async ({ sharedPage }) => {
     euclid = new EuclidRuleBuilder(sharedPage)
-    await euclid.goto('/routing/rules')
+    await euclid.goto('/routing/rules/new')
   })
 
   test.describe('Page rendering', () => {
-    test('shows the rule builder form and an empty existing-rules panel', async ({ sharedPage }) => {
-      await expect(sharedPage.getByRole('heading', { name: 'Rule Builder' })).toBeVisible()
-      await expect(sharedPage.getByRole('heading', { name: 'Existing Rules' })).toBeVisible()
+    test('shows the rule builder form', async ({ sharedPage }) => {
+      await expect(sharedPage.getByRole('heading', { name: 'Create Payment Rule' })).toBeVisible()
       await expect(sharedPage.getByPlaceholder('my-rule')).toBeVisible()
       await expect(sharedPage.getByPlaceholder('Optional description')).toBeVisible()
-      await expect(sharedPage.getByText('No rule-based rules yet.')).toBeVisible()
+      await expect(sharedPage.getByText('Configured Rules')).toBeVisible()
     })
 
-    test('shows the Default Fallback section below the rule list', async ({ sharedPage }) => {
-      await expect(sharedPage.getByText('Default Fallback')).toBeVisible()
-      await expect(sharedPage.getByText('Used when no rule matches')).toBeVisible()
+    test('shows the Default Fallback Gateway section', async ({ sharedPage }) => {
+      await expect(sharedPage.getByText('Default Fallback Gateway')).toBeVisible()
+      await expect(
+        sharedPage.getByText('This gateway handles any transactions that do not match'),
+      ).toBeVisible()
     })
 
-    test('shows Create Rule and Preview JSON buttons', async ({ sharedPage }) => {
+    test('links back to the rules list', async ({ sharedPage }) => {
+      await expect(sharedPage.getByRole('button', { name: 'Rule-Based Routing' })).toBeVisible()
+    })
+
+    test('shows Create Rule and Clear buttons', async ({ sharedPage }) => {
       await expect(sharedPage.getByRole('button', { name: 'Create Rule' })).toBeVisible()
-      await expect(sharedPage.getByRole('button', { name: 'Preview JSON' })).toBeVisible()
+      await expect(sharedPage.getByRole('button', { name: 'Clear' })).toBeVisible()
     })
   })
 
@@ -78,6 +83,30 @@ test.describe('Rule Builder — UI interactions', () => {
       await expect(block.getByText('If', { exact: true })).toHaveCount(0)
 
       await block.locator('button[aria-label="Expand rule"]').click()
+      await expect(block.getByText('If', { exact: true })).toBeVisible()
+    })
+
+    test('collapses a rule block by clicking its header', async ({ sharedPage }) => {
+      await euclid.addRuleBlock()
+      const block = euclid.ruleBlock(0)
+      await expect(block.getByText('If', { exact: true })).toBeVisible()
+
+      // The hint text beside the name is part of the header, so it toggles too.
+      await block.getByText('(Highest priority matching check)').click()
+      await expect(block.getByText('If', { exact: true })).toHaveCount(0)
+
+      await block.getByText('(Highest priority matching check)').click()
+      await expect(block.getByText('If', { exact: true })).toBeVisible()
+    })
+
+    test('keeps the rule name editable without collapsing the block', async ({ sharedPage }) => {
+      await euclid.addRuleBlock()
+      const block = euclid.ruleBlock(0)
+
+      await block.getByPlaceholder('Rule name').click()
+      await block.getByPlaceholder('Rule name').fill('card-rule')
+
+      await expect(block.getByPlaceholder('Rule name')).toHaveValue('card-rule')
       await expect(block.getByText('If', { exact: true })).toBeVisible()
     })
 
@@ -313,45 +342,51 @@ test.describe('Rule Builder — UI interactions', () => {
     })
 
     test('shows correct description text', async ({ sharedPage }) => {
-      await expect(sharedPage.getByText('Used when no rule matches')).toBeVisible()
+      await expect(
+        sharedPage.getByText('This gateway handles any transactions that do not match'),
+      ).toBeVisible()
       await expect(sharedPage.getByText('fallback_output')).toBeVisible()
     })
   })
 
-  test.describe('Preview JSON', () => {
-    test('toggles the JSON preview panel', async ({ sharedPage }) => {
-      await sharedPage.getByRole('button', { name: 'Preview JSON' }).click()
-      await expect(sharedPage.getByRole('heading', { name: 'JSON Preview' })).toBeVisible()
-
-      await sharedPage.getByRole('button', { name: 'Hide JSON' }).click()
-      await expect(sharedPage.getByRole('heading', { name: 'JSON Preview' })).toHaveCount(0)
-    })
-
-    test('reflects the rule name in the JSON preview', async ({ sharedPage }) => {
-      const ruleName = 'preview-name-rule'
-      await sharedPage.getByPlaceholder('my-rule').fill(ruleName)
-      await sharedPage.getByRole('button', { name: 'Preview JSON' }).click()
-
-      await expect(sharedPage.locator('pre')).toContainText(ruleName)
-    })
-
-    test('reflects added gateways in the JSON preview', async ({ sharedPage }) => {
+  test.describe('Clear', () => {
+    test('removes every added rule block', async ({ sharedPage }) => {
       await euclid.addRuleBlock()
-      await euclid.addGatewayToBlock(0, 'stripe', 'mca_stripe')
-      await sharedPage.getByPlaceholder('my-rule').fill('preview-gateway-rule')
-      await sharedPage.getByRole('button', { name: 'Preview JSON' }).click()
+      await euclid.addRuleBlock()
+      await expect(sharedPage.getByPlaceholder('Rule name')).toHaveCount(2)
 
-      await expect(sharedPage.locator('pre')).toContainText('stripe')
+      await sharedPage.getByRole('button', { name: 'Clear' }).click()
+
+      await expect(sharedPage.getByPlaceholder('Rule name')).toHaveCount(0)
     })
 
-    test('reflects conditions in the JSON preview', async ({ sharedPage }) => {
-      await euclid.addRuleBlock()
-      await sharedPage.getByPlaceholder('my-rule').fill('preview-condition-rule')
-      await sharedPage.getByRole('button', { name: 'Preview JSON' }).click()
+    test('resets the rule name, description and fallback', async ({ sharedPage }) => {
+      await sharedPage.getByPlaceholder('my-rule').fill('clear-me')
+      await sharedPage.getByPlaceholder('Optional description').fill('scratch rule')
+      await euclid.addFallbackGateway('stripe', 'mca_stripe')
 
-      const preview = sharedPage.locator('pre')
-      await expect(preview).toContainText('statements')
-      await expect(preview).toContainText('condition')
+      await sharedPage.getByRole('button', { name: 'Clear' }).click()
+
+      await expect(sharedPage.getByPlaceholder('my-rule')).toHaveValue('')
+      await expect(sharedPage.getByPlaceholder('Optional description')).toHaveValue('')
+      await expect(sharedPage.getByText('mca_stripe')).toHaveCount(0)
+    })
+
+    test('clears the validation error left by a blocked submission', async ({ sharedPage }) => {
+      await sharedPage.getByRole('button', { name: 'Create Rule' }).click()
+      await expect(sharedPage.getByText('Rule name is required.')).toBeVisible()
+
+      await sharedPage.getByRole('button', { name: 'Clear' }).click()
+
+      await expect(sharedPage.getByText('Rule name is required.')).toHaveCount(0)
+    })
+
+    test('switches the code editor back to visual mode', async ({ sharedPage }) => {
+      await sharedPage.getByRole('button', { name: 'Code', exact: true }).click()
+      await sharedPage.getByRole('button', { name: 'Clear' }).click()
+
+      await expect(sharedPage.getByPlaceholder('my-rule')).toBeVisible()
+      await expect(sharedPage.getByRole('button', { name: 'Add Rule', exact: true })).toBeVisible()
     })
   })
 

--- a/tests/e2e/routing/rules/euclid-e2e.spec.ts
+++ b/tests/e2e/routing/rules/euclid-e2e.spec.ts
@@ -22,7 +22,7 @@ test.describe('End-to-end creation', () => {
   test.beforeEach(async ({ authedPage }) => {
     ruleName = factory.ruleName('adv_rule')
     euclid = new EuclidRuleBuilder(authedPage)
-    await euclid.goto('/routing/rules')
+    await euclid.goto('/routing/rules/new')
     await euclid.addRuleBlock()
   })
 
@@ -32,7 +32,8 @@ test.describe('End-to-end creation', () => {
     await page.getByRole('button', { name: 'Create Rule' }).click()
     const { status, requestBody, body } = await call
     expect(status, `POST /routing/create failed: ${JSON.stringify(body)}`).toBe(200)
-    await expect(page.getByText('Rule created')).toBeVisible()
+    // A successful create returns to the rules list.
+    await expect(page.getByRole('heading', { name: 'Rule-Based Routing' })).toBeVisible()
     return requestBody
   }
 

--- a/tests/e2e/routing/rules/euclid-enum-operators.spec.ts
+++ b/tests/e2e/routing/rules/euclid-enum-operators.spec.ts
@@ -69,13 +69,13 @@ test.describe('"is one of" / "is not one of" operator', () => {
     const options = sharedPage.locator('button[data-value]:not(.cond-select)')
     const chosen = await options.first().getAttribute('data-value')
     await options.first().click({ force: true })
-    await sharedPage.locator('body').click({ force: true })
+    await euclid.dismissDropdown()
     await expect(value.locator(PILL)).toHaveCount(1)
 
     // Re-open and click the same option to deselect it.
     await value.click()
     await sharedPage.locator(`button[data-value="${chosen}"]:not(.cond-select)`).click({ force: true })
-    await sharedPage.locator('body').click({ force: true })
+    await euclid.dismissDropdown()
 
     await expect(value.locator(PILL)).toHaveCount(0)
   })
@@ -93,7 +93,7 @@ test.describe('"is one of" / "is not one of" operator', () => {
     const second = await options.nth(1).getAttribute('data-value')
     await sharedPage.locator(`button[data-value="${first}"]:not(.cond-select)`).click({ force: true })
     await sharedPage.locator(`button[data-value="${second}"]:not(.cond-select)`).click({ force: true })
-    await sharedPage.locator('body').click({ force: true })
+    await euclid.dismissDropdown()
 
     await expect(value.locator(PILL)).toHaveCount(2)
   })

--- a/tests/e2e/routing/rules/euclid-enum-operators.spec.ts
+++ b/tests/e2e/routing/rules/euclid-enum-operators.spec.ts
@@ -22,7 +22,7 @@ test.describe('"is one of" / "is not one of" operator', () => {
 
   test.beforeEach(async ({ sharedPage }) => {
     euclid = new EuclidRuleBuilder(sharedPage)
-    await euclid.goto('/routing/rules')
+    await euclid.goto('/routing/rules/new')
     await euclid.addRuleBlock()
     await euclid.selectCondLhs(0, 'payment_method')
   })
@@ -117,41 +117,5 @@ test.describe('"is one of" / "is not one of" operator', () => {
     await euclid.ruleBlock(0).locator('select.cond-select').first().selectOption({ label: 'is one of' })
 
     await expect(sharedPage.locator('[data-cy="cond-val"]').first().locator(PILL)).toHaveCount(1)
-  })
-
-  test('JSON preview emits enum_variant_array type with the selected values', async ({ sharedPage }) => {
-    await euclid.ruleBlock(0).locator('select.cond-select').first().selectOption({ label: 'is one of' })
-
-    const value = sharedPage.locator('[data-cy="cond-val"]').first()
-    await value.click()
-    const options = sharedPage.locator('button[data-value]:not(.cond-select)')
-    await options.nth(0).click()
-    await options.nth(1).click()
-    await sharedPage.locator('body').click({ force: true })
-
-    await euclid.addGatewayToBlock(0, 'stripe')
-    await sharedPage.getByPlaceholder('my-rule').fill('enum-array-rule')
-    await sharedPage.getByRole('button', { name: 'Preview JSON' }).click()
-
-    const preview = sharedPage.locator('pre')
-    await expect(preview).toContainText('"type": "enum_variant_array"')
-    await expect(preview).toContainText('"value": [')
-  })
-
-  test('JSON preview for "is not one of" uses not_equal comparison', async ({ sharedPage }) => {
-    await euclid.ruleBlock(0).locator('select.cond-select').first().selectOption({ label: 'is not one of' })
-
-    const value = sharedPage.locator('[data-cy="cond-val"]').first()
-    await value.click()
-    await sharedPage.locator('button[data-value]:not(.cond-select)').nth(0).click()
-    await sharedPage.locator('body').click({ force: true })
-
-    await euclid.addGatewayToBlock(0, 'stripe')
-    await sharedPage.getByPlaceholder('my-rule').fill('enum-not-array-rule')
-    await sharedPage.getByRole('button', { name: 'Preview JSON' }).click()
-
-    const preview = sharedPage.locator('pre')
-    await expect(preview).toContainText('"comparison": "not_equal"')
-    await expect(preview).toContainText('"type": "enum_variant_array"')
   })
 })

--- a/tests/e2e/routing/rules/euclid-lifecycle.spec.ts
+++ b/tests/e2e/routing/rules/euclid-lifecycle.spec.ts
@@ -22,7 +22,7 @@ test.describe('Rule Lifecycle — creation and management', () => {
   test.beforeEach(async ({ authedPage }) => {
     ruleName = factory.ruleName('ui_rule')
     euclid = new EuclidRuleBuilder(authedPage)
-    await euclid.goto('/routing/rules')
+    await euclid.goto('/routing/rules/new')
   })
 
   /** Click Create Rule and assert the backend accepted it, surfacing the body on failure. */
@@ -41,7 +41,7 @@ test.describe('Rule Lifecycle — creation and management', () => {
 
       await createRuleAndExpectSuccess(authedPage)
 
-      await expect(authedPage.getByText('Rule created')).toBeVisible()
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
     })
 
     test('creates a rule with one condition and one gateway', async ({ authedPage }) => {
@@ -58,7 +58,7 @@ test.describe('Rule Lifecycle — creation and management', () => {
 
       await createRuleAndExpectSuccess(authedPage)
 
-      await expect(authedPage.getByText('Rule created')).toBeVisible()
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
       await expect(authedPage.getByText(ruleName).first()).toBeVisible()
     })
 
@@ -80,7 +80,7 @@ test.describe('Rule Lifecycle — creation and management', () => {
 
       await createRuleAndExpectSuccess(authedPage)
 
-      await expect(authedPage.getByText('Rule created')).toBeVisible()
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
     })
 
     test('creates a rule with two OR groups', async ({ authedPage }) => {
@@ -102,7 +102,7 @@ test.describe('Rule Lifecycle — creation and management', () => {
 
       await createRuleAndExpectSuccess(authedPage)
 
-      await expect(authedPage.getByText('Rule created')).toBeVisible()
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
     })
 
     test('creates two rule blocks each targeting a different gateway', async ({ authedPage }) => {
@@ -124,7 +124,7 @@ test.describe('Rule Lifecycle — creation and management', () => {
 
       await createRuleAndExpectSuccess(authedPage)
 
-      await expect(authedPage.getByText('Rule created')).toBeVisible()
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
     })
 
     test('creates a rule with an amount (integer) condition', async ({ authedPage }) => {
@@ -140,92 +140,149 @@ test.describe('Rule Lifecycle — creation and management', () => {
 
       await createRuleAndExpectSuccess(authedPage)
 
-      await expect(authedPage.getByText('Rule created')).toBeVisible()
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
     })
   })
 
-  test.describe('Existing rules panel', () => {
-    /** Locate the panel row for a rule by name. */
-    const ruleRow = (page: any, name: string) =>
-      page.getByText(name).first().locator('xpath=ancestor::*[contains(@class,"flex-col")][1]')
-
-    test.beforeEach(async ({ api, merchant, authedPage }) => {
-      // Seed a rule through the API so the panel has something to manage.
+  test.describe('Rules list', () => {
+    test.beforeEach(async ({ api, merchant }) => {
+      // Seed a rule through the API so the list has something to manage.
       const created = await api.createRoutingAlgorithm(
         factory.advancedRoutingPayload(merchant.id, { name: ruleName }),
       )
       expect(created.status).toBe(200)
-      await euclid.goto('/routing/rules')
+      await euclid.gotoList()
     })
 
-    test('shows the created rule as Inactive', async ({ authedPage }) => {
-      await expect(authedPage.getByText(ruleName).first()).toBeVisible()
-      await expect(ruleRow(authedPage, ruleName).getByText('Inactive')).toBeVisible()
+    test('shows the created rule as Inactive', async () => {
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
+      await expect(euclid.ruleRow(ruleName).getByText('Inactive')).toBeVisible()
     })
 
-    test('shows the rule description under the rule name', async ({ authedPage }) => {
-      // The Cypress original asserted a `p.text-xs` condition summary; the panel now renders the
-      // algorithm's description at text-[11px] instead, so assert on the content rather than the class.
-      await expect(
-        ruleRow(authedPage, ruleName).getByText('advanced routing rule'),
-      ).toBeVisible()
+    test('summarises the rule destination in the table', async () => {
+      await expect(euclid.ruleRow(ruleName).getByText(/Priority 100%|fallback/)).toBeVisible()
     })
 
-    test('expands rule details when rule header is clicked', async ({ authedPage }) => {
-      await authedPage.getByText(ruleName).first().click()
+    test('expands rule details when the row is clicked', async ({ authedPage }) => {
+      await euclid.ruleRow(ruleName).click()
 
-      await expect(ruleRow(authedPage, ruleName).locator('.border-t').first()).toBeVisible()
+      await expect(authedPage.getByText('advanced routing rule')).toBeVisible()
     })
 
-    test('hides rule details when rule header is clicked again', async ({ authedPage }) => {
-      await authedPage.getByText(ruleName).first().click()
-      await expect(ruleRow(authedPage, ruleName).locator('.border-t').first()).toBeVisible()
+    test('hides rule details when the row is clicked again', async ({ authedPage }) => {
+      await euclid.ruleRow(ruleName).click()
+      await expect(authedPage.getByText('advanced routing rule')).toBeVisible()
 
-      await authedPage.getByText(ruleName).first().click()
+      await euclid.ruleRow(ruleName).click()
 
-      await expect(ruleRow(authedPage, ruleName).locator('.border-t')).toHaveCount(0)
+      await expect(authedPage.getByText('advanced routing rule')).toHaveCount(0)
     })
 
     test('activates the rule', async ({ authedPage }) => {
-      await ruleRow(authedPage, ruleName).getByRole('button', { name: 'Activate' }).click()
+      await euclid.ruleAction(ruleName, 'Activate')
 
       await expect(authedPage.getByText('Rule activated successfully.')).toBeVisible()
-      await expect(ruleRow(authedPage, ruleName).getByText('● Active')).toBeVisible()
+      await expect(euclid.ruleRow(ruleName).getByText('Active', { exact: true })).toBeVisible()
     })
 
     test('deactivates an active rule', async ({ authedPage }) => {
-      await ruleRow(authedPage, ruleName).getByRole('button', { name: 'Activate' }).click()
+      await euclid.ruleAction(ruleName, 'Activate')
       await expect(authedPage.getByText('Rule activated successfully.')).toBeVisible()
 
-      await ruleRow(authedPage, ruleName).getByRole('button', { name: 'Deactivate' }).click()
+      await euclid.ruleAction(ruleName, 'Deactivate')
 
       // Deactivation is behind a confirmation dialog — turning off live routing is not a stray click.
       await expect(authedPage.getByText('Deactivate this rule?')).toBeVisible()
       await authedPage.locator('.fixed.inset-0').getByRole('button', { name: 'Deactivate' }).click()
 
       await expect(authedPage.getByText('Rule deactivated successfully.')).toBeVisible()
-      await expect(ruleRow(authedPage, ruleName).getByText('Inactive')).toBeVisible()
+      await expect(euclid.ruleRow(ruleName).getByText('Inactive')).toBeVisible()
     })
 
-    test('shows Activate Now immediately after creating from the form', async ({ authedPage }) => {
-      await authedPage.getByPlaceholder('my-rule').fill(factory.ruleName('quick'))
-      await euclid.addFallbackGateway('stripe', 'mca_stripe')
+    test('blocks Edit and Delete while the rule is active', async ({ authedPage }) => {
+      await euclid.ruleAction(ruleName, 'Activate')
+      await expect(authedPage.getByText('Rule activated successfully.')).toBeVisible()
 
-      await createRuleAndExpectSuccess(authedPage)
-
-      await expect(authedPage.getByRole('button', { name: 'Activate Now' })).toBeVisible()
+      // /routing/update and /routing/delete both reject an active algorithm.
+      await euclid.openRuleMenu(ruleName)
+      await expect(euclid.menuItem('Edit')).toBeDisabled()
+      await expect(euclid.menuItem('Delete')).toBeDisabled()
     })
 
-    test('activates a newly created rule via Activate Now', async ({ authedPage }) => {
-      const quickRule = factory.ruleName('quick')
-      await authedPage.getByPlaceholder('my-rule').fill(quickRule)
-      await euclid.addFallbackGateway('stripe', 'mca_stripe')
+    test('edits an inactive rule and sends the update to the backend', async ({ authedPage }) => {
+      const renamed = `${ruleName}-edited`
 
-      await createRuleAndExpectSuccess(authedPage)
-      await authedPage.getByRole('button', { name: 'Activate Now' }).click()
+      await euclid.ruleAction(ruleName, 'Edit')
+      await euclid.waitUntilReady()
+      await expect(authedPage.getByRole('heading', { name: 'Edit Payment Rule' })).toBeVisible()
+      await expect(authedPage.getByPlaceholder('my-rule')).toHaveValue(ruleName)
 
-      await expect(authedPage.getByText('Rule activated successfully.')).toBeVisible({ timeout: 15_000 })
-      await expect(ruleRow(authedPage, quickRule).getByText('● Active')).toBeVisible()
+      await authedPage.getByPlaceholder('my-rule').fill(renamed)
+      const call = expectApiCall(authedPage, '/routing/update')
+      await authedPage.getByRole('button', { name: 'Save Changes' }).click()
+      const { status, requestBody, body } = await call
+      expect(status, `POST /routing/update failed: ${JSON.stringify(body)}`).toBe(200)
+      expect(requestBody.name).toBe(renamed)
+
+      await expect(euclid.ruleRow(renamed)).toBeVisible()
+    })
+
+    test('deletes an inactive rule', async ({ authedPage }) => {
+      await euclid.ruleAction(ruleName, 'Delete')
+
+      await expect(authedPage.getByText('Delete this rule?')).toBeVisible()
+      await authedPage.locator('.fixed.inset-0').getByRole('button', { name: 'Delete' }).click()
+
+      await expect(euclid.ruleRow(ruleName)).toHaveCount(0)
+    })
+
+    test('filters the list by name from the column header', async ({ authedPage }) => {
+      // The header label is a button until it is clicked; then it becomes the filter input.
+      await authedPage.getByLabel('Filter rules by name').click()
+      await authedPage.getByLabel('Filter rules by name').fill('no-such-rule-exists')
+
+      await expect(euclid.ruleRow(ruleName)).toHaveCount(0)
+      await expect(authedPage.getByText('No rules match these filters.')).toBeVisible()
+    })
+
+    test('restores every row via Clear filters', async ({ authedPage }) => {
+      await authedPage.getByLabel('Filter rules by name').click()
+      await authedPage.getByLabel('Filter rules by name').fill('no-such-rule-exists')
+      await expect(authedPage.getByText('No rules match these filters.')).toBeVisible()
+
+      await authedPage.getByRole('button', { name: 'Clear filters' }).click()
+
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
+    })
+
+    test('filters the list by status from the column header', async ({ authedPage }) => {
+      await authedPage.getByLabel('Filter by status').click()
+      await authedPage.getByRole('button', { name: 'Active', exact: true }).click()
+
+      await expect(euclid.ruleRow(ruleName)).toHaveCount(0)
+
+      await authedPage.getByLabel('Filter by status').click()
+      await authedPage.getByRole('button', { name: 'Inactive', exact: true }).click()
+
+      await expect(euclid.ruleRow(ruleName)).toBeVisible()
+    })
+
+    test('names the active filter in the column header', async ({ authedPage }) => {
+      await authedPage.getByLabel('Filter by status').click()
+      await authedPage.getByRole('button', { name: 'Inactive', exact: true }).click()
+
+      // A narrowed table has to say why it is short.
+      await expect(authedPage.getByLabel('Filter by status')).toHaveText(/Status: Inactive/i)
+    })
+
+    test('returns to the list from the builder via Cancel', async ({ authedPage }) => {
+      await authedPage.getByRole('button', { name: 'Create Rule' }).click()
+      await euclid.waitUntilReady()
+      await expect(authedPage.getByRole('heading', { name: 'Create Payment Rule' })).toBeVisible()
+
+      await authedPage.getByRole('button', { name: 'Cancel' }).click()
+
+      await expect(authedPage.getByRole('heading', { name: 'Rule-Based Routing' })).toBeVisible()
     })
   })
 })

--- a/tests/e2e/routing/rules/euclid-nested-branches.spec.ts
+++ b/tests/e2e/routing/rules/euclid-nested-branches.spec.ts
@@ -16,7 +16,7 @@ test.describe('Nested AND+OR branches', () => {
 
   test.beforeEach(async ({ sharedPage }) => {
     euclid = new EuclidRuleBuilder(sharedPage)
-    await euclid.goto('/routing/rules')
+    await euclid.goto('/routing/rules/new')
     await euclid.addRuleBlock()
   })
 
@@ -96,20 +96,5 @@ test.describe('Nested AND+OR branches', () => {
     await euclid.ruleBlock(0).getByRole('button', { name: 'Add OR group' }).click()
 
     await expect(euclid.ruleBlock(0).getByRole('button', { name: 'Add nested branch' })).toHaveCount(2)
-  })
-
-  test('JSON preview emits a non-null nested array when a branch is added', async ({ sharedPage }) => {
-    await euclid.selectCondLhs(0, 'amount')
-    await euclid.ruleBlock(0).locator('select.cond-select').first().selectOption({ label: 'greater than' })
-    await euclid.ruleBlock(0).locator('input[type="number"]').fill('10')
-
-    await euclid.addNestedBranch(0)
-    await euclid.selectCondLhs(1, 'payment_method')
-
-    await euclid.addGatewayToBlock(0, 'rbl')
-    await sharedPage.getByPlaceholder('my-rule').fill('nested-preview-rule')
-    await sharedPage.getByRole('button', { name: 'Preview JSON' }).click()
-
-    await expect(sharedPage.locator('pre')).toContainText('"nested": [')
   })
 })

--- a/tests/e2e/routing/rules/euclid-volume-split-output.spec.ts
+++ b/tests/e2e/routing/rules/euclid-volume-split-output.spec.ts
@@ -19,7 +19,7 @@ test.describe('Volume split output', () => {
 
   test.beforeEach(async ({ sharedPage }) => {
     euclid = new EuclidRuleBuilder(sharedPage)
-    await euclid.goto('/routing/rules')
+    await euclid.goto('/routing/rules/new')
     await euclid.addRuleBlock()
     await euclid.switchOutputType(0, 'Volume Split')
   })
@@ -88,18 +88,5 @@ test.describe('Volume split output', () => {
     const then = euclid.thenSection(0)
     await expect(then.getByPlaceholder('Split %')).toHaveCount(0)
     await expect(then.getByPlaceholder('Gateway name')).toBeVisible()
-  })
-
-  test('JSON preview emits routing_type: volume_split with correct split values', async ({ sharedPage }) => {
-    await euclid.addVolumeSplitEntry(0, 70, 'stripe', 'mca_stripe')
-    await euclid.addVolumeSplitEntry(0, 30, 'adyen', 'mca_adyen')
-    await sharedPage.getByPlaceholder('my-rule').fill('volume-split-preview-rule')
-    await sharedPage.getByRole('button', { name: 'Preview JSON' }).click()
-
-    const preview = sharedPage.locator('pre')
-    await expect(preview).toContainText('"routing_type": "volume_split"')
-    await expect(preview).toContainText('"split": 70')
-    await expect(preview).toContainText('"split": 30')
-    await expect(preview).toContainText('"volume_split": [')
   })
 })

--- a/tests/e2e/routing/volume-split-page.spec.ts
+++ b/tests/e2e/routing/volume-split-page.spec.ts
@@ -1,39 +1,166 @@
-import { test, expect } from '../../fixtures/test'
+import { test, expect, factory } from '../../fixtures/test'
+import { VolumeSplitBuilder } from '../../pages/volume-page'
+import { expectApiCall } from '../../helpers/network'
 
 /**
- * UI-journey port of cypress/e2e/ui/volume-split-page.cy.js.
+ * The volume split pages: the list table at /routing/volume and the builder at /routing/volume/new
+ * and /:id/edit — the same split the rule-based pages use.
  *
- * `authedPage` (page pre-seeded with the merchant's auth) replaces Cypress `visitWithMerchant`;
- * the `merchant` fixture creates + cleans the account. `cy.intercept(...).as()` + `cy.wait('@...')`
- * becomes `page.waitForResponse(...)`.
+ * Every test here mutates merchant state (creating, activating or deleting a rule), so they use the
+ * per-test `merchant` fixture rather than the worker-scoped one.
  */
 test.use({ viewport: { width: 1600, height: 1200 } })
 
-test.describe('Volume Split (UI)', () => {
-  test('creates and activates a volume split rule from the page', async ({ authedPage, merchant }) => {
-    const page = authedPage
+test.describe('Volume Split', () => {
+  let volume: VolumeSplitBuilder
+  let ruleName: string
 
-    await page.goto('/routing/volume')
+  test.beforeEach(async ({ authedPage }) => {
+    ruleName = factory.ruleName('vol_rule')
+    volume = new VolumeSplitBuilder(authedPage)
+  })
 
-    await expect(page.getByRole('heading', { level: 1, name: 'Volume Split Routing' })).toBeVisible()
-    await page.getByPlaceholder('e.g. ab-test-split').fill('ui-volume-split')
+  test.describe('Builder', () => {
+    test.beforeEach(async () => {
+      await volume.goto()
+    })
 
-    await page.getByPlaceholder('e.g. stripe').nth(0).fill('stripe')
-    await page.getByPlaceholder('optional gateway_id').nth(0).fill('mca_stripe_ui')
-    await page.getByPlaceholder('e.g. stripe').nth(1).fill('adyen')
-    await page.getByPlaceholder('optional gateway_id').nth(1).fill('mca_adyen_ui')
+    test('shows the builder form and its live distribution rail', async ({ authedPage }) => {
+      await expect(authedPage.getByRole('heading', { name: 'Create Volume Split Rule' })).toBeVisible()
+      await expect(authedPage.getByPlaceholder('e.g. ab-test-split')).toBeVisible()
+      await expect(authedPage.getByText('Rule details')).toBeVisible()
+    })
 
-    const createResponse = page.waitForResponse(
-      (r) => r.url().includes('/routing/create') && r.request().method() === 'POST',
-      { timeout: 20000 },
-    )
-    await page.getByRole('button', { name: 'Create Rule' }).click()
-    await createResponse
+    test('auto-computes the last split so the total stays 100', async ({ authedPage }) => {
+      await volume.setGateway(0, 'stripe', 'mca_stripe', 70)
 
-    // On success the component shows "Rule created: <id>" + an "Activate Now" button.
-    await expect(page.getByText('Rule created:')).toBeVisible({ timeout: 15000 })
-    await page.getByRole('button', { name: 'Activate Now' }).click()
-    await expect(page.getByText('Rule activated.')).toBeVisible({ timeout: 15000 })
-    await expect(page.getByText('Saved Rules').first()).toBeVisible()
+      // The final row absorbs the remainder rather than being typed in.
+      await expect(authedPage.getByText('Total: 100%')).toBeVisible()
+    })
+
+    test('creates a rule and returns to the list', async ({ authedPage }) => {
+      await authedPage.getByPlaceholder('e.g. ab-test-split').fill(ruleName)
+      await volume.setGateway(0, 'stripe', 'mca_stripe')
+      await volume.setGateway(1, 'adyen', 'mca_adyen')
+
+      const call = expectApiCall(authedPage, '/routing/create')
+      await authedPage.getByRole('button', { name: 'Create Rule' }).click()
+      const { status, requestBody, body } = await call
+      expect(status, `POST /routing/create failed: ${JSON.stringify(body)}`).toBe(200)
+      expect(requestBody.algorithm.type).toBe('volume_split')
+      expect(requestBody.algorithm.data).toHaveLength(2)
+
+      await expect(authedPage.getByRole('heading', { name: 'Volume Split Routing' })).toBeVisible()
+      await expect(volume.ruleRow(ruleName)).toBeVisible()
+    })
+
+    test('blocks a rule with no name', async ({ authedPage }) => {
+      await volume.setGateway(0, 'stripe')
+      await volume.setGateway(1, 'adyen')
+
+      await authedPage.getByRole('button', { name: 'Create Rule' }).click()
+
+      await expect(authedPage.getByText('Enter a rule name')).toBeVisible()
+    })
+
+    test('returns to the list via Cancel', async ({ authedPage }) => {
+      await authedPage.getByRole('button', { name: 'Cancel' }).click()
+
+      await expect(authedPage.getByRole('heading', { name: 'Volume Split Routing' })).toBeVisible()
+    })
+  })
+
+  test.describe('Rules list', () => {
+    test.beforeEach(async ({ authedPage }) => {
+      // Seed through the UI so the row under test matches what the builder produces.
+      await volume.goto()
+      await authedPage.getByPlaceholder('e.g. ab-test-split').fill(ruleName)
+      await volume.setGateway(0, 'stripe', 'mca_stripe')
+      await volume.setGateway(1, 'adyen', 'mca_adyen')
+      const call = expectApiCall(authedPage, '/routing/create')
+      await authedPage.getByRole('button', { name: 'Create Rule' }).click()
+      expect((await call).status).toBe(200)
+      await expect(volume.ruleRow(ruleName)).toBeVisible()
+    })
+
+    test('shows the split distribution in the row', async () => {
+      await expect(volume.ruleRow(ruleName).getByText(/stripe \d+% \/ adyen \d+%/)).toBeVisible()
+      await expect(volume.ruleRow(ruleName).getByText('Inactive')).toBeVisible()
+    })
+
+    test('expands the row to the distribution breakdown', async ({ authedPage }) => {
+      await volume.ruleRow(ruleName).click()
+
+      await expect(authedPage.getByText('mca_stripe')).toBeVisible()
+    })
+
+    test('activates and deactivates the rule', async ({ authedPage }) => {
+      await volume.ruleAction(ruleName, 'Activate')
+      await expect(authedPage.getByText('Rule activated.')).toBeVisible()
+      await expect(volume.ruleRow(ruleName).getByText('Active', { exact: true })).toBeVisible()
+
+      await volume.ruleAction(ruleName, 'Deactivate')
+      await expect(authedPage.getByText('Deactivate this rule?')).toBeVisible()
+      await authedPage.locator('.fixed.inset-0').getByRole('button', { name: 'Deactivate' }).click()
+
+      await expect(authedPage.getByText('Rule deactivated.')).toBeVisible()
+      await expect(volume.ruleRow(ruleName).getByText('Inactive')).toBeVisible()
+    })
+
+    test('blocks Edit and Delete while the rule is active', async ({ authedPage }) => {
+      await volume.ruleAction(ruleName, 'Activate')
+      await expect(authedPage.getByText('Rule activated.')).toBeVisible()
+
+      // /routing/update and /routing/delete both reject an active algorithm.
+      await volume.openRuleMenu(ruleName)
+      await expect(volume.menuItem('Edit')).toBeDisabled()
+      await expect(volume.menuItem('Delete')).toBeDisabled()
+    })
+
+    test('edits an inactive rule and sends the update to the backend', async ({ authedPage }) => {
+      const renamed = `${ruleName}-edited`
+
+      await volume.ruleAction(ruleName, 'Edit')
+      await expect(authedPage.getByRole('heading', { name: 'Edit Volume Split Rule' })).toBeVisible()
+      await expect(authedPage.getByPlaceholder('e.g. ab-test-split')).toHaveValue(ruleName)
+
+      await authedPage.getByPlaceholder('e.g. ab-test-split').fill(renamed)
+      const call = expectApiCall(authedPage, '/routing/update')
+      await authedPage.getByRole('button', { name: 'Save Changes' }).click()
+      const { status, requestBody, body } = await call
+      expect(status, `POST /routing/update failed: ${JSON.stringify(body)}`).toBe(200)
+      expect(requestBody.name).toBe(renamed)
+      expect(requestBody.algorithm.type).toBe('volume_split')
+
+      await expect(volume.ruleRow(renamed)).toBeVisible()
+    })
+
+    test('duplicates a rule into the builder', async ({ authedPage }) => {
+      await volume.ruleAction(ruleName, 'Duplicate')
+
+      await expect(authedPage.getByRole('heading', { name: 'Create Volume Split Rule' })).toBeVisible()
+      await expect(authedPage.getByPlaceholder('e.g. ab-test-split')).toHaveValue(`copy-of-${ruleName}`)
+    })
+
+    test('deletes an inactive rule', async ({ authedPage }) => {
+      await volume.ruleAction(ruleName, 'Delete')
+
+      await expect(authedPage.getByText('Delete this rule?')).toBeVisible()
+      await authedPage.locator('.fixed.inset-0').getByRole('button', { name: 'Delete' }).click()
+
+      await expect(volume.ruleRow(ruleName)).toHaveCount(0)
+    })
+
+    test('filters the list by status from the column header', async ({ authedPage }) => {
+      await authedPage.getByLabel('Filter by status').click()
+      await authedPage.getByRole('button', { name: 'Active', exact: true }).click()
+
+      await expect(volume.ruleRow(ruleName)).toHaveCount(0)
+      await expect(authedPage.getByText('No rules match these filters.')).toBeVisible()
+
+      await authedPage.getByRole('button', { name: 'Clear filters' }).click()
+
+      await expect(volume.ruleRow(ruleName)).toBeVisible()
+    })
   })
 })

--- a/tests/pages/euclid-page.ts
+++ b/tests/pages/euclid-page.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, type Locator } from '@playwright/test'
+import { RoutingListPage } from './routing-list'
 
 /**
  * Page object for the Euclid rule builder — Playwright port of cypress/support/euclid-helpers.js.
@@ -7,14 +8,22 @@ import { expect, type Page, type Locator } from '@playwright/test'
  * `.within()` scoping becomes chained locators, and the `{withinSubject: null}` portal trick becomes
  * a plain page-level locator (the dropdown renders at the document root).
  */
-export class EuclidRuleBuilder {
-  constructor(private readonly page: Page) {}
+export class EuclidRuleBuilder extends RoutingListPage {
+  constructor(page: Page) {
+    super(page)
+  }
 
   /** Navigate to the rule builder and wait for the routing-key fetch to settle. */
-  async goto(path = '/routing/rules'): Promise<void> {
+  async goto(path = '/routing/rules/new'): Promise<void> {
     await this.page.goto(path)
     await this.waitUntilReady()
   }
+
+  /** Navigate to the rules list (the table of saved rules), which has no routing-key gate. */
+  async gotoList(): Promise<void> {
+    await this.page.goto('/routing/rules')
+  }
+
 
   /**
    * The builder renders a "Loading routing keys from backend..." placeholder until GET
@@ -55,9 +64,7 @@ export class EuclidRuleBuilder {
 
   /** THEN section of the nth rule block, regardless of current output type. */
   thenSection(blockIndex = 0): Locator {
-    return this.ruleBlock(blockIndex)
-      .locator('div[class*="py-4"]')
-      .filter({ has: this.page.locator('p', { hasText: 'Then route' }) })
+    return this.ruleBlock(blockIndex).locator('[data-cy="then-section"]')
   }
 
   async setRuleName(index: number, name: string): Promise<void> {

--- a/tests/pages/euclid-page.ts
+++ b/tests/pages/euclid-page.ts
@@ -153,7 +153,17 @@ export class EuclidRuleBuilder extends RoutingListPage {
       if (!cls.includes('text-brand-600')) await opt.click({ force: true })
       await search.focus()
     }
-    await this.page.locator('body').click({ force: true })
+    await this.dismissDropdown()
+  }
+
+  /**
+   * Close an open SearchableSelect / SearchableMultiSelect.
+   *
+   * Not a body click: the dropdown is portalled to <body>, so a click at the body's centre lands on
+   * whichever option happens to sit under that point and silently toggles it.
+   */
+  async dismissDropdown(): Promise<void> {
+    await this.page.keyboard.press('Escape')
   }
 
   private async selectFromPortal(value: string): Promise<void> {

--- a/tests/pages/routing-list.ts
+++ b/tests/pages/routing-list.ts
@@ -1,0 +1,35 @@
+import { type Page, type Locator } from '@playwright/test'
+
+/**
+ * Shared behaviour of the routing list tables (`/routing/rules`, `/routing/volume`).
+ *
+ * Both render rows with the same `data-testid`/`data-rule-name` hooks and the same ⋮ action menu,
+ * so the row and menu handling lives here rather than being copied per page object.
+ */
+export class RoutingListPage {
+  constructor(protected readonly page: Page) {}
+
+  /** A row in the rules list, addressed by the rule's name rather than its DOM shape. */
+  ruleRow(name: string): Locator {
+    return this.page.locator(`[data-testid="rule-row"][data-rule-name="${name}"]`)
+  }
+
+  /** Open a row's action menu. The panel is portalled to <body>, so it is NOT inside the row. */
+  async openRuleMenu(name: string): Promise<void> {
+    await this.ruleRow(name).getByRole('button', { name: 'Rule actions' }).click()
+  }
+
+  /**
+   * An item in the currently open row menu. Exact matching matters here — a substring match on
+   * "Activate" would also hit "Deactivate".
+   */
+  menuItem(action: string): Locator {
+    return this.page.getByRole('menuitem', { name: action, exact: true })
+  }
+
+  /** Open a row's menu and run one action. */
+  async ruleAction(name: string, action: string): Promise<void> {
+    await this.openRuleMenu(name)
+    await this.menuItem(action).click()
+  }
+}

--- a/tests/pages/routing-list.ts
+++ b/tests/pages/routing-list.ts
@@ -1,4 +1,4 @@
-import { type Page, type Locator } from '@playwright/test'
+import { expect, type Page, type Locator } from '@playwright/test'
 
 /**
  * Shared behaviour of the routing list tables (`/routing/rules`, `/routing/volume`).
@@ -16,7 +16,13 @@ export class RoutingListPage {
 
   /** Open a row's action menu. The panel is portalled to <body>, so it is NOT inside the row. */
   async openRuleMenu(name: string): Promise<void> {
-    await this.ruleRow(name).getByRole('button', { name: 'Rule actions' }).click()
+    const trigger = this.ruleRow(name).getByRole('button', { name: 'Rule actions' })
+    // The menu is anchored to the trigger's rect and closes itself on any scroll or resize, so a
+    // list re-render arriving just after the click can dismiss it. Re-open until it stays up.
+    await expect(async () => {
+      await trigger.click()
+      await expect(this.page.getByRole('menu')).toBeVisible({ timeout: 1_000 })
+    }).toPass({ timeout: 15_000 })
   }
 
   /**
@@ -29,7 +35,12 @@ export class RoutingListPage {
 
   /** Open a row's menu and run one action. */
   async ruleAction(name: string, action: string): Promise<void> {
-    await this.openRuleMenu(name)
-    await this.menuItem(action).click()
+    const item = this.menuItem(action)
+    // Same reason as openRuleMenu: if the menu is dismissed between opening it and clicking the
+    // item, re-open and try again rather than waiting out the action timeout on a gone element.
+    await expect(async () => {
+      if (!(await item.isVisible())) await this.openRuleMenu(name)
+      await item.click({ timeout: 2_000 })
+    }).toPass({ timeout: 20_000 })
   }
 }

--- a/tests/pages/volume-page.ts
+++ b/tests/pages/volume-page.ts
@@ -1,0 +1,43 @@
+import { type Page, type Locator } from '@playwright/test'
+import { RoutingListPage } from './routing-list'
+
+/**
+ * Page object for the volume split pages — the list at /routing/volume and the builder at
+ * /routing/volume/new and /routing/volume/:id/edit. Row and ⋮ menu handling comes from
+ * `RoutingListPage`, shared with the rule-based list.
+ */
+export class VolumeSplitBuilder extends RoutingListPage {
+  constructor(page: Page) {
+    super(page)
+  }
+
+  /** Navigate to the builder. */
+  async goto(path = '/routing/volume/new'): Promise<void> {
+    await this.page.goto(path)
+  }
+
+  /** Navigate to the list of saved volume split rules. */
+  async gotoList(): Promise<void> {
+    await this.page.goto('/routing/volume')
+  }
+
+  /** The nth gateway row in the builder's distribution table. */
+  gatewayRow(index: number): Locator {
+    return this.page.locator('input[placeholder="e.g. stripe"]').nth(index)
+  }
+
+  /** Fill one gateway row. The last row's split is auto-computed, so it takes no percentage. */
+  async setGateway(index: number, name: string, gatewayId = '', split?: number): Promise<void> {
+    await this.page.locator('input[placeholder="e.g. stripe"]').nth(index).fill(name)
+    if (gatewayId) {
+      await this.page.locator('input[placeholder="optional gateway_id"]').nth(index).fill(gatewayId)
+    }
+    if (split !== undefined) {
+      await this.page.getByLabel(`${name} split percentage`).fill(String(split))
+    }
+  }
+
+  async addGateway(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Add Gateway' }).click()
+  }
+}

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -5,6 +5,8 @@ import { DecisionExplorerPage } from './components/pages/DecisionExplorerPage'
 import { DecisionSimulatorPage } from './components/pages/DecisionSimulatorPage'
 import { DebitRoutingPage } from './components/pages/DebitRoutingPage'
 import { EuclidRulesPage } from './components/pages/EuclidRulesPage'
+import { EuclidRuleBuilderPage } from './components/pages/EuclidRuleBuilderPage'
+import { VolumeSplitBuilderPage } from './components/pages/VolumeSplitBuilderPage'
 import { OverviewPage } from './components/pages/OverviewPage'
 import { PaymentAuditPage } from './components/pages/PaymentAuditPage'
 import { RoutingEventsPage } from './components/pages/RoutingEventsPage'
@@ -115,7 +117,11 @@ export default function App() {
           <Route path="routing" element={<RoutingHubPage />} />
           <Route path="routing/sr" element={<SRRoutingPage />} />
           <Route path="routing/rules" element={<EuclidRulesPage />} />
+          <Route path="routing/rules/new" element={<EuclidRuleBuilderPage />} />
+          <Route path="routing/rules/:id/edit" element={<EuclidRuleBuilderPage />} />
           <Route path="routing/volume" element={<VolumeSplitPage />} />
+          <Route path="routing/volume/new" element={<VolumeSplitBuilderPage />} />
+          <Route path="routing/volume/:id/edit" element={<VolumeSplitBuilderPage />} />
           <Route path="routing/debit" element={<DebitRoutingPage />} />
           {/* Cost Estimation moved into the Multi Objective page as a tab; keep the
               old path working for bookmarks/links. */}

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -175,7 +175,7 @@ export function Sidebar() {
         {accountOpen ? (
           <div className="absolute bottom-full left-4 right-4 mb-3 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-[0_20px_60px_-36px_rgba(15,23,42,0.35)] dark:border-[#2a303a] dark:bg-[#0d1118]">
             <div className="border-b border-slate-200 px-3 py-3 dark:border-[#242b36]">
-              <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
+              <p className="break-all text-sm font-semibold text-slate-900 dark:text-white">
                 {user?.email || 'Signed-in user'}
               </p>
               {user?.merchantId ? (
@@ -211,24 +211,25 @@ export function Sidebar() {
           </div>
         ) : null}
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
           <button
             type="button"
             onClick={() => setAccountOpen((value) => !value)}
             aria-haspopup="menu"
             aria-expanded={accountOpen}
-            className="flex min-w-0 flex-1 items-center gap-3 rounded-2xl px-2 py-2 text-left transition-colors hover:bg-slate-100 dark:hover:bg-[#151b24]"
+            title={user?.email || 'Account'}
+            className="flex min-w-0 flex-1 items-center gap-2 rounded-2xl px-1.5 py-2 text-left transition-colors hover:bg-slate-100 dark:hover:bg-[#151b24]"
           >
-            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-600 text-[11px] font-semibold text-white">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-600 text-[10px] font-semibold text-white">
               {initials}
             </span>
             <span className="min-w-0 flex-1">
-              <span className="block truncate text-sm font-semibold text-slate-900 dark:text-white">
+              <span className="block truncate text-xs font-semibold text-slate-900 dark:text-white">
                 {user?.email || 'Account'}
               </span>
             </span>
             <ChevronDown
-              size={15}
+              size={13}
               className={`shrink-0 text-slate-400 transition-transform ${accountOpen ? 'rotate-180' : ''}`}
             />
           </button>
@@ -236,11 +237,11 @@ export function Sidebar() {
           <button
             type="button"
             onClick={handleThemeToggle}
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-[#1a1f2a] dark:hover:text-white"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-[#1a1f2a] dark:hover:text-white"
             aria-label="Toggle theme"
             title="Toggle theme"
           >
-            {isDark ? <Sun size={18} /> : <Moon size={18} />}
+            {isDark ? <Sun size={15} /> : <Moon size={15} />}
           </button>
         </div>
       </div>

--- a/website/src/components/layout/TopBar.tsx
+++ b/website/src/components/layout/TopBar.tsx
@@ -142,12 +142,13 @@ export function TopBar() {
 
   const currentMerchant = merchants.find((m) => m.merchant_id === user?.merchantId)
 
-  // A handed-over session's list is the scopes Hyperswitch granted it, which always includes the
-  // one it is already on. A single entry therefore means there is nothing to switch between, and
-  // the read-only context chip is the honest control; a DE session's list works the other way,
-  // where one membership is still a switcher.
-  const canSwitchMerchant =
-    !user?.isSuperAdminView && merchants.length > (user?.isRedirectSession ? 1 : 0)
+  // A granted session's list is the scopes it was handed — a handed-over one from Hyperswitch, a
+  // super-admin view from the organization it entered — and always includes the one it is already
+  // on. A single entry therefore means there is nothing to switch between, and the read-only
+  // context chip is the honest control; a DE session's list works the other way, where one
+  // membership is still a switcher.
+  const isGranted = Boolean(user?.isRedirectSession || user?.isSuperAdminView)
+  const canSwitchMerchant = merchants.length > (isGranted ? 1 : 0)
   const showAccountContext = !!user?.hierarchy && !canSwitchMerchant
 
   return (
@@ -287,7 +288,7 @@ export function TopBar() {
             {merchantOpen && (
               <div className="absolute right-0 top-10 w-60 bg-white dark:bg-[#0c0c10] border border-[#e6e6ee] dark:border-[#1a1a24] rounded-lg shadow-lg py-1 z-50">
                 <p className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500">
-                  {user?.isRedirectSession ? 'Profiles' : 'Merchants'}
+                  {isGranted ? 'Profiles' : 'Merchants'}
                 </p>
                 {merchants.map((m) => (
                   <button

--- a/website/src/components/pages/ABTestingPage.tsx
+++ b/website/src/components/pages/ABTestingPage.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../types/api'
 import { ShieldAlert, PowerOff, Plus, FlaskConical, CheckCircle2, XCircle, Clock, AlertTriangle, Sliders, Pencil, Trash2, Info, GitCompare, Copy } from 'lucide-react'
 import * as type from '../ui/typography'
-import { RuleBreakdown } from './EuclidRulesPage'
+import { RuleBreakdown } from '../routing/euclid/RuleBreakdown'
 import { validateABTestForm } from '../../features/routing/abTesting/schema'
 import { toABTestCreatePayload } from '../../features/routing/abTesting/payload'
 import { toABTestFormValues } from '../../features/routing/abTesting/state'

--- a/website/src/components/pages/DecisionExplorerPage.tsx
+++ b/website/src/components/pages/DecisionExplorerPage.tsx
@@ -2562,7 +2562,7 @@ export function DecisionExplorerPage() {
                         inputMode="numeric"
                         value={volumePayments}
                         onChange={e => setVolumePayments(e.target.value)}
-                        className="min-w-0 flex-1 bg-transparent text-xl font-semibold text-slate-950 outline-none dark:text-white"
+                        className="input-bare min-w-0 flex-1 text-xl font-semibold text-slate-950 outline-none dark:text-white"
                       />
                       <span className="shrink-0 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-500 dark:bg-[#1d2633] dark:text-[#91a0b8]">
                         runs

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -4526,7 +4526,7 @@ export function DecisionSimulatorPage() {
                         inputMode="numeric"
                         value={volumePayments}
                         onChange={e => setVolumePayments(e.target.value)}
-                        className="min-w-0 flex-1 bg-transparent text-xl font-semibold text-slate-950 outline-none dark:text-white"
+                        className="input-bare min-w-0 flex-1 text-xl font-semibold text-slate-950 outline-none dark:text-white"
                       />
                       <span className="shrink-0 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-500 dark:bg-[#1d2633] dark:text-[#91a0b8]">
                         runs

--- a/website/src/components/pages/EuclidRuleBuilderPage.tsx
+++ b/website/src/components/pages/EuclidRuleBuilderPage.tsx
@@ -1,0 +1,420 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import useSWR from 'swr'
+import { Plus, ArrowLeft } from 'lucide-react'
+import { Card, CardBody } from '../ui/Card'
+import { Button } from '../ui/Button'
+import { ErrorMessage } from '../ui/ErrorMessage'
+import { useMerchantStore } from '../../store/merchantStore'
+import { useCanEditRouting } from '../../store/authStore'
+import { apiPost } from '../../lib/api'
+import { RoutingAlgorithm } from '../../types/api'
+import { useDynamicRoutingConfig } from '../../hooks/useDynamicRoutingConfig'
+import {
+  RuleCodeEditor, serializeToDSL, parseDSL, CODE_EDITOR_PLACEHOLDER,
+  type RuleBlock,
+} from '../ui/RuleCodeEditor'
+import { PriorityEditor, RuleBlockEditor } from '../routing/euclid/editors'
+import { RuleBreakdown } from '../routing/euclid/RuleBreakdown'
+import {
+  buildAlgorithmData, createStatementGroup, parseAlgorithmToRuleBlocks,
+  type DefaultOutput,
+} from '../../features/routing/euclid/state'
+
+export function EuclidRuleBuilderPage() {
+  const canEditRouting = useCanEditRouting()
+  const navigate = useNavigate()
+  const { id: editId } = useParams<{ id: string }>()
+  const [searchParams] = useSearchParams()
+  const cloneFromId = searchParams.get('cloneFrom')
+  const isEdit = Boolean(editId)
+
+  const { merchantId } = useMerchantStore()
+  const { routingKeysConfig, isLoading: routingKeysLoading, error: routingKeysError } = useDynamicRoutingConfig()
+  const routingKeys = routingKeysConfig
+  const hasRoutingKeys = Object.keys(routingKeys).length > 0
+  const routingKeysUnavailable = !routingKeysLoading && (!hasRoutingKeys || Boolean(routingKeysError))
+
+  const [ruleName, setRuleName] = useState('')
+  const [ruleDesc, setRuleDesc] = useState('')
+  const [ruleBlocks, setRuleBlocks] = useState<RuleBlock[]>([])
+  const [defaultOutput, setDefaultOutput] = useState<DefaultOutput>({ priorityGateways: [] })
+  const [editorMode, setEditorMode] = useState<'visual' | 'code'>('visual')
+  const [codeText, setCodeText] = useState('')
+  const [codeParseError, setCodeParseError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const { data: allAlgorithms, mutate: mutateAlgorithms } = useSWR<RoutingAlgorithm[]>(
+    merchantId ? `/routing/list/${merchantId}` : null,
+    () => apiPost<RoutingAlgorithm[]>(`/routing/list/${merchantId}`)
+  )
+  const { data: activeAlgorithms } = useSWR<RoutingAlgorithm[]>(
+    merchantId ? `/routing/list/active/${merchantId}` : null,
+    () => apiPost<RoutingAlgorithm[]>(`/routing/list/active/${merchantId}`)
+  )
+
+  const sourceId = editId || cloneFromId
+  const sourceRule = sourceId ? (allAlgorithms || []).find((a) => a.id === sourceId) : undefined
+  // The backend refuses to update an active algorithm (ensure_routing_algorithm_inactive), so say
+  // that up front rather than letting Save fail.
+  const isEditingActiveRule = isEdit && (activeAlgorithms || []).some((a) => a.id === editId)
+
+  // Seed the form from the source rule exactly once. Without the guard, SWR revalidation would
+  // overwrite whatever the user has typed since the page loaded.
+  const seededFrom = useRef<string | null>(null)
+  useEffect(() => {
+    if (!sourceRule || seededFrom.current === sourceRule.id) return
+    seededFrom.current = sourceRule.id
+    const { ruleBlocks: parsedBlocks, defaultOutput: parsedDefault } = parseAlgorithmToRuleBlocks(sourceRule)
+    setRuleName(isEdit ? sourceRule.name : `copy-of-${sourceRule.name}`)
+    setRuleDesc(sourceRule.description && sourceRule.description !== 'N/A' ? sourceRule.description : '')
+    setRuleBlocks(parsedBlocks)
+    setDefaultOutput(parsedDefault)
+    setEditorMode('visual')
+  }, [sourceRule, isEdit])
+
+  const gatewaySuggestions = Array.from(new Set([
+    ...ruleBlocks.flatMap((b) => [
+      ...b.priorityGateways.map((g) => g.gatewayName),
+      ...b.volumeSplitEntries.map((e) => e.gatewayName),
+      ...b.volumeSplitPriorityEntries.flatMap((e) => e.gateways.map((g) => g.gatewayName)),
+    ]),
+    ...defaultOutput.priorityGateways.map((g) => g.gatewayName),
+  ].filter(Boolean)))
+
+  const algorithmData = buildAlgorithmData(ruleBlocks, defaultOutput, routingKeys)
+
+  function handleClear() {
+    setRuleName('')
+    setRuleDesc('')
+    setRuleBlocks([])
+    setDefaultOutput({ priorityGateways: [] })
+    setEditorMode('visual')
+    setCodeText('')
+    setCodeParseError(null)
+    setSubmitError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!merchantId) { setSubmitError('Set a Merchant ID first.'); return }
+    if (routingKeysUnavailable) {
+      setSubmitError('Routing key config is unavailable. Ensure backend /config/routing-keys is reachable and valid.')
+      return
+    }
+    if (!ruleName.trim()) { setSubmitError('Rule name is required.'); return }
+    if (ruleBlocks.some(b =>
+      (b.outputType === 'priority' && b.priorityGateways.length === 0) ||
+      (b.outputType === 'volume_split' && b.volumeSplitEntries.length === 0) ||
+      (b.outputType === 'volume_split_priority' && b.volumeSplitPriorityEntries.length === 0)
+    )) { setSubmitError('Every rule needs at least one destination gateway in its THEN section.'); return }
+    if (codeParseError) { setSubmitError(`Fix syntax error: ${codeParseError}`); return }
+
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      const algorithm = { type: 'advanced', data: algorithmData }
+      if (isEdit) {
+        await apiPost('/routing/update', {
+          created_by: merchantId,
+          routing_algorithm_id: editId,
+          name: ruleName.trim(),
+          description: ruleDesc,
+          algorithm,
+        })
+      } else {
+        await apiPost<RoutingAlgorithm>('/routing/create', {
+          name: ruleName.trim(),
+          description: ruleDesc,
+          created_by: merchantId,
+          algorithm_for: 'payment',
+          algorithm,
+        })
+      }
+      await mutateAlgorithms()
+      navigate('/routing/rules')
+    } catch (err) {
+      setSubmitError(String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function addRuleBlock() {
+    setRuleBlocks((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        name: `Rule ${prev.length + 1}`,
+        statements: [createStatementGroup(routingKeys)],
+        outputType: 'priority',
+        priorityGateways: [],
+        volumeSplitEntries: [],
+        volumeSplitPriorityEntries: [],
+      },
+    ])
+  }
+
+  function switchToCode() {
+    if (ruleBlocks.length > 0) {
+      setCodeText(serializeToDSL(ruleBlocks))
+    } else if (!codeText.trim()) {
+      setCodeText(CODE_EDITOR_PLACEHOLDER)
+    }
+    setCodeParseError(null)
+    setEditorMode('code')
+  }
+
+  function switchToVisual() {
+    setEditorMode('visual')
+  }
+
+  function handleCodeChange(text: string) {
+    setCodeText(text)
+    if (!text.trim()) { setCodeParseError(null); setRuleBlocks([]); return }
+    const result = parseDSL(text)
+    if (result.error) {
+      setCodeParseError(result.error)
+      setRuleBlocks([])
+    } else if (result.rules !== null) {
+      setCodeParseError(null)
+      setRuleBlocks(result.rules)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <button
+            type="button"
+            onClick={() => navigate('/routing/rules')}
+            className="mb-2 inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-brand-600 dark:text-[#8d96a8] dark:hover:text-brand-400"
+          >
+            <ArrowLeft size={16} /> Rule-Based Routing
+          </button>
+          <h1 className="truncate text-2xl font-semibold text-slate-900 dark:text-white">
+            {isEdit ? 'Edit Payment Rule' : 'Create Payment Rule'}
+          </h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-[#8d96a8]">
+            Create precise cascading routing paths for card transactions using conditional flags.
+          </p>
+        </div>
+        <div className="flex shrink-0 rounded-lg border border-slate-200 text-xs dark:border-[#222226] overflow-hidden">
+          <button
+            type="button"
+            onClick={switchToVisual}
+            className={`px-3 py-1.5 transition-colors ${editorMode === 'visual' ? 'bg-brand-500 text-white font-semibold' : 'text-slate-500 hover:bg-slate-100 dark:hover:bg-[#1c1c24]'}`}
+          >
+            Visual Builder
+          </button>
+          <button
+            type="button"
+            onClick={switchToCode}
+            className={`px-3 py-1.5 transition-colors ${editorMode === 'code' ? 'bg-brand-500 text-white font-semibold' : 'text-slate-500 hover:bg-slate-100 dark:hover:bg-[#1c1c24]'}`}
+          >
+            Code
+          </button>
+        </div>
+      </div>
+
+      {isEdit && !sourceRule && allAlgorithms && (
+        <ErrorMessage error="That rule no longer exists for this merchant." />
+      )}
+      {isEditingActiveRule && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+          <strong>This rule is active</strong> — active rules cannot be edited. Deactivate it from the
+          rules list first, then come back.
+        </div>
+      )}
+
+      <div className="flex flex-col gap-6 xl:flex-row xl:items-start">
+      <form onSubmit={handleSubmit} className="min-w-0 flex-1 space-y-4">
+        <Card>
+          <CardBody className="space-y-5">
+            {/* Inline labels share a fixed column so the two fields line up with each other. */}
+            <div className="grid grid-cols-1 gap-x-12 gap-y-4 md:grid-cols-2">
+              <div className="flex items-center gap-2">
+                <label
+                  htmlFor="rule-name"
+                  className="shrink-0 whitespace-nowrap text-[13px] font-semibold text-slate-700 dark:text-slate-300"
+                >
+                  Rule Name *
+                </label>
+                <input
+                  id="rule-name"
+                  value={ruleName}
+                  onChange={(e) => setRuleName(e.target.value)}
+                  placeholder="my-rule"
+                  className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-transparent px-3.5 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <label
+                  htmlFor="rule-description"
+                  className="shrink-0 whitespace-nowrap text-[13px] font-semibold text-slate-700 dark:text-slate-300"
+                >
+                  Description
+                </label>
+                <input
+                  id="rule-description"
+                  value={ruleDesc}
+                  onChange={(e) => setRuleDesc(e.target.value)}
+                  placeholder="Optional description"
+                  className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-transparent px-3.5 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <p className="border-b border-slate-100 pb-2.5 text-xs font-semibold uppercase tracking-widest text-slate-500 dark:border-[#1c1c24] dark:text-[#8d96a8]">
+                Configured Rules
+              </p>
+              {routingKeysLoading && (
+                <p className="text-sm text-slate-500">Loading routing keys from backend...</p>
+              )}
+              {routingKeysUnavailable && (
+                <ErrorMessage error="Routing keys are unavailable from backend (/config/routing-keys). Rule Builder is disabled until this is fixed." />
+              )}
+              {editorMode === 'visual' ? (
+                <>
+                  {ruleBlocks.map((block, i) => (
+                    <RuleBlockEditor
+                      key={block.id}
+                      block={block}
+                      index={i}
+                      routingKeys={routingKeys}
+                      gatewaySuggestions={gatewaySuggestions}
+                      onChange={(updated) =>
+                        setRuleBlocks((prev) => prev.map((b) => (b.id === block.id ? updated : b)))
+                      }
+                      onRemove={() =>
+                        setRuleBlocks((prev) => prev.filter((b) => b.id !== block.id))
+                      }
+                    />
+                  ))}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={addRuleBlock}
+                    disabled={routingKeysUnavailable}
+                  >
+                    <Plus size={14} /> Add Rule
+                  </Button>
+                </>
+              ) : (
+                <RuleCodeEditor
+                  value={codeText}
+                  onChange={handleCodeChange}
+                  parseError={codeParseError}
+                  routingKeys={routingKeys}
+                  gatewaySuggestions={gatewaySuggestions}
+                />
+              )}
+            </div>
+
+            <div className="rounded-xl border border-dashed border-slate-300 px-4 py-4 dark:border-[#2a303a]">
+              <p className="text-[15px] font-semibold text-slate-800 dark:text-slate-200">Default Fallback Gateway</p>
+              <p className="mb-4 mt-1 text-[13px] text-slate-400 dark:text-[#8d96a8]">
+                This gateway handles any transactions that do not match the custom rules configured
+                above. Per-request overrides are possible via <code className="font-mono">fallback_output</code>.
+              </p>
+              <PriorityEditor
+                gateways={defaultOutput.priorityGateways}
+                suggestions={gatewaySuggestions}
+                onChange={(gws) => setDefaultOutput({ ...defaultOutput, priorityGateways: gws })}
+              />
+            </div>
+
+            <ErrorMessage error={submitError} />
+          </CardBody>
+        </Card>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <Button
+            type="submit"
+            disabled={submitting || routingKeysUnavailable || isEditingActiveRule || !canEditRouting}
+          >
+            {submitting ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Rule'}
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={handleClear}>
+            Clear
+          </Button>
+          <button
+            type="button"
+            onClick={() => navigate('/routing/rules')}
+            className="text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-[#8d96a8] dark:hover:text-white"
+          >
+            Cancel
+          </button>
+          <p className="text-sm text-slate-400 dark:text-[#6d7a8d]">
+            {isEdit
+              ? 'Saved changes apply the next time this rule is activated.'
+              : 'A new rule is created inactive — activate it from the rules list.'}
+          </p>
+        </div>
+      </form>
+
+      <RuleSummary
+        ruleName={ruleName}
+        ruleBlocks={ruleBlocks}
+        algorithmData={algorithmData}
+      />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The right rail: what the rule currently says, in plain English, updating as it is edited.
+ * The builder's controls are narrow by nature, so the page's spare width earns its keep by
+ * answering "what did I just build?" instead of stretching a two-digit amount across the screen.
+ */
+function RuleSummary({
+  ruleName,
+  ruleBlocks,
+  algorithmData,
+}: {
+  ruleName: string
+  ruleBlocks: RuleBlock[]
+  algorithmData: ReturnType<typeof buildAlgorithmData>
+}) {
+  // Render the payload that will actually be saved, through the same component the rules list
+  // uses — so the rail cannot drift from either the request or the list's view of it.
+  const preview = {
+    id: 'preview',
+    name: ruleName,
+    description: '',
+    created_by: '',
+    algorithm: { type: 'advanced', data: algorithmData },
+  } as unknown as RoutingAlgorithm
+
+  return (
+    <aside className="w-full shrink-0 xl:w-[24rem]">
+      <div className="xl:sticky xl:top-6">
+        <Card>
+          <CardBody className="space-y-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-[#8d96a8]">
+                Rule details
+              </p>
+              <p className="mt-1 truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
+                {ruleName.trim() || 'Untitled rule'}
+              </p>
+            </div>
+
+            {ruleBlocks.length === 0 ? (
+              <p className="text-[13px] leading-relaxed text-slate-500 dark:text-[#8d96a8]">
+                No conditions yet — every payment will take the default fallback.
+              </p>
+            ) : (
+              <RuleBreakdown algo={preview} />
+            )}
+          </CardBody>
+        </Card>
+      </div>
+    </aside>
+  )
+}

--- a/website/src/components/pages/EuclidRulesPage.tsx
+++ b/website/src/components/pages/EuclidRulesPage.tsx
@@ -1,1115 +1,41 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  DragEndEvent,
-} from '@dnd-kit/core'
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { Card, CardBody, CardHeader } from '../ui/Card'
+import { Plus, ChevronDown, ChevronRight, Zap, PowerOff, Pencil, Copy, Trash2 } from 'lucide-react'
+import { Card } from '../ui/Card'
+import { HeaderFilter, HeaderSearch, RowMenu } from '../ui/TableControls'
 import { Button } from '../ui/Button'
 import { ErrorMessage } from '../ui/ErrorMessage'
-import { SearchableSelect } from '../ui/SearchableSelect'
-import { SearchableMultiSelect } from '../ui/SearchableMultiSelect'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { useMerchantStore } from '../../store/merchantStore'
 import { useCanEditRouting } from '../../store/authStore'
 import { apiPost } from '../../lib/api'
 import { RoutingAlgorithm } from '../../types/api'
-import { useDynamicRoutingConfig, RoutingKeyConfig } from '../../hooks/useDynamicRoutingConfig'
-import { EuclidAlgorithmData } from '../../types/api'
+import { RuleBreakdown } from '../routing/euclid/RuleBreakdown'
 import {
-  RuleCodeEditor, serializeToDSL, parseDSL, CODE_EDITOR_PLACEHOLDER,
-  type RuleBlock, type StatementGroup, type ConditionRow,
-  type GatewayEntry, type VolumeSplitEntry, type VolumeSplitPriorityEntry,
-} from '../ui/RuleCodeEditor'
-import { Plus, Trash2, GripVertical, ChevronDown, ChevronUp, PowerOff, CornerDownRight, CopyPlus, MoreVertical } from 'lucide-react'
-import { ConfirmDialog } from '../ui/ConfirmDialog'
-import { CopyButton } from '../ui/CopyButton'
+  summarizeConditions, summarizeDestination, destinationGateways,
+} from '../../features/routing/euclid/summarize'
 
-const OPERATOR_TO_API: Record<string, string> = {
-  '==': 'equal',
-  '!=': 'not_equal',
-  '>': 'greater_than',
-  '<': 'less_than',
-  '>=': 'greater_than_equal',
-  '<=': 'less_than_equal',
-  'in': 'equal',
-  'not_in': 'not_equal',
-}
+type StatusFilter = 'all' | 'active' | 'inactive'
 
-const OPERATOR_LABELS: Record<string, string> = {
-  '==': 'equals',
-  '!=': 'not equals',
-  '>': 'greater than',
-  '<': 'less than',
-  '>=': 'greater than or equal',
-  '<=': 'less than or equal',
-  'in': 'is one of',
-  'not_in': 'is not one of',
-}
-
-function toLabel(key: string): string {
-  return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
-}
-
-
-type DefaultOutput = {
-  priorityGateways: GatewayEntry[]
-}
-
-function createCondition(routingKeys: Record<string, RoutingKeyConfig>): ConditionRow {
-  const firstKey = Object.keys(routingKeys)[0] || 'payment_method'
-  const firstKeyValues = routingKeys[firstKey]?.values || []
-  return {
-    id: crypto.randomUUID(),
-    lhs: firstKey,
-    operator: '==',
-    value: firstKeyValues[0] || '',
-    metadataKey: '',
-  }
-}
-
-function createStatementGroup(routingKeys: Record<string, RoutingKeyConfig>): StatementGroup {
-  return {
-    id: crypto.randomUUID(),
-    conditions: [createCondition(routingKeys)],
-    nested: [],
-  }
-}
-
-function formatOp(comparison: string): string {
-  const map: Record<string, string> = {
-    equal: '=', not_equal: '≠',
-    greater_than: '>', less_than: '<',
-    greater_than_equal: '≥', less_than_equal: '≤',
-  }
-  return map[comparison] ?? comparison.replace(/_/g, ' ')
-}
-
-
-export function RuleBreakdown({ algo }: { algo: RoutingAlgorithm }) {
-  const algorithm = algo.algorithm_data || algo.algorithm
-  const data = algorithm?.data as EuclidAlgorithmData | undefined
-  const defaultSel = data?.default_selection || data?.defaultSelection
-
-  return (
-    <div className="space-y-2.5">
-      {(data?.rules ?? []).map((rule, i) => {
-        const output = rule.output as Record<string, unknown> | undefined
-        // Backend may return { priority: [...] }, { type, data: [...] }, { volume_split: [...] }, or { volume_split_priority: [...] }
-        const rawPriority = output?.priority ?? output?.data
-        const rawVolume = output?.volume_split ?? (output?.type === 'volume_split' ? output?.data : undefined)
-        const rawVolumeSplitPriority = output?.volume_split_priority
-        const priorityGateways = (
-          Array.isArray(rawPriority) ? rawPriority : []
-        ) as { gateway_name: string; gateway_id: string | null }[]
-        const volumeSplits = (
-          Array.isArray(rawVolume) ? rawVolume : []
-        ) as { split: number; output: { gateway_name: string } }[]
-        const volumeSplitPriorityEntries = (
-          Array.isArray(rawVolumeSplitPriority) ? rawVolumeSplitPriority : []
-        ) as { split: number; output: { gateway_name: string; gateway_id: string | null }[] }[]
-        const isVolumeSplit = rule.routing_type === 'volume_split' || volumeSplits.length > 0
-        const isVolumeSplitPriority = rule.routing_type === 'volume_split_priority' || volumeSplitPriorityEntries.length > 0
-
-        type CondEntry = { op: 'IF' | 'AND' | 'OR'; cond: typeof rule.statements[0]['condition'][0] }
-        // Each statement becomes its own visual group, separated by OR dividers.
-        const condGroups: CondEntry[][] = []
-        rule.statements.forEach((s) => {
-          const group: CondEntry[] = []
-
-          s.condition.forEach((cond) => {
-            group.push({ op: group.length === 0 ? 'IF' : 'AND', cond })
-          })
-
-          ;(s.nested ?? []).forEach((nestedGroup, ni) => {
-            nestedGroup.condition.forEach((cond, ci) => {
-              if (ci === 0) group.push({ op: (group.length === 0 || ni === 0) ? (group.length === 0 ? 'IF' : 'AND') : 'OR', cond })
-              else group.push({ op: 'AND', cond })
-            })
-          })
-
-          if (group.length > 0) condGroups.push(group)
-        })
-
-        return (
-          <div key={i} className="overflow-hidden rounded-xl border border-slate-200 dark:border-[#1e2330] bg-white dark:bg-[#0d1018]">
-            <div className="flex items-center justify-between gap-2 border-b border-slate-100 dark:border-[#1e2330] bg-slate-50 dark:bg-[#10131c] px-3 py-1.5">
-              <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400 dark:text-[#4e5870]">
-                {rule.name || `Rule ${i + 1}`}
-              </span>
-              {rule.routing_type && (
-                <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
-                  rule.routing_type === 'volume_split_priority'
-                    ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400'
-                    : rule.routing_type === 'volume_split'
-                    ? 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400'
-                    : 'bg-brand-100 dark:bg-brand-900/30 text-brand-600 dark:text-brand-400'
-                }`}>
-                  {rule.routing_type === 'volume_split_priority' ? 'Split + Priority'
-                    : rule.routing_type === 'volume_split' ? 'Volume Split'
-                    : 'Priority'}
-                </span>
-              )}
-            </div>
-            <div className="space-y-1.5 px-3 py-2.5">
-              {condGroups.map((group, gi) => (
-                <div key={gi}>
-                  {gi > 0 && (
-                    <div className="flex items-center gap-2 my-1.5">
-                      <span className="h-px flex-1 bg-slate-200 dark:bg-[#1e2330]" />
-                      <span className="text-[10px] font-bold text-sky-500">OR</span>
-                      <span className="h-px flex-1 bg-slate-200 dark:bg-[#1e2330]" />
-                    </div>
-                  )}
-                  <div className="rounded-lg border border-slate-200 dark:border-[#1e2330] divide-y divide-slate-100 dark:divide-[#1e2330] overflow-hidden">
-                    {group.map(({ op, cond }, ci) => (
-                      <div key={ci} className="flex items-center gap-2 text-xs px-2 py-1.5">
-                        <span className={`w-7 shrink-0 text-right text-[10px] font-bold select-none ${op === 'OR' ? 'text-sky-400 dark:text-sky-500' : 'text-slate-300 dark:text-[#3a4258]'}`}>
-                          {op}
-                        </span>
-                        <span className="rounded-md bg-slate-100 dark:bg-[#1a1f2a] px-2 py-1 text-slate-700 dark:text-[#c8d0de]">
-                          {toLabel(String(cond.lhs ?? ''))}{' '}
-                          <span className="font-mono text-slate-400 dark:text-[#5d6880]">{formatOp(String(cond.comparison ?? ''))}</span>{' '}
-                          <span className="font-medium">
-                            {cond.value?.type === 'metadata_variant' && cond.value.value && typeof cond.value.value === 'object'
-                              ? `{ "${(cond.value.value as { key?: string }).key ?? ''}" : "${(cond.value.value as { value?: string }).value ?? ''}" }`
-                              : toLabel(String(cond.value?.value ?? ''))}
-                          </span>
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ))}
-              <div className="flex items-start gap-2 pt-0.5 text-xs">
-                <span className="w-7 shrink-0 text-right text-[10px] font-bold text-brand-500 select-none">→</span>
-                <div className="flex flex-wrap gap-1">
-                  {isVolumeSplitPriority
-                    ? volumeSplitPriorityEntries.map((e, j) => (
-                        <span key={j} className="rounded-full bg-purple-50 dark:bg-purple-900/20 px-2 py-0.5 text-[11px] font-medium text-purple-700 dark:text-purple-300">
-                          {e.split}%: {e.output.map(g => g.gateway_name).join(', ')}
-                        </span>
-                      ))
-                    : isVolumeSplit
-                    ? volumeSplits.map((s, j) => (
-                        <span key={j} className="rounded-full bg-emerald-50 dark:bg-emerald-900/20 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-                          {s.output.gateway_name} {s.split}%
-                        </span>
-                      ))
-                    : priorityGateways.map((g, j) => (
-                        <span key={j} className="rounded-full bg-brand-50 dark:bg-brand-900/20 px-2 py-0.5 text-[11px] font-medium text-brand-700 dark:text-brand-300">
-                          {j + 1}. {g.gateway_name}
-                        </span>
-                      ))
-                  }
-                  {!isVolumeSplitPriority && !isVolumeSplit && priorityGateways.length === 0 && (
-                    <span className="text-slate-400 italic">No output configured</span>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        )
-      })}
-
-      {(() => {
-        const defRaw = defaultSel as Record<string, unknown> | undefined
-        const defGateways = (Array.isArray(defRaw?.priority) ? defRaw!.priority : Array.isArray(defRaw?.data) ? defRaw!.data : []) as { gateway_name: string }[]
-        return defGateways.length > 0 ? (
-          <div className="flex items-center gap-2 px-1 text-xs">
-            <span className="text-slate-400 dark:text-[#4e5870]">Default:</span>
-            <div className="flex flex-wrap gap-1">
-              {defGateways.map((g, i) => (
-                <span key={i} className="rounded-full bg-slate-100 dark:bg-[#1a1f2a] px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:text-[#8090a8]">
-                  {g.gateway_name}
-                </span>
-              ))}
-            </div>
-          </div>
-        ) : null
-      })()}
-
-      {(!data?.rules || data.rules.length === 0) && (
-        <p className="text-xs text-slate-400 italic">No rules configured.</p>
-      )}
-    </div>
-  )
-}
-
-// ---- Sortable gateway item ----
-function SortableGatewayItem({
-  id,
-  name,
-  onRemove,
-}: {
-  id: string
-  name: string
-  onRemove: () => void
-}) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
-  const style = { transform: CSS.Transform.toString(transform), transition }
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className="flex items-center gap-2 bg-slate-100 dark:bg-[#111118] border border-slate-200 dark:border-[#1c1c24] rounded-lg px-2 py-1.5"
-    >
-      <span {...attributes} {...listeners} className="cursor-grab text-slate-400">
-        <GripVertical size={14} />
-      </span>
-      <span className="text-sm flex-1 font-mono">{name}</span>
-      <button type="button" onClick={onRemove} className="text-red-400 hover:text-red-600">
-        <Trash2 size={12} />
-      </button>
-    </div>
-  )
-}
-
-// ---- Priority output editor ----
-function PriorityEditor({
-  gateways,
-  onChange,
-  suggestions = [],
-}: {
-  gateways: GatewayEntry[]
-  onChange: (gws: GatewayEntry[]) => void
-  suggestions?: string[]
-}) {
-  const [newGatewayName, setNewGatewayName] = useState('')
-  const [newGatewayId, setNewGatewayId] = useState('')
-  const listId = useRef(`gateway-suggestions-${Math.random().toString(36).slice(2)}`).current
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  )
-
-  function handleDragEnd(event: DragEndEvent) {
-    const { active, over } = event
-    if (over && active.id !== over.id) {
-      const oldIndex = gateways.findIndex((g) => g.id === active.id)
-      const newIndex = gateways.findIndex((g) => g.id === over.id)
-      onChange(arrayMove(gateways, oldIndex, newIndex))
-    }
-  }
-
-  function add() {
-    if (!newGatewayName.trim()) return
-    onChange([
-      ...gateways,
-      { id: crypto.randomUUID(), gatewayName: newGatewayName.trim(), gatewayId: newGatewayId.trim() },
-    ])
-    setNewGatewayName('')
-    setNewGatewayId('')
-  }
-
-  const unusedSuggestions = suggestions.filter((s) => !gateways.some((g) => g.gatewayName === s))
-
-  return (
-    <div className="space-y-2">
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={gateways.map((g) => g.id)} strategy={verticalListSortingStrategy}>
-          {gateways.map((gw, idx) => (
-            <SortableGatewayItem
-              key={gw.id}
-              id={gw.id}
-              name={`${idx + 1}. ${gw.gatewayName}${gw.gatewayId ? ` (${gw.gatewayId})` : ''}`}
-              onRemove={() => onChange(gateways.filter((g) => g.id !== gw.id))}
-            />
-          ))}
-        </SortableContext>
-      </DndContext>
-      <datalist id={listId}>
-        {unusedSuggestions.map((s) => <option key={s} value={s} />)}
-      </datalist>
-      <div className="flex gap-2">
-        <input
-          value={newGatewayName}
-          onChange={(e) => setNewGatewayName(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
-          list={listId}
-          placeholder="Gateway name"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm flex-1 focus:outline-none focus:ring-1 focus:ring-brand-500"
-        />
-        <input
-          value={newGatewayId}
-          onChange={(e) => setNewGatewayId(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
-          placeholder="Gateway ID (optional)"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm flex-1 focus:outline-none focus:ring-1 focus:ring-brand-500"
-        />
-        <Button type="button" size="sm" variant="secondary" onClick={add}>
-          <Plus size={13} /> Add
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-// ---- Volume split editor ----
-function VolumeSplitEditor({
-  entries,
-  onChange,
-  suggestions = [],
-}: {
-  entries: VolumeSplitEntry[]
-  onChange: (e: VolumeSplitEntry[]) => void
-  suggestions?: string[]
-}) {
-  const [newSplit, setNewSplit] = useState('')
-  const [newName, setNewName] = useState('')
-  const [newId, setNewId] = useState('')
-  const listId = `vs-suggestions-${Math.random().toString(36).slice(2)}`
-
-  const total = entries.reduce((s, e) => s + e.split, 0)
-
-  function add() {
-    if (!newName.trim() || !newSplit) return
-    onChange([
-      ...entries,
-      { id: crypto.randomUUID(), split: Number(newSplit), gatewayName: newName.trim(), gatewayId: newId.trim() },
-    ])
-    setNewSplit('')
-    setNewName('')
-    setNewId('')
-  }
-
-  const unusedSuggestions = suggestions.filter((s) => !entries.some((e) => e.gatewayName === s))
-
-  return (
-    <div className="space-y-2">
-      {entries.map((e) => (
-        <div
-          key={e.id}
-          className="flex items-center gap-2 bg-slate-100 dark:bg-[#111118] border border-slate-200 dark:border-[#1c1c24] rounded-lg px-2 py-1.5"
-        >
-          <span className="text-xs font-bold text-brand-500 w-10 shrink-0 tabular-nums">{e.split}%</span>
-          <span className="text-sm flex-1 font-mono">
-            {e.gatewayName}{e.gatewayId ? ` (${e.gatewayId})` : ''}
-          </span>
-          <button type="button" onClick={() => onChange(entries.filter((x) => x.id !== e.id))} className="text-red-400 hover:text-red-600">
-            <Trash2 size={12} />
-          </button>
-        </div>
-      ))}
-      {entries.length > 0 && (
-        <p className={`text-xs font-medium ${total === 100 ? 'text-emerald-500' : 'text-amber-500'}`}>
-          Total: {total}%{total !== 100 ? ' (must equal 100%)' : ' ✓'}
-        </p>
-      )}
-      <datalist id={listId}>
-        {unusedSuggestions.map((s) => <option key={s} value={s} />)}
-      </datalist>
-      <div className="flex gap-2">
-        <input
-          type="number"
-          value={newSplit}
-          onChange={(e) => setNewSplit(e.target.value)}
-          placeholder="Split %"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm w-20 focus:outline-none focus:ring-1 focus:ring-brand-500"
-        />
-        <input
-          value={newName}
-          onChange={(e) => setNewName(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
-          list={listId}
-          placeholder="Gateway name"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm flex-1 focus:outline-none focus:ring-1 focus:ring-brand-500"
-        />
-        <input
-          value={newId}
-          onChange={(e) => setNewId(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
-          placeholder="Gateway ID (optional)"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm flex-1 focus:outline-none focus:ring-1 focus:ring-brand-500"
-        />
-        <Button type="button" size="sm" variant="secondary" onClick={add}>
-          <Plus size={13} /> Add
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-// ---- Volume split priority editor ----
-function VolumeSplitPriorityEditor({
-  entries,
-  onChange,
-  suggestions = [],
-}: {
-  entries: VolumeSplitPriorityEntry[]
-  onChange: (e: VolumeSplitPriorityEntry[]) => void
-  suggestions?: string[]
-}) {
-  const [newSplit, setNewSplit] = useState('')
-
-  const total = entries.reduce((s, e) => s + e.split, 0)
-
-  function addSplit() {
-    if (!newSplit) return
-    onChange([...entries, { id: crypto.randomUUID(), split: Number(newSplit), gateways: [] }])
-    setNewSplit('')
-  }
-
-  function updateEntry(id: string, patch: Partial<VolumeSplitPriorityEntry>) {
-    onChange(entries.map((e) => (e.id === id ? { ...e, ...patch } : e)))
-  }
-
-  return (
-    <div className="space-y-3">
-      {entries.length > 0 && (
-        <p className={`text-xs font-medium ${total === 100 ? 'text-emerald-500' : 'text-amber-500'}`}>
-          Total: {total}%{total !== 100 ? ' (must equal 100%)' : ' ✓'}
-        </p>
-      )}
-      {entries.map((entry, idx) => (
-        <div
-          key={entry.id}
-          className="rounded-lg border border-slate-200 dark:border-[#222226] overflow-hidden"
-        >
-          <div className="flex items-center gap-2 px-3 py-2 bg-slate-50 dark:bg-[#111118] border-b border-slate-200 dark:border-[#1c1c24]">
-            <span className="text-xs text-slate-400 font-medium shrink-0">Split {idx + 1}:</span>
-            <input
-              type="number"
-              value={entry.split}
-              onChange={(e) => updateEntry(entry.id, { split: Number(e.target.value) })}
-              className="border border-slate-200 dark:border-[#222226] bg-transparent rounded px-2 py-0.5 text-xs w-16 focus:outline-none"
-            />
-            <span className="text-xs text-slate-400">%</span>
-            <button
-              type="button"
-              onClick={() => onChange(entries.filter((e) => e.id !== entry.id))}
-              className="ml-auto text-red-400 hover:text-red-600"
-            >
-              <Trash2 size={12} />
-            </button>
-          </div>
-          <div className="p-3">
-            <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 mb-2">Priority list for this split</p>
-            <PriorityEditor
-              gateways={entry.gateways}
-              suggestions={suggestions}
-              onChange={(gws) => updateEntry(entry.id, { gateways: gws })}
-            />
-          </div>
-        </div>
-      ))}
-      <div className="flex gap-2 items-center">
-        <input
-          type="number"
-          value={newSplit}
-          onChange={(e) => setNewSplit(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addSplit())}
-          placeholder="Split %"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm w-24 focus:outline-none focus:ring-1 focus:ring-brand-500"
-        />
-        <Button type="button" size="sm" variant="secondary" onClick={addSplit}>
-          <Plus size={13} /> Add split
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-// ---- Condition row ----
-function ConditionRowEditor({
-  row,
-  onChange,
-  onRemove,
-  routingKeys,
-}: {
-  row: ConditionRow
-  onChange: (r: ConditionRow) => void
-  onRemove: () => void
-  routingKeys: Record<string, RoutingKeyConfig>
-}) {
-  const keyInfo = routingKeys[row.lhs]
-  const isEnum = keyInfo?.type === 'enum'
-  const isInt = keyInfo?.type === 'integer'
-  const isStr = keyInfo?.type === 'str_value'
-  const isMetadata = keyInfo?.type === 'udf' || keyInfo?.type === 'global_ref'
-  const isMulti = row.operator === 'in' || row.operator === 'not_in'
-
-  const operators = isInt
-    ? ['>', '<', '>=', '<=', '==', '!=']
-    : isEnum
-    ? ['==', '!=', 'in', 'not_in']
-    : ['==', '!=']
-
-  const selectedValues = Array.isArray(row.value) ? row.value : []
-
-  function handleOperatorChange(op: string) {
-    const switchingToMulti = op === 'in' || op === 'not_in'
-    const switchingFromMulti = row.operator === 'in' || row.operator === 'not_in'
-    let newValue: string | string[] = row.value
-    if (switchingToMulti && !Array.isArray(row.value)) {
-      newValue = row.value ? [row.value as string] : []
-    } else if (!switchingToMulti && switchingFromMulti) {
-      newValue = Array.isArray(row.value) ? (row.value[0] ?? '') : ''
-    }
-    onChange({ ...row, operator: op, value: newValue })
-  }
-
-  return (
-    <div className="flex items-start gap-2 flex-wrap">
-      <SearchableSelect
-        dataCy="cond-lhs"
-        value={row.lhs}
-        onChange={(newKey) => {
-          const newConfig = routingKeys[newKey]
-          const defaultValue = newConfig?.type === 'enum' ? (newConfig.values?.[0] ?? '') : ''
-          onChange({ ...row, lhs: newKey, value: defaultValue, operator: '==' })
-        }}
-        options={Object.keys(routingKeys).map((k) => ({ value: k, label: toLabel(k) }))}
-      />
-      <select
-        value={row.operator}
-        onChange={(e) => handleOperatorChange(e.target.value)}
-        aria-label="Condition operator"
-        className="cond-select min-w-[9.5rem]"
-      >
-        {operators.map((op) => (
-          <option key={op} value={op}>{OPERATOR_LABELS[op] || op}</option>
-        ))}
-      </select>
-      {isEnum && isMulti ? (
-        <div data-cy="cond-val">
-          <SearchableMultiSelect
-            values={selectedValues}
-            onChange={(vals) => onChange({ ...row, value: vals })}
-            options={(keyInfo?.values || []).map((v: string) => ({ value: v, label: toLabel(v) }))}
-            placeholder="Select values…"
-          />
-        </div>
-      ) : isEnum ? (
-        <SearchableSelect
-          dataCy="cond-val"
-          value={row.value as string}
-          onChange={(v) => onChange({ ...row, value: v })}
-          options={(keyInfo?.values || []).map((v: string) => ({ value: v, label: toLabel(v) }))}
-        />
-      ) : isInt ? (
-        <input
-          type="number"
-          value={row.value as string}
-          onChange={(e) => onChange({ ...row, value: e.target.value })}
-          placeholder="value"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-xs w-24 focus:outline-none"
-        />
-      ) : isMetadata ? (
-        <>
-          <input
-            type="text"
-            value={row.metadataKey || ''}
-            onChange={(e) => onChange({ ...row, metadataKey: e.target.value })}
-            placeholder="key"
-            className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-xs w-24 focus:outline-none"
-          />
-          <span className="text-xs text-slate-400 dark:text-slate-500 select-none">=</span>
-          <input
-            type="text"
-            value={row.value as string}
-            onChange={(e) => onChange({ ...row, value: e.target.value })}
-            placeholder="value"
-            className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-xs w-32 focus:outline-none"
-          />
-        </>
-      ) : isStr ? (
-        <input
-          type="text"
-          value={row.value as string}
-          onChange={(e) => onChange({ ...row, value: e.target.value })}
-          placeholder="value"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-xs w-32 focus:outline-none"
-        />
-      ) : (
-        <input
-          type="text"
-          value={row.value as string}
-          onChange={(e) => onChange({ ...row, value: e.target.value })}
-          placeholder="value"
-          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-xs w-32 focus:outline-none"
-        />
-      )}
-      <button type="button" onClick={onRemove} aria-label="Remove condition" className="text-red-400 hover:text-red-600 mt-1">
-        <Trash2 size={12} />
-      </button>
-    </div>
-  )
-}
-
-// ---- Condition group ----
-function ConditionGroupEditor({
-  group,
-  onChange,
-  onRemove,
-  canRemove,
-  routingKeys,
-  depth = 0,
-}: {
-  group: StatementGroup
-  onChange: (g: StatementGroup) => void
-  onRemove: () => void
-  canRemove: boolean
-  routingKeys: Record<string, RoutingKeyConfig>
-  depth?: number
-}) {
-  function addCondition() {
-    onChange({ ...group, conditions: [...group.conditions, createCondition(routingKeys)] })
-  }
-
-  function addNestedBranch() {
-    onChange({ ...group, nested: [...group.nested, createStatementGroup(routingKeys)] })
-  }
-
-  return (
-    <div className="rounded-lg border border-slate-200 dark:border-[#222733] bg-white dark:bg-[#0f141d]">
-      <div className="space-y-0 divide-y divide-slate-100 dark:divide-[#1c1c24]">
-        {group.conditions.map((cond, idx) => (
-          <div key={cond.id} className="flex items-start gap-2 px-3 py-2.5 flex-wrap">
-            {group.conditions.length > 1 && (
-              <span className="w-8 shrink-0 text-[10px] font-bold uppercase tracking-widest text-slate-400 select-none mt-1.5">
-                {idx === 0 ? 'IF' : 'AND'}
-              </span>
-            )}
-            <ConditionRowEditor
-              row={cond}
-              routingKeys={routingKeys}
-              onChange={(updated) =>
-                onChange({ ...group, conditions: group.conditions.map((c) => (c.id === cond.id ? updated : c)) })
-              }
-              onRemove={() =>
-                onChange({
-                  ...group,
-                  conditions: group.conditions.length > 1
-                    ? group.conditions.filter((c) => c.id !== cond.id)
-                    : group.conditions,
-                })
-              }
-            />
-          </div>
-        ))}
-      </div>
-
-      {/* Nested OR branches — shown only at depth 0 */}
-      {depth === 0 && group.nested.length > 0 && (
-        <div className="border-t border-slate-100 dark:border-[#1c1c24] px-3 pt-3 pb-2 space-y-2">
-          <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-400">
-            <CornerDownRight size={11} />
-            Then match any of (nested OR)
-          </div>
-          {group.nested.map((nestedGroup, nIdx) => (
-            <div key={nestedGroup.id} className="pl-3 border-l-2 border-sky-200 dark:border-sky-800">
-              {nIdx > 0 && (
-                <p className="text-[10px] font-bold text-sky-500 mb-1">OR</p>
-              )}
-              <ConditionGroupEditor
-                group={nestedGroup}
-                routingKeys={routingKeys}
-                canRemove={true}
-                depth={1}
-                onChange={(updated) =>
-                  onChange({ ...group, nested: group.nested.map((n) => (n.id === nestedGroup.id ? updated : n)) })
-                }
-                onRemove={() =>
-                  onChange({ ...group, nested: group.nested.filter((n) => n.id !== nestedGroup.id) })
-                }
-              />
-            </div>
-          ))}
-        </div>
-      )}
-
-      <div className="flex items-center gap-3 border-t border-slate-100 dark:border-[#1c1c24] px-3 py-2 flex-wrap">
-        <button
-          type="button"
-          onClick={addCondition}
-          className="flex items-center gap-1 text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-        >
-          <Plus size={12} /> Add condition
-        </button>
-        {depth === 0 && (
-          <button
-            type="button"
-            onClick={addNestedBranch}
-            className="flex items-center gap-1 text-xs text-sky-400 hover:text-sky-600 transition-colors"
-          >
-            <CornerDownRight size={12} /> Add nested branch
-          </button>
-        )}
-        {canRemove && (
-          <button
-            type="button"
-            onClick={onRemove}
-            className="ml-auto flex items-center gap-1 text-xs text-red-400 hover:text-red-600 transition-colors"
-          >
-            <Trash2 size={12} /> Remove group
-          </button>
-        )}
-      </div>
-    </div>
-  )
-}
-
-const OUTPUT_TYPE_LABELS: Record<string, string> = {
-  priority: 'Priority',
-  volume_split: 'Volume Split',
-}
-
-// ---- Rule block ----
-function RuleBlockEditor({
-  block,
-  onChange,
-  onRemove,
-  routingKeys,
-  gatewaySuggestions = [],
-}: {
-  block: RuleBlock
-  onChange: (b: RuleBlock) => void
-  onRemove: () => void
-  routingKeys: Record<string, RoutingKeyConfig>
-  gatewaySuggestions?: string[]
-}) {
-  const [collapsed, setCollapsed] = useState(false)
-
-  function addGroup() {
-    onChange({ ...block, statements: [...block.statements, createStatementGroup(routingKeys)] })
-  }
-
-  return (
-    <div className="border border-slate-200 dark:border-[#1c1c24] rounded-xl overflow-hidden">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2.5 bg-slate-50 dark:bg-[#111118] border-b border-slate-200 dark:border-[#1c1c24]">
-        <input
-          value={block.name}
-          onChange={(e) => onChange({ ...block, name: e.target.value })}
-          placeholder="Rule name"
-          className="bg-transparent text-sm font-semibold focus:outline-none text-slate-700 dark:text-slate-200 w-full"
-        />
-        <div className="flex items-center gap-2 ml-2 shrink-0">
-          <button type="button" onClick={onRemove} aria-label="Delete rule" className="text-red-400 hover:text-red-600">
-            <Trash2 size={14} />
-          </button>
-          <button
-            type="button"
-            onClick={() => setCollapsed(!collapsed)}
-            aria-label={collapsed ? 'Expand rule' : 'Collapse rule'}
-            className="text-slate-400 hover:text-slate-600"
-          >
-            {collapsed ? <ChevronDown size={14} /> : <ChevronUp size={14} />}
-          </button>
-        </div>
-      </div>
-
-      {!collapsed && (
-        <div className="divide-y divide-slate-100 dark:divide-[#1c1c24]">
-          {/* IF section */}
-          <div className="px-4 py-4 space-y-2">
-            <p className="text-[11px] font-semibold uppercase tracking-widest text-slate-400 mb-3">If</p>
-            {block.statements.map((group, idx) => (
-              <div key={group.id} className="space-y-2">
-                {idx > 0 && (
-                  <div className="flex items-center gap-3">
-                    <span className="h-px flex-1 bg-slate-200 dark:bg-[#222]" />
-                    <span className="text-[11px] font-bold uppercase tracking-widest text-sky-500 px-1">or</span>
-                    <span className="h-px flex-1 bg-slate-200 dark:bg-[#222]" />
-                  </div>
-                )}
-                <ConditionGroupEditor
-                  group={group}
-                  routingKeys={routingKeys}
-                  canRemove={block.statements.length > 1}
-                  onChange={(updated) =>
-                    onChange({ ...block, statements: block.statements.map((s) => (s.id === group.id ? updated : s)) })
-                  }
-                  onRemove={() =>
-                    onChange({ ...block, statements: block.statements.filter((s) => s.id !== group.id) })
-                  }
-                />
-              </div>
-            ))}
-            <button
-              type="button"
-              onClick={addGroup}
-              className="flex items-center gap-1 text-xs text-sky-500 hover:text-sky-600 font-medium transition-colors mt-1"
-            >
-              <Plus size={12} /> Add OR group
-            </button>
-          </div>
-
-          {/* THEN section */}
-          <div className="px-4 py-4">
-            <div className="flex items-center gap-3 mb-3">
-              <p className="text-[11px] font-semibold uppercase tracking-widest text-slate-400 shrink-0">Then route</p>
-              <div className="flex rounded-lg border border-slate-200 dark:border-[#222226] overflow-hidden text-[11px]">
-                {Object.keys(OUTPUT_TYPE_LABELS).map((type) => (
-                  <button
-                    key={type}
-                    type="button"
-                    onClick={() => onChange({ ...block, outputType: type as RuleBlock['outputType'] })}
-                    className={`px-2.5 py-1 transition-colors ${
-                      block.outputType === type
-                        ? 'bg-brand-500 text-white font-semibold'
-                        : 'text-slate-500 hover:bg-slate-100 dark:hover:bg-[#1c1c24]'
-                    }`}
-                  >
-                    {OUTPUT_TYPE_LABELS[type]}
-                  </button>
-                ))}
-              </div>
-            </div>
-            {block.outputType === 'priority' && (
-              <PriorityEditor
-                gateways={block.priorityGateways}
-                suggestions={gatewaySuggestions}
-                onChange={(gws) => onChange({ ...block, priorityGateways: gws })}
-              />
-            )}
-            {block.outputType === 'volume_split' && (
-              <VolumeSplitEditor
-                entries={block.volumeSplitEntries}
-                suggestions={gatewaySuggestions}
-                onChange={(entries) => onChange({ ...block, volumeSplitEntries: entries })}
-              />
-            )}
-            {block.outputType === 'volume_split_priority' && (
-              <VolumeSplitPriorityEditor
-                entries={block.volumeSplitPriorityEntries}
-                suggestions={gatewaySuggestions}
-                onChange={(entries) => onChange({ ...block, volumeSplitPriorityEntries: entries })}
-              />
-            )}
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ---- Build Euclid payload ----
-function buildAlgorithmData(rules: RuleBlock[], defaultOutput: DefaultOutput, routingKeys: Record<string, RoutingKeyConfig>) {
-  function buildPriorityOutput(gateways: GatewayEntry[]): Record<string, unknown> {
-    return {
-      priority: gateways.map((g) => ({ gateway_name: g.gatewayName, gateway_id: g.gatewayId || null })),
-    }
-  }
-
-  function buildOutput(block: RuleBlock): Record<string, unknown> {
-    if (block.outputType === 'volume_split') {
-      return {
-        volume_split: block.volumeSplitEntries.map((e) => ({
-          split: e.split,
-          output: { gateway_name: e.gatewayName, gateway_id: e.gatewayId || null },
-        })),
-      }
-    }
-    if (block.outputType === 'volume_split_priority') {
-      return {
-        volume_split_priority: block.volumeSplitPriorityEntries.map((e) => ({
-          split: e.split,
-          output: e.gateways.map((g) => ({ gateway_name: g.gatewayName, gateway_id: g.gatewayId || null })),
-        })),
-      }
-    }
-    return buildPriorityOutput(block.priorityGateways)
-  }
-
-  function buildCondition(c: ConditionRow) {
-    const keyType = routingKeys[c.lhs]?.type
-    const isMulti = c.operator === 'in' || c.operator === 'not_in'
-
-    if (isMulti && Array.isArray(c.value)) {
-      return {
-        lhs: c.lhs,
-        comparison: OPERATOR_TO_API[c.operator],
-        value: { type: 'enum_variant_array', value: c.value },
-        metadata: {},
-      }
-    }
-
-    if (keyType === 'udf' || keyType === 'global_ref') {
-      return {
-        lhs: c.lhs,
-        comparison: OPERATOR_TO_API[c.operator] || c.operator,
-        value: {
-          type: 'metadata_variant',
-          value: { key: c.metadataKey || c.lhs, value: c.value },
-        },
-        metadata: {},
-      }
-    }
-
-    const apiValueType =
-      keyType === 'integer' ? 'number' :
-      keyType === 'str_value' ? 'str_value' :
-      'enum_variant'
-    return {
-      lhs: c.lhs,
-      comparison: OPERATOR_TO_API[c.operator] || c.operator,
-      value: {
-        type: apiValueType,
-        value: keyType === 'integer' ? Number(c.value) : c.value,
-      },
-      metadata: {},
-    }
-  }
-
-  function buildStatement(group: StatementGroup): Record<string, unknown> {
-    const statement: Record<string, unknown> = {
-      condition: group.conditions.map(buildCondition),
-      nested: group.nested.length > 0 ? group.nested.map(buildStatement) : null,
-    }
-    return statement
-  }
-
-  return {
-    globals: {},
-    default_selection: buildPriorityOutput(defaultOutput.priorityGateways),
-    rules: rules.map((r) => ({
-      name: r.name,
-      routing_type: r.outputType,
-      output: buildOutput(r),
-      statements: r.statements.map(buildStatement),
-    })),
-  }
-}
-
-// ---- Reverse-parse API → RuleBlocks ----
-const API_OPERATOR_TO_UI: Record<string, string> = {
-  equal: '==', not_equal: '!=',
-  greater_than: '>', less_than: '<',
-  greater_than_equal: '>=', less_than_equal: '<=',
-}
-
-function parseAlgorithmToRuleBlocks(algo: RoutingAlgorithm): { ruleBlocks: RuleBlock[]; defaultOutput: DefaultOutput } {
-  const algorithm = algo.algorithm_data || algo.algorithm
-  const data = algorithm?.data as EuclidAlgorithmData | undefined
-  if (!data) return { ruleBlocks: [], defaultOutput: { priorityGateways: [] } }
-
-  function parseGateways(arr: { gateway_name: string; gateway_id?: string | null }[]): GatewayEntry[] {
-    return arr.map((g) => ({ id: crypto.randomUUID(), gatewayName: g.gateway_name, gatewayId: g.gateway_id ?? '' }))
-  }
-
-  function parseCondition(cond: { lhs: string; comparison: string; value: { type: string; value: unknown } }): ConditionRow {
-    const isArray = cond.value?.type === 'enum_variant_array'
-    const isMetadataVariant = cond.value?.type === 'metadata_variant'
-    let operator = API_OPERATOR_TO_UI[cond.comparison] ?? cond.comparison
-    if (isArray && cond.comparison === 'equal') operator = 'in'
-    if (isArray && cond.comparison === 'not_equal') operator = 'not_in'
-
-    if (isMetadataVariant) {
-      const metaVal = cond.value?.value as { key?: string; value?: unknown } | undefined
-      return {
-        id: crypto.randomUUID(),
-        lhs: String(cond.lhs),
-        operator,
-        value: String(metaVal?.value ?? ''),
-        metadataKey: String(metaVal?.key ?? cond.lhs),
-      }
-    }
-
-    const value = isArray
-      ? (Array.isArray(cond.value?.value) ? (cond.value.value as string[]) : [String(cond.value?.value)])
-      : String(cond.value?.value ?? '')
-    return { id: crypto.randomUUID(), lhs: String(cond.lhs), operator, value, metadataKey: '' }
-  }
-
-  function parseStatement(stmt: { condition: Parameters<typeof parseCondition>[0][]; nested?: typeof stmt[] }): StatementGroup {
-    return {
-      id: crypto.randomUUID(),
-      conditions: (stmt.condition ?? []).map(parseCondition),
-      nested: (stmt.nested ?? []).map(parseStatement),
-    }
-  }
-
-  const ruleBlocks: RuleBlock[] = (data.rules ?? []).map((rule) => {
-    const output = rule.output as Record<string, unknown> | undefined
-    const outputType: RuleBlock['outputType'] = rule.routing_type ?? 'priority'
-    const rawPriority = output?.priority ?? output?.data
-    const rawVolume = output?.volume_split ?? (output?.type === 'volume_split' ? output?.data : undefined)
-    const rawVolumeSplitPriority = output?.volume_split_priority
-
-    return {
-      id: crypto.randomUUID(),
-      name: rule.name || 'Cloned Rule',
-      statements: (rule.statements ?? []).map(parseStatement),
-      outputType,
-      priorityGateways: outputType === 'priority'
-        ? parseGateways((Array.isArray(rawPriority) ? rawPriority : []) as { gateway_name: string; gateway_id?: string | null }[])
-        : [],
-      volumeSplitEntries: outputType === 'volume_split'
-        ? (Array.isArray(rawVolume) ? rawVolume : []).map((e: { split: number; output: { gateway_name: string; gateway_id?: string | null } }) => ({
-            id: crypto.randomUUID(), split: e.split, gatewayName: e.output.gateway_name, gatewayId: e.output.gateway_id ?? '',
-          }))
-        : [],
-      volumeSplitPriorityEntries: outputType === 'volume_split_priority'
-        ? (Array.isArray(rawVolumeSplitPriority) ? rawVolumeSplitPriority : []).map((e: { split: number; output: { gateway_name: string; gateway_id?: string | null }[] }) => ({
-            id: crypto.randomUUID(), split: e.split, gateways: parseGateways(e.output),
-          }))
-        : [],
-    }
-  })
-
-  const defRaw = (data.default_selection || data.defaultSelection) as Record<string, unknown> | undefined
-  const defArr = (Array.isArray(defRaw?.priority) ? defRaw!.priority : Array.isArray(defRaw?.data) ? defRaw!.data : []) as { gateway_name: string; gateway_id?: string | null }[]
-
-  return { ruleBlocks, defaultOutput: { priorityGateways: parseGateways(defArr) } }
-}
-
-// ---- Main Page ----
 export function EuclidRulesPage() {
   // Read-only sessions still see everything; the controls that would change it are inert.
   const canEditRouting = useCanEditRouting()
+  const navigate = useNavigate()
   const { merchantId } = useMerchantStore()
-  const { routingKeysConfig, isLoading: routingKeysLoading, error: routingKeysError } = useDynamicRoutingConfig()
-  const routingKeys = routingKeysConfig
-  const hasRoutingKeys = Object.keys(routingKeys).length > 0
-  const routingKeysUnavailable = !routingKeysLoading && (!hasRoutingKeys || Boolean(routingKeysError))
-  const [ruleName, setRuleName] = useState('')
-  const [ruleDesc, setRuleDesc] = useState('')
-  const [ruleBlocks, setRuleBlocks] = useState<RuleBlock[]>([])
-  const [defaultOutput, setDefaultOutput] = useState<DefaultOutput>({ priorityGateways: [] })
-  const [editorMode, setEditorMode] = useState<'visual' | 'code'>('visual')
-  const [codeText, setCodeText] = useState('')
-  const [codeParseError, setCodeParseError] = useState<string | null>(null)
-  const [showJson, setShowJson] = useState(false)
-  const [submitting, setSubmitting] = useState(false)
-  const [submitError, setSubmitError] = useState<string | null>(null)
-  const [createdId, setCreatedId] = useState<string | null>(null)
-  const [activating, setActivating] = useState(false)
-  const [activateError, setActivateError] = useState<string | null>(null)
-  const [activateSuccess, setActivateSuccess] = useState(false)
-  const [deactivatingId, setDeactivatingId] = useState<string | null>(null)
-  const [deactivateError, setDeactivateError] = useState<string | null>(null)
-  const [deactivateSuccess, setDeactivateSuccess] = useState(false)
+
   const [expandedRuleIds, setExpandedRuleIds] = useState<Set<string>>(new Set())
   const [pendingActivateId, setPendingActivateId] = useState<string | null>(null)
   const [pendingDeactivateId, setPendingDeactivateId] = useState<string | null>(null)
-  const builderRef = useRef<HTMLDivElement>(null)
-  const [openMenuId, setOpenMenuId] = useState<string | null>(null)
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
+  const [activating, setActivating] = useState(false)
+  const [deactivatingId, setDeactivatingId] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null)
 
-  function handleClone(source: RoutingAlgorithm) {
-    const { ruleBlocks: clonedBlocks, defaultOutput: clonedDefault } = parseAlgorithmToRuleBlocks(source)
-    setRuleName(`copy-of-${source.name}`)
-    setRuleDesc(source.description && source.description !== 'N/A' ? source.description : '')
-    setRuleBlocks(clonedBlocks)
-    setDefaultOutput(clonedDefault)
-    setEditorMode('visual')
-    setCreatedId(null)
-    setSubmitError(null)
-    builderRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-  }
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [gatewayFilter, setGatewayFilter] = useState('all')
+  const [nameFilter, setNameFilter] = useState('')
 
   const { data: allAlgorithms, mutate: mutateAlgorithms } = useSWR<RoutingAlgorithm[]>(
     merchantId ? `/routing/list/${merchantId}` : null,
@@ -1136,6 +62,7 @@ export function EuclidRulesPage() {
         return new Set([d?.control_algorithm_id, d?.variant_algorithm_id].filter(Boolean) as string[])
       })()
     : new Set<string>()
+
   const ruleAlgorithms = (allAlgorithms || [])
     .filter((algo) => {
       const algorithm = algo.algorithm_data || algo.algorithm
@@ -1143,62 +70,27 @@ export function EuclidRulesPage() {
     })
     .sort((a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime())
 
-  const gatewaySuggestions = Array.from(new Set([
-    ...ruleBlocks.flatMap((b) => [
-      ...b.priorityGateways.map((g) => g.gatewayName),
-      ...b.volumeSplitEntries.map((e) => e.gatewayName),
-      ...b.volumeSplitPriorityEntries.flatMap((e) => e.gateways.map((g) => g.gatewayName)),
-    ]),
-    ...defaultOutput.priorityGateways.map((g) => g.gatewayName),
-  ].filter(Boolean)))
+  const gatewayOptions = Array.from(new Set(ruleAlgorithms.flatMap(destinationGateways))).sort()
 
-  const algorithmData = buildAlgorithmData(ruleBlocks, defaultOutput, routingKeys)
-
-  function resetConfigurator() {
-    setRuleName('')
-    setRuleDesc('')
-    setRuleBlocks([])
-    setDefaultOutput({ priorityGateways: [] })
-    setEditorMode('visual')
-    setCodeText('')
-    setCodeParseError(null)
-    setShowJson(false)
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!merchantId) { setSubmitError('Set a Merchant ID first.'); return }
-    if (routingKeysUnavailable) {
-      setSubmitError('Routing key config is unavailable. Ensure backend /config/routing-keys is reachable and valid.')
-      return
+  const visibleRules = ruleAlgorithms.filter((algo) => {
+    if (statusFilter === 'active' && !activeIds.has(algo.id)) return false
+    if (statusFilter === 'inactive' && activeIds.has(algo.id)) return false
+    if (gatewayFilter !== 'all' && !destinationGateways(algo).includes(gatewayFilter)) return false
+    if (nameFilter.trim()) {
+      const needle = nameFilter.trim().toLowerCase()
+      if (!algo.name.toLowerCase().includes(needle) && !algo.id.toLowerCase().includes(needle)) {
+        return false
+      }
     }
-    if (!ruleName.trim()) { setSubmitError('Rule name is required.'); return }
-    if (ruleBlocks.some(b =>
-      (b.outputType === 'priority' && b.priorityGateways.length === 0) ||
-      (b.outputType === 'volume_split' && b.volumeSplitEntries.length === 0) ||
-      (b.outputType === 'volume_split_priority' && b.volumeSplitPriorityEntries.length === 0)
-    )) { setSubmitError('Enter a gateway name here, then click Add to include it in the rule output.'); return }
-    if (codeParseError) { setSubmitError(`Fix syntax error: ${codeParseError}`); return }
-    setSubmitting(true)
-    setSubmitError(null)
-    setCreatedId(null)
-    try {
-      const nextRuleName = ruleName.trim()
-      const result = await apiPost<RoutingAlgorithm>('/routing/create', {
-        name: nextRuleName,
-        description: ruleDesc,
-        created_by: merchantId,
-        algorithm_for: 'payment',
-        algorithm: { type: 'advanced', data: algorithmData },
-      })
-      setCreatedId(result.rule_id ?? result.id)
-      resetConfigurator()
-      mutateAlgorithms()
-    } catch (err) {
-      setSubmitError(String(err))
-    } finally {
-      setSubmitting(false)
-    }
+    return true
+  })
+
+  function toggleRuleExpand(id: string) {
+    setExpandedRuleIds(prev => {
+      const newSet = new Set(prev)
+      if (newSet.has(id)) { newSet.delete(id) } else { newSet.add(id) }
+      return newSet
+    })
   }
 
   async function handleActivate(id: string) {
@@ -1212,92 +104,50 @@ export function EuclidRulesPage() {
 
   async function doActivate(id: string) {
     setActivating(true)
-    setActivateError(null)
-    setActivateSuccess(false)
-    setDeactivateError(null)
-    setDeactivateSuccess(false)
+    setActionError(null)
+    setActionSuccess(null)
     try {
       await apiPost('/routing/activate', { created_by: merchantId, routing_algorithm_id: id })
-      setActivateSuccess(true)
+      setActionSuccess('Rule activated successfully.')
       await Promise.all([mutateAlgorithms(), mutateActiveAlgorithms()])
     } catch (err) {
-      setActivateError(String(err))
+      setActionError(String(err))
     } finally {
       setActivating(false)
     }
   }
 
-  async function handleDeactivate(id: string) {
-    if (!merchantId) return
-    setPendingDeactivateId(id)
-  }
-
   async function doDeactivate(id: string) {
     setDeactivatingId(id)
-    setDeactivateError(null)
-    setDeactivateSuccess(false)
-    setActivateError(null)
-    setActivateSuccess(false)
+    setActionError(null)
+    setActionSuccess(null)
     try {
       await apiPost('/routing/deactivate', { created_by: merchantId, routing_algorithm_id: id })
-      setDeactivateSuccess(true)
+      setActionSuccess('Rule deactivated successfully.')
       await Promise.all([mutateAlgorithms(), mutateActiveAlgorithms()])
     } catch (err) {
-      setDeactivateError(String(err))
+      setActionError(String(err))
     } finally {
       setDeactivatingId(null)
     }
   }
 
-  function toggleRuleExpand(id: string) {
-    setExpandedRuleIds(prev => {
-      const newSet = new Set(prev)
-      if (newSet.has(id)) { newSet.delete(id) } else { newSet.add(id) }
-      return newSet
-    })
-  }
-
-  function addRuleBlock() {
-    setRuleBlocks((prev) => [
-      ...prev,
-      {
-        id: crypto.randomUUID(),
-        name: `Rule ${prev.length + 1}`,
-        statements: [createStatementGroup(routingKeys)],
-        outputType: 'priority',
-        priorityGateways: [],
-        volumeSplitEntries: [],
-        volumeSplitPriorityEntries: [],
-      },
-    ])
-  }
-
-function switchToCode() {
-    if (ruleBlocks.length > 0) {
-      setCodeText(serializeToDSL(ruleBlocks))
-    } else if (!codeText.trim()) {
-      setCodeText(CODE_EDITOR_PLACEHOLDER)
-    }
-    setCodeParseError(null)
-    setEditorMode('code')
-  }
-
-  function switchToVisual() {
-    setEditorMode('visual')
-  }
-
-  function handleCodeChange(text: string) {
-    setCodeText(text)
-    if (!text.trim()) { setCodeParseError(null); setRuleBlocks([]); return }
-    const result = parseDSL(text)
-    if (result.error) {
-      setCodeParseError(result.error)
-      setRuleBlocks([])
-    } else if (result.rules !== null) {
-      setCodeParseError(null)
-      setRuleBlocks(result.rules)
+  async function doDelete(id: string) {
+    if (!merchantId) return
+    setActionError(null)
+    setActionSuccess(null)
+    try {
+      await apiPost('/routing/delete', { created_by: merchantId, routing_algorithm_id: id })
+      setActionSuccess('Rule deleted.')
+      await Promise.all([mutateAlgorithms(), mutateActiveAlgorithms()])
+    } catch (err) {
+      setActionError(String(err))
+    } finally {
+      setPendingDeleteId(null)
     }
   }
+
+  const pendingDeleteRule = ruleAlgorithms.find((a) => a.id === pendingDeleteId)
 
   return (
     <div className="space-y-6">
@@ -1319,333 +169,240 @@ function switchToCode() {
         onConfirm={() => { const id = pendingDeactivateId!; setPendingDeactivateId(null); doDeactivate(id) }}
         onCancel={() => setPendingDeactivateId(null)}
       />
-      <div>
-        <h1 className="text-lg font-semibold text-slate-900 dark:text-white">Rule-Based Routing</h1>
+      <ConfirmDialog
+        open={pendingDeleteId !== null}
+        title="Delete this rule?"
+        description={`"${pendingDeleteRule?.name}" will be permanently deleted. This cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => doDelete(pendingDeleteId!)}
+        onCancel={() => setPendingDeleteId(null)}
+      />
+
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Rule-Based Routing</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-[#8d96a8]">
+            Create conditions to route card and alternative payment transactions dynamically across
+            multiple active gateways.
+          </p>
+        </div>
+        <Button onClick={() => navigate('/routing/rules/new')} disabled={!canEditRouting}>
+          <Plus size={15} /> Create Rule
+        </Button>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Rule list */}
-        <div className="lg:col-span-1 space-y-3">
-          <Card>
-            <CardHeader>
-              <h2 className="text-sm font-semibold text-slate-800">Existing Rules</h2>
-            </CardHeader>
-            <div>
-              {!merchantId ? (
-                <p className="px-4 py-3 text-sm text-slate-400">Set merchant ID to load rules.</p>
-              ) : !allAlgorithms ? (
-                <p className="px-4 py-3 text-sm text-slate-400">Loading...</p>
-              ) : ruleAlgorithms.length === 0 ? (
-                <p className="px-4 py-3 text-sm text-slate-400">No rule-based rules yet.</p>
-              ) : (
-                <div>
-                  {ruleAlgorithms.map((algo) => {
-                    const isActive = activeIds.has(algo.id)
-                    const isInAbTest = abTestArmIds.has(algo.id)
-                    const isExpanded = expandedRuleIds.has(algo.id)
-
-                    return (
-                      <div
-                        key={algo.id}
-                        className={`border-b border-slate-100 dark:border-[#1e2330] last:border-b-0 transition-colors ${
-                          isActive ? 'bg-emerald-50/50 dark:bg-emerald-900/10' : isInAbTest ? 'bg-purple-50/40 dark:bg-purple-900/10' : ''
-                        }`}
-                      >
-                        <div className="px-6 pt-3 pb-2">
-                          {/* Row 1: name + id (left) | action buttons (right) */}
-                          <div className="flex items-center justify-between gap-2">
-                            <button
-                              type="button"
-                              onClick={() => toggleRuleExpand(algo.id)}
-                              className="min-w-0 flex-1 text-left group"
-                            >
-                              <div className="flex items-center gap-1.5">
-                                <p className={`truncate font-medium group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors ${
-                                  isActive ? 'text-emerald-900 dark:text-emerald-100' : isInAbTest ? 'text-purple-900 dark:text-purple-100' : 'text-slate-900 dark:text-white'
-                                }`}>
-                                  {algo.name}
-                                </p>
-                                {isActive && (
-                                  <span className="shrink-0 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400">
-                                    ● Active
-                                  </span>
-                                )}
-                                {!isActive && isInAbTest && (
-                                  <span className="shrink-0 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
-                                    ⚗ In A/B test
-                                  </span>
-                                )}
-                                {isExpanded
-                                  ? <ChevronUp size={12} className="text-slate-400 shrink-0 ml-auto" />
-                                  : <ChevronDown size={12} className="text-slate-400 shrink-0 ml-auto" />
-                                }
-                              </div>
-                              <div className="mt-0.5 flex items-center gap-1">
-                                <span className="text-[10px] font-mono text-slate-500 dark:text-[#607087]">
-                                  {algo.id}
-                                </span>
-                                <CopyButton text={algo.id} size={10} label="Copy routing ID" />
-                              </div>
-                            </button>
-
-                            <div className="shrink-0 flex items-center gap-1.5">
-                              {!isActive ? (
-                                <button
-                                  type="button"
-                                  onClick={() => handleActivate(algo.id)}
-                                  disabled={activating || !canEditRouting}
-                                  className="group/badge relative inline-flex items-center justify-center min-w-[68px] px-2.5 py-0.5 rounded-full text-xs font-medium border transition-colors duration-150
-                                    bg-slate-100 text-slate-500 border-slate-200 hover:bg-brand-50 hover:text-brand-600 hover:border-brand-200
-                                    dark:bg-[#1a1f2a] dark:text-[#8090a8] dark:border-[#2a3040] dark:hover:bg-brand-900/20 dark:hover:text-brand-400 dark:hover:border-brand-800
-                                    disabled:opacity-50 disabled:cursor-not-allowed"
-                                >
-                                  <span className="transition-opacity duration-150 group-hover/badge:opacity-0">Inactive</span>
-                                  <span className="absolute inset-0 flex items-center justify-center gap-1 opacity-0 transition-opacity duration-150 group-hover/badge:opacity-100">
-                                    <Plus size={10} /> Activate
-                                  </span>
-                                </button>
-                              ) : (
-                                <Button size="sm" variant="danger" onClick={() => handleDeactivate(algo.id)} disabled={deactivatingId === algo.id}>
-                                  <PowerOff size={13} />
-                                  {deactivatingId === algo.id ? 'Deactivating…' : 'Deactivate'}
-                                </Button>
-                              )}
-                              <div className="relative">
-                                <button
-                                  type="button"
-                                  onClick={(e) => { e.stopPropagation(); setOpenMenuId(openMenuId === algo.id ? null : algo.id) }}
-                                  className="p-1 rounded-md text-slate-400 hover:text-slate-600 hover:bg-slate-100 dark:hover:text-slate-300 dark:hover:bg-[#1c1c24] transition-colors"
-                                >
-                                  <MoreVertical size={14} />
-                                </button>
-                                {openMenuId === algo.id && (
-                                  <>
-                                    <div className="fixed inset-0 z-10" onClick={() => setOpenMenuId(null)} />
-                                    <div className="absolute right-0 top-full mt-1 z-20 min-w-[150px] rounded-lg border border-slate-200 bg-white shadow-lg dark:border-[#2a303a] dark:bg-[#11151d] py-1 overflow-hidden">
-                                      <button
-                                        type="button"
-                                        onClick={() => { handleClone(algo); setOpenMenuId(null) }}
-                                        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-slate-700 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-[#1c2030] transition-colors"
-                                      >
-                                        <CopyPlus size={13} className="text-brand-500" />
-                                        Clone to builder
-                                      </button>
-                                    </div>
-                                  </>
-                                )}
-                              </div>
-                            </div>
-                          </div>
-
-                          {/* Row 2: description (left) | date (right) — same row */}
-                          {(algo.description && algo.description !== 'N/A' || algo.created_at) && (
-                            <div className="flex items-center justify-between gap-2 mt-0.5">
-                              {algo.description && algo.description !== 'N/A'
-                                ? <p className="text-[11px] text-slate-500 dark:text-[#6d7a8d] truncate min-w-0">{algo.description}</p>
-                                : <span />
-                              }
-                              {algo.created_at && (
-                                <span className="shrink-0 text-[10px] text-slate-400 dark:text-[#4e5870] pr-[12px]">
-                                  {new Date(algo.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
-                                </span>
-                              )}
-                            </div>
-                          )}
-                        </div>
-
-                        {isExpanded && (
-                          <div className="border-t border-slate-100 dark:border-[#1e2330] bg-slate-50/60 dark:bg-[#0c0f17] px-6 py-3">
-                            {algo.description && algo.description !== 'N/A' && (
-                              <p className="mb-3 text-xs text-slate-500 dark:text-[#6d7a8d]">{algo.description}</p>
-                            )}
-                            <RuleBreakdown algo={algo} />
-                          </div>
-                        )}
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
-            </div>
-          </Card>
-          {activeVolumeAlgorithm && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
-              <strong>Volume Split is active</strong> — activating a rule-based rule will automatically deactivate it.
-            </div>
-          )}
-          {activeAbTestAlgorithm && (
-            <div className="rounded-lg border border-purple-200 bg-purple-50 px-3 py-2 text-xs text-purple-700 dark:border-purple-500/30 dark:bg-purple-500/10 dark:text-purple-300">
-              <strong>A/B experiment "{activeAbTestAlgorithm.name}" is active</strong> — rules marked "In A/B test" are used as experiment arms. Activating a rule directly will stop the experiment.
-            </div>
-          )}
-          {activateError && <ErrorMessage error={activateError} />}
-          {activateSuccess && (
-            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-3 py-2 text-sm text-emerald-400">
-              Rule activated successfully.
-            </div>
-          )}
-          {deactivateError && <ErrorMessage error={deactivateError} />}
-          {deactivateSuccess && (
-            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-3 py-2 text-sm text-emerald-400">
-              Rule deactivated successfully.
-            </div>
-          )}
+      {actionError && <ErrorMessage error={actionError} />}
+      {actionSuccess && (
+        <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-3 py-2 text-sm text-emerald-600 dark:text-emerald-400">
+          {actionSuccess}
         </div>
+      )}
 
-        {/* Rule builder */}
-        <div ref={builderRef} className="lg:col-span-2 space-y-4">
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <Card>
-              <CardHeader>
-                <h2 className="text-sm font-semibold text-slate-800">Rule Builder</h2>
-              </CardHeader>
-              <CardBody className="space-y-4">
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="block text-xs text-slate-500 mb-1">Rule Name *</label>
-                    <input
-                      value={ruleName}
-                      onChange={(e) => setRuleName(e.target.value)}
-                      placeholder="my-rule"
-                      className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm w-full focus:outline-none focus:ring-1 focus:ring-brand-500"
+      <Card className="!rounded-[18px]">
+        {!merchantId ? (
+          <p className="px-4 py-6 text-sm text-slate-400">Set merchant ID to load rules.</p>
+        ) : !allAlgorithms ? (
+          <p className="px-4 py-6 text-sm text-slate-400">Loading...</p>
+        ) : ruleAlgorithms.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-slate-400">No rule-based rules yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[880px] text-left">
+              <thead>
+                <tr className="border-b border-slate-100 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:border-[#1e2330] dark:text-[#6d7a8d]">
+                  <th className="px-5 py-3.5">
+                    <HeaderSearch
+                      label="Rule Name & ID"
+                      value={nameFilter}
+                      onChange={setNameFilter}
+                      ariaLabel="Filter rules by name"
                     />
-                  </div>
-                  <div>
-                    <label className="block text-xs text-slate-500 mb-1">Description</label>
-                    <input
-                      value={ruleDesc}
-                      onChange={(e) => setRuleDesc(e.target.value)}
-                      placeholder="Optional description"
-                      className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm w-full focus:outline-none focus:ring-1 focus:ring-brand-500"
+                  </th>
+                  <th className="px-5 py-3.5">
+                    <HeaderFilter
+                      label="Status"
+                      value={statusFilter}
+                      options={[
+                        { value: 'all', label: 'All statuses' },
+                        { value: 'active', label: 'Active' },
+                        { value: 'inactive', label: 'Inactive' },
+                      ]}
+                      onChange={(v) => setStatusFilter(v as StatusFilter)}
+                      ariaLabel="Filter by status"
                     />
-                  </div>
-                </div>
-
-                {/* Rule blocks */}
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">Rules</p>
-                    <div className="flex rounded-lg border border-slate-200 dark:border-[#222226] overflow-hidden text-[11px]">
+                  </th>
+                  <th className="px-5 py-3.5">Conditions Overview</th>
+                  <th className="px-5 py-3.5">
+                    <HeaderFilter
+                      label="Destination Gateway"
+                      value={gatewayFilter}
+                      options={[
+                        { value: 'all', label: 'All gateways' },
+                        ...gatewayOptions.map((g) => ({ value: g, label: g })),
+                      ]}
+                      onChange={setGatewayFilter}
+                      ariaLabel="Filter by gateway"
+                    />
+                  </th>
+                  <th className="px-5 py-3.5">Last Modified</th>
+                  <th className="px-5 py-3.5 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleRules.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center">
+                      <p className="text-sm text-slate-400">No rules match these filters.</p>
                       <button
                         type="button"
-                        onClick={switchToVisual}
-                        className={`px-3 py-1 transition-colors ${editorMode === 'visual' ? 'bg-brand-500 text-white font-semibold' : 'text-slate-500 hover:bg-slate-100 dark:hover:bg-[#1c1c24]'}`}
+                        onClick={() => { setStatusFilter('all'); setGatewayFilter('all'); setNameFilter('') }}
+                        className="mt-1.5 text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400"
                       >
-                        Visual
+                        Clear filters
                       </button>
-                      <button
-                        type="button"
-                        onClick={switchToCode}
-                        className={`px-3 py-1 transition-colors ${editorMode === 'code' ? 'bg-brand-500 text-white font-semibold' : 'text-slate-500 hover:bg-slate-100 dark:hover:bg-[#1c1c24]'}`}
-                      >
-                        Code
-                      </button>
-                    </div>
-                  </div>
-                  {routingKeysLoading && (
-                    <p className="text-sm text-slate-500">Loading routing keys from backend...</p>
-                  )}
-                  {routingKeysUnavailable && (
-                    <ErrorMessage error="Routing keys are unavailable from backend (/config/routing-keys). Rule Builder is disabled until this is fixed." />
-                  )}
-                  {editorMode === 'visual' ? (
-                    <>
-                      {ruleBlocks.map((block) => (
-                        <RuleBlockEditor
-                          key={block.id}
-                          block={block}
-                          routingKeys={routingKeys}
-                          gatewaySuggestions={gatewaySuggestions}
-                          onChange={(updated) =>
-                            setRuleBlocks((prev) => prev.map((b) => (b.id === block.id ? updated : b)))
-                          }
-                          onRemove={() =>
-                            setRuleBlocks((prev) => prev.filter((b) => b.id !== block.id))
-                          }
-                        />
-                      ))}
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        size="sm"
-                        onClick={addRuleBlock}
-                        disabled={routingKeysUnavailable}
-                      >
-                        <Plus size={14} /> Add Rule
-                      </Button>
-                    </>
-                  ) : (
-                    <RuleCodeEditor
-                      value={codeText}
-                      onChange={handleCodeChange}
-                      parseError={codeParseError}
-                      routingKeys={routingKeys}
-                      gatewaySuggestions={gatewaySuggestions}
-                    />
-                  )}
-                </div>
-
-                {/* Default selection */}
-                <div className="border border-slate-200 dark:border-[#1c1c24] rounded-xl px-4 py-3">
-                  <p className="text-xs font-medium text-slate-500 mb-1">Default Fallback</p>
-                  <p className="mb-3 text-xs text-slate-400 dark:text-[#8d96a8]">
-                    Used when no rule matches. Per-request overrides are possible via <code className="font-mono">fallback_output</code>.
-                  </p>
-                  <PriorityEditor
-                    gateways={defaultOutput.priorityGateways}
-                    suggestions={gatewaySuggestions}
-                    onChange={(gws) => setDefaultOutput({ ...defaultOutput, priorityGateways: gws })}
-                  />
-                </div>
-
-                <ErrorMessage error={submitError} />
-                {createdId && (
-                  <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-200">
-                    <span className="min-w-0">
-                      Rule created: <span className="font-mono">{createdId}</span>
-                    </span>
-                    <Button type="button" size="sm" onClick={() => handleActivate(createdId)} disabled={activating || !canEditRouting}>
-                      Activate Now
-                    </Button>
-                  </div>
+                    </td>
+                  </tr>
                 )}
-                <div className="flex gap-3">
-                  <Button type="submit" disabled={submitting || routingKeysUnavailable}>
-                    {submitting ? 'Creating...' : 'Create Rule'}
-                  </Button>
-                  <Button type="button" variant="secondary" size="sm" onClick={() => setShowJson(!showJson)}>
-                    {showJson ? 'Hide JSON' : 'Preview JSON'}
-                  </Button>
-                </div>
-              </CardBody>
-            </Card>
-          </form>
+                {visibleRules.map((algo) => {
+                  const isActive = activeIds.has(algo.id)
+                  const isInAbTest = abTestArmIds.has(algo.id)
+                  const isExpanded = expandedRuleIds.has(algo.id)
+                  const conditions = summarizeConditions(algo)
+                  const destination = summarizeDestination(algo)
+                  // Both /routing/update and /routing/delete reject an active algorithm, so the
+                  // controls mirror that rather than letting the request fail.
+                  const lockedReason = isActive
+                    ? 'Deactivate this rule first'
+                    : !canEditRouting
+                    ? 'You do not have permission to change routing'
+                    : undefined
 
-          {/* JSON preview */}
-          {showJson && (
-            <Card>
-              <CardHeader>
-                <h2 className="text-sm font-semibold text-slate-800">JSON Preview</h2>
-              </CardHeader>
-              <CardBody>
-                <pre className="max-h-64 overflow-auto rounded-lg border border-slate-200/80 bg-slate-50/90 p-4 font-mono text-xs leading-6 text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),0_16px_30px_-28px_rgba(15,23,42,0.18)] dark:border-[#2a303a] dark:bg-[#0b1017] dark:text-[#d8e1ef] dark:shadow-none">
-                  {JSON.stringify(
-                    {
-                      name: ruleName,
-                      description: ruleDesc,
-                      created_by: merchantId,
-                      algorithm_for: 'payment',
-                      algorithm: { type: 'advanced', data: algorithmData },
-                    },
-                    null,
-                    2
-                  )}
-                </pre>
-              </CardBody>
-            </Card>
-          )}
+                  return [
+                    <tr
+                      key={algo.id}
+                      data-testid="rule-row"
+                      data-rule-name={algo.name}
+                      onClick={() => toggleRuleExpand(algo.id)}
+                      className={`cursor-pointer border-b border-slate-100 align-middle transition-colors hover:bg-slate-50 dark:border-[#1e2330] dark:hover:bg-[#11151d] ${
+                        isActive ? 'bg-emerald-50/50 dark:bg-emerald-900/10' : isInAbTest ? 'bg-purple-50/40 dark:bg-purple-900/10' : ''
+                      }`}
+                    >
+                      <td className="px-5 py-4">
+                        <div className="flex items-start gap-2">
+                          {isExpanded
+                            ? <ChevronDown size={14} className="mt-1 shrink-0 text-slate-400" />
+                            : <ChevronRight size={14} className="mt-1 shrink-0 text-slate-400" />
+                          }
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
+                              {algo.name}
+                            </p>
+                            <p className="mt-0.5 truncate font-mono text-xs text-slate-400 dark:text-[#6d7a8d]">
+                              {algo.id}
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-5 py-4">
+                        <span className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-1 text-[11px] font-semibold ${
+                          isActive
+                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                            : 'bg-slate-100 text-slate-500 dark:bg-[#1a1f2a] dark:text-[#8090a8]'
+                        }`}>
+                          {isActive ? 'Active' : 'Inactive'}
+                        </span>
+                        {isInAbTest && (
+                          <span className="mt-1.5 block text-[11px] font-medium text-purple-600 dark:text-purple-400">
+                            In A/B test
+                          </span>
+                        )}
+                      </td>
+                      <td className="max-w-[340px] px-5 py-4">
+                        <p className="truncate font-mono text-xs text-slate-600 dark:text-[#8d96a8]" title={conditions}>
+                          {conditions}
+                        </p>
+                      </td>
+                      <td className="max-w-[260px] px-5 py-4">
+                        <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200" title={destination}>
+                          {destination}
+                        </p>
+                      </td>
+                      <td className="whitespace-nowrap px-5 py-4 text-[13px] text-slate-500 dark:text-[#6d7a8d]">
+                        {algo.created_at
+                          ? new Date(algo.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+                          : '—'}
+                      </td>
+                      <td className="px-5 py-4" onClick={(e) => e.stopPropagation()}>
+                        <RowMenu
+                          items={[
+                            isActive
+                              ? {
+                                  label: deactivatingId === algo.id ? 'Deactivating…' : 'Deactivate',
+                                  icon: PowerOff,
+                                  onSelect: () => setPendingDeactivateId(algo.id),
+                                  disabled: deactivatingId === algo.id || !canEditRouting,
+                                }
+                              : {
+                                  label: 'Activate',
+                                  icon: Zap,
+                                  tone: 'positive',
+                                  onSelect: () => handleActivate(algo.id),
+                                  disabled: activating || !canEditRouting,
+                                },
+                            {
+                              label: 'Edit',
+                              icon: Pencil,
+                              onSelect: () => navigate(`/routing/rules/${algo.id}/edit`),
+                              disabled: Boolean(lockedReason),
+                              hint: lockedReason,
+                            },
+                            {
+                              label: 'Duplicate',
+                              icon: Copy,
+                              onSelect: () => navigate(`/routing/rules/new?cloneFrom=${algo.id}`),
+                              disabled: !canEditRouting,
+                            },
+                            {
+                              label: 'Delete',
+                              icon: Trash2,
+                              tone: 'danger',
+                              onSelect: () => setPendingDeleteId(algo.id),
+                              disabled: Boolean(lockedReason),
+                              hint: lockedReason,
+                            },
+                          ]}
+                        />
+                      </td>
+                    </tr>,
+                    isExpanded ? (
+                      <tr key={`${algo.id}-detail`} className="border-b border-slate-100 dark:border-[#1e2330]">
+                        <td colSpan={6} className="bg-slate-50/60 px-6 py-5 dark:bg-[#0c0f17]">
+                          {algo.description && algo.description !== 'N/A' && (
+                            <p className="mb-3 text-sm text-slate-500 dark:text-[#6d7a8d]">{algo.description}</p>
+                          )}
+                          <RuleBreakdown algo={algo} />
+                        </td>
+                      </tr>
+                    ) : null,
+                  ]
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {activeVolumeAlgorithm && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+          <strong>Volume Split is active</strong> — activating a rule-based rule will automatically deactivate it.
         </div>
-      </div>
+      )}
+      {activeAbTestAlgorithm && (
+        <div className="rounded-lg border border-purple-200 bg-purple-50 px-3 py-2 text-xs text-purple-700 dark:border-purple-500/30 dark:bg-purple-500/10 dark:text-purple-300">
+          <strong>A/B experiment "{activeAbTestAlgorithm.name}" is active</strong> — rules marked "In A/B test" are used as experiment arms. Activating a rule directly will stop the experiment.
+        </div>
+      )}
     </div>
   )
 }

--- a/website/src/components/pages/VolumeSplitBuilderPage.tsx
+++ b/website/src/components/pages/VolumeSplitBuilderPage.tsx
@@ -1,0 +1,363 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import useSWR from 'swr'
+import { Plus, Trash2, ArrowLeft } from 'lucide-react'
+import { Card, CardBody } from '../ui/Card'
+import { Button } from '../ui/Button'
+import { ErrorMessage } from '../ui/ErrorMessage'
+import { Spinner } from '../ui/Spinner'
+import { useMerchantStore } from '../../store/merchantStore'
+import { useCanEditRouting } from '../../store/authStore'
+import { apiPost } from '../../lib/api'
+import { RoutingAlgorithm } from '../../types/api'
+import { VolumeSplitGatewayFormEntry } from '../../features/routing/volumeSplit/types'
+import { toVolumeSplitCreatePayload, toVolumeSplitAlgorithm } from '../../features/routing/volumeSplit/payload'
+import { toVolumeSplitRuleDetailsState } from '../../features/routing/volumeSplit/state'
+import { validateVolumeSplitRule } from '../../features/routing/volumeSplit/schema'
+import { SplitBreakdown, SPLIT_COLORS } from '../routing/volumeSplit/SplitBreakdown'
+
+function makeId() { return Math.random().toString(36).slice(2) }
+
+function createInitialGateways(): VolumeSplitGatewayFormEntry[] {
+  return [
+    { id: makeId(), gatewayName: '', gatewayId: '', split: 50 },
+    { id: makeId(), gatewayName: '', gatewayId: '', split: 50 },
+  ]
+}
+
+function clampSplit(value: number) {
+  if (Number.isNaN(value)) return 0
+  return Math.min(100, Math.max(0, Math.round(value)))
+}
+
+/** The last row absorbs whatever the fixed rows leave, so a split always totals 100. */
+function withInferredSplit(entries: VolumeSplitGatewayFormEntry[]) {
+  if (entries.length === 0) return entries
+  const fixed = entries.slice(0, -1)
+  const fixedTotal = fixed.reduce((sum, entry) => sum + entry.split, 0)
+  const remainder = clampSplit(100 - fixedTotal)
+  const last = entries[entries.length - 1]
+  return [...fixed, { ...last, split: remainder }]
+}
+
+export function VolumeSplitBuilderPage() {
+  const canEditRouting = useCanEditRouting()
+  const navigate = useNavigate()
+  const { id: editId } = useParams<{ id: string }>()
+  const [searchParams] = useSearchParams()
+  const cloneFromId = searchParams.get('cloneFrom')
+  const isEdit = Boolean(editId)
+
+  const { merchantId } = useMerchantStore()
+
+  const [ruleName, setRuleName] = useState('')
+  const [ruleDesc, setRuleDesc] = useState('')
+  const [gateways, setGateways] = useState<VolumeSplitGatewayFormEntry[]>(() => createInitialGateways())
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const { data: allRules, mutate: mutateRules } = useSWR<RoutingAlgorithm[]>(
+    merchantId ? `/routing/list/${merchantId}` : null,
+    () => apiPost<RoutingAlgorithm[]>(`/routing/list/${merchantId}`)
+  )
+  const { data: activeRules } = useSWR<RoutingAlgorithm[]>(
+    merchantId ? `/routing/list/active/${merchantId}` : null,
+    () => apiPost<RoutingAlgorithm[]>(`/routing/list/active/${merchantId}`)
+  )
+
+  const sourceId = editId || cloneFromId
+  const sourceRule = sourceId ? (allRules || []).find((r) => r.id === sourceId) : undefined
+  // /routing/update rejects an active algorithm (ensure_routing_algorithm_inactive), so say so up
+  // front rather than letting Save fail.
+  const isEditingActiveRule = isEdit && (activeRules || []).some((r) => r.id === editId)
+
+  // Seed from the source rule exactly once — otherwise SWR revalidation would overwrite edits.
+  const seededFrom = useRef<string | null>(null)
+  useEffect(() => {
+    if (!sourceRule || seededFrom.current === sourceRule.id) return
+    const details = toVolumeSplitRuleDetailsState(sourceRule)
+    if (!details) return
+    seededFrom.current = sourceRule.id
+    setRuleName(isEdit ? details.name : `copy-of-${details.name}`)
+    setRuleDesc(details.description && details.description !== 'N/A' ? details.description : '')
+    if (details.gateways.length > 0) setGateways(details.gateways)
+  }, [sourceRule, isEdit])
+
+  const inferredGatewayId = gateways[gateways.length - 1]?.id ?? null
+  const fixedTotal = inferredGatewayId
+    ? gateways.filter((g) => g.id !== inferredGatewayId).reduce((sum, g) => sum + g.split, 0)
+    : 0
+  const overAllocated = Math.max(0, fixedTotal - 100)
+  const total = gateways.reduce((sum, g) => sum + g.split, 0)
+
+  function updateGateway(id: string, field: 'gatewayName' | 'gatewayId' | 'split', val: string | number) {
+    setGateways((gs) =>
+      withInferredSplit(
+        gs.map((g) => {
+          if (g.id !== id) return g
+          if (field === 'split') return { ...g, split: clampSplit(Number(val)) }
+          return { ...g, [field]: val }
+        })
+      )
+    )
+  }
+
+  function addGateway() {
+    setGateways((gs) => withInferredSplit([...gs, { id: makeId(), gatewayName: '', gatewayId: '', split: 0 }]))
+  }
+
+  function removeGateway(id: string) {
+    setGateways((gs) => {
+      const remaining = gs.filter((g) => g.id !== id)
+      return withInferredSplit(
+        remaining.length ? remaining : [{ id: makeId(), gatewayName: '', gatewayId: '', split: 100 }]
+      )
+    })
+  }
+
+  function handleClear() {
+    setRuleName('')
+    setRuleDesc('')
+    setGateways(createInitialGateways())
+    setError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!merchantId) { setError('Set a merchant ID first'); return }
+    const validationError = validateVolumeSplitRule({ ruleName, description: ruleDesc, gateways })
+    if (validationError) { setError(validationError); return }
+
+    setSaving(true)
+    setError(null)
+    try {
+      if (isEdit) {
+        await apiPost('/routing/update', {
+          created_by: merchantId,
+          routing_algorithm_id: editId,
+          name: ruleName.trim(),
+          description: ruleDesc,
+          algorithm: toVolumeSplitAlgorithm(gateways),
+        })
+      } else {
+        await apiPost<RoutingAlgorithm>(
+          '/routing/create',
+          toVolumeSplitCreatePayload({ ruleName, description: ruleDesc, gateways }, merchantId)
+        )
+      }
+      await mutateRules()
+      navigate('/routing/volume')
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to save rule')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="min-w-0">
+        <button
+          type="button"
+          onClick={() => navigate('/routing/volume')}
+          className="mb-2 inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-brand-600 dark:text-[#8d96a8] dark:hover:text-brand-400"
+        >
+          <ArrowLeft size={16} /> Volume Split Routing
+        </button>
+        <h1 className="truncate text-2xl font-semibold text-slate-900 dark:text-white">
+          {isEdit ? 'Edit Volume Split Rule' : 'Create Volume Split Rule'}
+        </h1>
+        <p className="mt-1 text-sm text-slate-500 dark:text-[#8d96a8]">
+          Divide traffic across gateways by percentage. The last row absorbs whatever the others leave.
+        </p>
+      </div>
+
+      {isEdit && !sourceRule && allRules && (
+        <ErrorMessage error="That rule no longer exists for this merchant." />
+      )}
+      {isEditingActiveRule && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+          <strong>This rule is active</strong> — active rules cannot be edited. Deactivate it from the
+          rules list first, then come back.
+        </div>
+      )}
+
+      <div className="flex flex-col gap-6 xl:flex-row xl:items-start">
+        <form onSubmit={handleSubmit} className="min-w-0 flex-1 space-y-4">
+          <Card>
+            <CardBody className="space-y-5">
+              <div className="grid grid-cols-1 gap-x-12 gap-y-4 md:grid-cols-2">
+                <div className="flex items-center gap-2">
+                  <label
+                    htmlFor="volume-rule-name"
+                    className="shrink-0 whitespace-nowrap text-[13px] font-semibold text-slate-700 dark:text-slate-300"
+                  >
+                    Rule Name *
+                  </label>
+                  <input
+                    id="volume-rule-name"
+                    value={ruleName}
+                    onChange={(e) => setRuleName(e.target.value)}
+                    placeholder="e.g. ab-test-split"
+                    className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-transparent px-3.5 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <label
+                    htmlFor="volume-rule-description"
+                    className="shrink-0 whitespace-nowrap text-[13px] font-semibold text-slate-700 dark:text-slate-300"
+                  >
+                    Description
+                  </label>
+                  <input
+                    id="volume-rule-description"
+                    value={ruleDesc}
+                    onChange={(e) => setRuleDesc(e.target.value)}
+                    placeholder="Optional description"
+                    className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-transparent px-3.5 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <p className="border-b border-slate-100 pb-2.5 text-xs font-semibold uppercase tracking-widest text-slate-500 dark:border-[#1c1c24] dark:text-[#8d96a8]">
+                  Traffic Distribution
+                </p>
+
+                <div className="hidden grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(260px,320px)_32px] gap-3 px-1 text-xs font-medium text-slate-500 md:grid">
+                  <span>Gateway Name</span>
+                  <span>Gateway ID</span>
+                  <span>Split %</span>
+                  <span />
+                </div>
+
+                {gateways.map((g, index) => {
+                  const isInferred = g.id === inferredGatewayId
+                  const label = g.gatewayName.trim() || `Gateway ${index + 1}`
+                  return (
+                    <div
+                      key={g.id}
+                      className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(260px,320px)_32px] md:items-center"
+                    >
+                      <input
+                        value={g.gatewayName}
+                        onChange={(e) => updateGateway(g.id, 'gatewayName', e.target.value)}
+                        placeholder="e.g. stripe"
+                        className="rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+                      />
+                      <input
+                        value={g.gatewayId}
+                        onChange={(e) => updateGateway(g.id, 'gatewayId', e.target.value)}
+                        placeholder="optional gateway_id"
+                        className="rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+                      />
+                      <div className="flex min-w-0 items-center gap-2 rounded-lg border border-slate-200 bg-transparent px-2.5 py-2 focus-within:ring-1 focus-within:ring-brand-500 dark:border-[#222226]">
+                        <span
+                          className="h-2.5 w-2.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: SPLIT_COLORS[index % SPLIT_COLORS.length] }}
+                        />
+                        <input
+                          type="range"
+                          min={0}
+                          max={100}
+                          value={g.split}
+                          disabled={isInferred}
+                          onChange={(e) => updateGateway(g.id, 'split', Number(e.target.value))}
+                          aria-label={`${label} allocation slider`}
+                          className="h-2 min-w-0 flex-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+                          style={{ accentColor: SPLIT_COLORS[index % SPLIT_COLORS.length] }}
+                        />
+                        <input
+                          type="number"
+                          min={0}
+                          max={100}
+                          value={g.split}
+                          onChange={(e) => updateGateway(g.id, 'split', Number(e.target.value))}
+                          disabled={isInferred}
+                          aria-label={`${label} split percentage`}
+                          className="w-12 border-0 bg-transparent p-0 text-right text-sm tabular-nums focus:outline-none disabled:cursor-not-allowed disabled:opacity-70"
+                        />
+                        <span className="text-xs text-slate-500">%</span>
+                        {isInferred && gateways.length > 1 && (
+                          <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-600 dark:bg-[#1a1a22] dark:text-slate-300">
+                            Auto
+                          </span>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => removeGateway(g.id)}
+                        disabled={gateways.length === 1}
+                        aria-label={`Remove ${label}`}
+                        className="text-slate-400 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    </div>
+                  )
+                })}
+
+                <div className="flex items-center gap-4">
+                  <button
+                    type="button"
+                    onClick={addGateway}
+                    className="flex items-center gap-1 text-[13px] font-medium text-brand-600 transition-colors hover:text-brand-700 dark:text-brand-400"
+                  >
+                    <Plus size={14} /> Add Gateway
+                  </button>
+                  <span className={`text-xs font-medium ${total === 100 ? 'text-emerald-500' : 'text-red-500'}`}>
+                    Total: {total}%
+                    {overAllocated
+                      ? ` (reduce fixed splits by ${overAllocated}%)`
+                      : total !== 100 ? ' (must be 100)' : ''}
+                  </span>
+                </div>
+              </div>
+
+              <ErrorMessage error={error} />
+            </CardBody>
+          </Card>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <Button type="submit" disabled={saving || !merchantId || !canEditRouting || isEditingActiveRule}>
+              {saving ? <><Spinner size={14} /> Saving…</> : isEdit ? 'Save Changes' : 'Create Rule'}
+            </Button>
+            <Button type="button" variant="secondary" size="sm" onClick={handleClear}>
+              Clear
+            </Button>
+            <button
+              type="button"
+              onClick={() => navigate('/routing/volume')}
+              className="text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-[#8d96a8] dark:hover:text-white"
+            >
+              Cancel
+            </button>
+            <p className="text-sm text-slate-400 dark:text-[#6d7a8d]">
+              {isEdit
+                ? 'Saved changes apply the next time this rule is activated.'
+                : 'A new rule is created inactive — activate it from the rules list.'}
+            </p>
+          </div>
+        </form>
+
+        <aside className="w-full shrink-0 xl:w-[24rem]">
+          <div className="xl:sticky xl:top-6">
+            <Card>
+              <CardBody className="space-y-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-[#8d96a8]">
+                    Rule details
+                  </p>
+                  <p className="mt-1 truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
+                    {ruleName.trim() || 'Untitled rule'}
+                  </p>
+                </div>
+                <SplitBreakdown gateways={gateways} />
+              </CardBody>
+            </Card>
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/website/src/components/pages/VolumeSplitPage.tsx
+++ b/website/src/components/pages/VolumeSplitPage.tsx
@@ -1,206 +1,92 @@
 import { useState } from 'react'
-import useSWR, { useSWRConfig } from 'swr'
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts'
-import { Card, CardBody, CardHeader } from '../ui/Card'
+import { useNavigate } from 'react-router-dom'
+import useSWR from 'swr'
+import { Plus, ChevronDown, ChevronRight, Zap, PowerOff, Pencil, Copy, Trash2 } from 'lucide-react'
+import { Card } from '../ui/Card'
 import { Button } from '../ui/Button'
 import { ErrorMessage } from '../ui/ErrorMessage'
-import { Spinner } from '../ui/Spinner'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { HeaderFilter, HeaderSearch, RowMenu } from '../ui/TableControls'
 import { useMerchantStore } from '../../store/merchantStore'
 import { useCanEditRouting } from '../../store/authStore'
 import { apiPost } from '../../lib/api'
-import { CHART_TOOLTIP_ITEM_STYLE, CHART_TOOLTIP_LABEL_STYLE, CHART_TOOLTIP_STYLE } from '../../lib/chartStyles'
 import { RoutingAlgorithm } from '../../types/api'
-import { Plus, Trash2, PowerOff, ChevronDown, ChevronUp } from 'lucide-react'
-import { ConfirmDialog } from '../ui/ConfirmDialog'
-import { validateVolumeSplitRule } from '../../features/routing/volumeSplit/schema'
-import { toVolumeSplitCreatePayload } from '../../features/routing/volumeSplit/payload'
 import { toVolumeSplitRuleDetailsState } from '../../features/routing/volumeSplit/state'
-import { VolumeSplitGatewayFormEntry } from '../../features/routing/volumeSplit/types'
+import { SplitBreakdown } from '../routing/volumeSplit/SplitBreakdown'
 
-const COLORS = ['#0069ED', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899']
+type StatusFilter = 'all' | 'active' | 'inactive'
 
-function makeId() { return Math.random().toString(36).slice(2) }
-
-function createInitialGateways(): VolumeSplitGatewayFormEntry[] {
-  return [
-    { id: makeId(), gatewayName: '', gatewayId: '', split: 50 },
-    { id: makeId(), gatewayName: '', gatewayId: '', split: 50 },
-  ]
+/** "stripe 50% / adyen 50%" — the row's one-line view of where traffic goes. */
+function describeSplit(algo: RoutingAlgorithm): string {
+  const gateways = toVolumeSplitRuleDetailsState(algo)?.gateways ?? []
+  const named = gateways.filter((g) => g.gatewayName.trim())
+  if (named.length === 0) return 'No gateways configured'
+  return named.map((g) => `${g.gatewayName} ${g.split}%`).join(' / ')
 }
 
-function clampSplit(value: number) {
-  if (!Number.isFinite(value)) return 0
-  return Math.min(100, Math.max(0, Math.round(value)))
-}
-
-function withInferredSplit(entries: VolumeSplitGatewayFormEntry[]) {
-  if (!entries.length) return entries
-
-  const normalized = entries.map(entry => ({
-    ...entry,
-    split: clampSplit(entry.split),
-  }))
-
-  if (normalized.length === 1) {
-    return [{ ...normalized[0], split: 100 }]
-  }
-
-  const inferredIndex = normalized.length - 1
-  const fixedTotal = normalized
-    .slice(0, inferredIndex)
-    .reduce((sum, gateway) => sum + gateway.split, 0)
-
-  return normalized.map((entry, index) =>
-    index === inferredIndex
-      ? { ...entry, split: Math.max(0, 100 - fixedTotal) }
-      : entry,
-  )
+function splitGateways(algo: RoutingAlgorithm): string[] {
+  return (toVolumeSplitRuleDetailsState(algo)?.gateways ?? [])
+    .map((g) => g.gatewayName.trim())
+    .filter(Boolean)
 }
 
 export function VolumeSplitPage() {
   // Read-only sessions still see everything; the controls that would change it are inert.
   const canEditRouting = useCanEditRouting()
+  const navigate = useNavigate()
   const { merchantId } = useMerchantStore()
-  const { mutate: mutateCache } = useSWRConfig()
 
-  const { data: active, mutate: mutateActive } = useSWR<RoutingAlgorithm[]>(
-    merchantId ? ['active-routing', merchantId] : null,
-    () => apiPost(`/routing/list/active/${merchantId}`)
+  const [expandedRuleIds, setExpandedRuleIds] = useState<Set<string>>(new Set())
+  const [pendingActivateId, setPendingActivateId] = useState<string | null>(null)
+  const [pendingDeactivateId, setPendingDeactivateId] = useState<string | null>(null)
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
+  const [activating, setActivating] = useState(false)
+  const [deactivatingId, setDeactivatingId] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null)
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [gatewayFilter, setGatewayFilter] = useState('all')
+  const [nameFilter, setNameFilter] = useState('')
+
+  // Same SWR keys as the rule-based pages, so activating here invalidates their view too — the
+  // backend deactivates the other mode's rule, and a separate cache entry would go stale.
+  const { data: allRules, mutate: mutateRules } = useSWR<RoutingAlgorithm[]>(
+    merchantId ? `/routing/list/${merchantId}` : null,
+    () => apiPost<RoutingAlgorithm[]>(`/routing/list/${merchantId}`)
+  )
+  const { data: activeRules, mutate: mutateActive } = useSWR<RoutingAlgorithm[]>(
+    merchantId ? `/routing/list/active/${merchantId}` : null,
+    () => apiPost<RoutingAlgorithm[]>(`/routing/list/active/${merchantId}`)
   )
 
-  const activeVol = active?.find(r => (r.algorithm_data || r.algorithm)?.type === 'volume_split')
-  const activeRuleBased = active?.find(r => {
+  const activeIds = new Set((activeRules || []).map((r) => r.id))
+  const activeRuleBased = (activeRules || []).find((r) => {
     const t = (r.algorithm_data || r.algorithm)?.type
     return t && t !== 'volume_split'
   })
 
-  const [gateways, setGateways] = useState<VolumeSplitGatewayFormEntry[]>(() => createInitialGateways())
-  const [ruleName, setRuleName] = useState('')
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
-  const [createdId, setCreatedId] = useState<string | null>(null)
-  const [expandedRuleIds, setExpandedRuleIds] = useState<Set<string>>(new Set())
-  const [deactivatingRuleId, setDeactivatingRuleId] = useState<string | null>(null)
-  const [pendingActivateId, setPendingActivateId] = useState<string | null>(null)
-  const [pendingDeactivateId, setPendingDeactivateId] = useState<string | null>(null)
+  const volumeRules = (allRules || [])
+    .filter((r) => (r.algorithm_data || r.algorithm)?.type === 'volume_split')
+    .sort((a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime())
 
-  const inferredGatewayId = gateways[gateways.length - 1]?.id ?? null
-  const fixedTotal = inferredGatewayId
-    ? gateways
-        .filter(gateway => gateway.id !== inferredGatewayId)
-        .reduce((sum, gateway) => sum + gateway.split, 0)
-    : 0
-  const overAllocated = Math.max(0, fixedTotal - 100)
-  const total = gateways.reduce((s, g) => s + g.split, 0)
+  const gatewayOptions = Array.from(new Set(volumeRules.flatMap(splitGateways))).sort()
 
-  function updateGateway(id: string, field: 'gatewayName' | 'gatewayId' | 'split', val: string | number) {
-    setGateways(gs =>
-      withInferredSplit(
-        gs.map(g => {
-          if (g.id !== id) return g
-          if (field === 'split') {
-            return { ...g, split: clampSplit(Number(val)) }
-          }
-          return { ...g, [field]: val }
-        }),
-      ),
-    )
-  }
-
-  function addGateway() {
-    setGateways(gs => withInferredSplit([...gs, { id: makeId(), gatewayName: '', gatewayId: '', split: 0 }]))
-  }
-
-  function removeGateway(id: string) {
-    setGateways(gs => {
-      const remaining = gs.filter(g => g.id !== id)
-      return withInferredSplit(
-        remaining.length
-          ? remaining
-          : [{ id: makeId(), gatewayName: '', gatewayId: '', split: 100 }],
-      )
-    })
-  }
-
-  async function handleCreate() {
-    if (!merchantId) return setError('Set a merchant ID first')
-    const validationError = validateVolumeSplitRule({ ruleName, gateways })
-    if (validationError) return setError(validationError)
-
-    setSaving(true); setError(null); setSuccess(null); setCreatedId(null)
-    try {
-      const nextRuleName = ruleName.trim()
-      const payload = toVolumeSplitCreatePayload({ ruleName, gateways }, merchantId)
-      const result = await apiPost<RoutingAlgorithm>('/routing/create', payload)
-      await Promise.all([
-        mutateActive(),
-        mutateCache(['routing-list', merchantId]),
-      ])
-      setCreatedId(result.rule_id ?? result.id)
-      setSuccess(`Rule "${nextRuleName}" created successfully. Configurator reset.`)
-      setRuleName('')
-      setGateways(createInitialGateways())
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to create rule')
-    } finally {
-      setSaving(false)
+  const visibleRules = volumeRules.filter((algo) => {
+    if (statusFilter === 'active' && !activeIds.has(algo.id)) return false
+    if (statusFilter === 'inactive' && activeIds.has(algo.id)) return false
+    if (gatewayFilter !== 'all' && !splitGateways(algo).includes(gatewayFilter)) return false
+    if (nameFilter.trim()) {
+      const needle = nameFilter.trim().toLowerCase()
+      if (!algo.name.toLowerCase().includes(needle) && !algo.id.toLowerCase().includes(needle)) {
+        return false
+      }
     }
-  }
-
-  async function handleActivate(ruleId: string) {
-    if (!merchantId) return
-    setSuccess(null)
-    setCreatedId(null)
-    if (activeRuleBased) {
-      setPendingActivateId(ruleId)
-      return
-    }
-    await doActivate(ruleId)
-  }
-
-  async function doActivate(ruleId: string) {
-    try {
-      setError(null)
-      setSuccess(null)
-      setCreatedId(null)
-      await apiPost('/routing/activate', { created_by: merchantId, routing_algorithm_id: ruleId })
-      await Promise.all([
-        mutateActive(),
-        mutateCache(['routing-list', merchantId]),
-      ])
-      setSuccess('Rule activated.')
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to activate')
-    }
-  }
-
-  async function handleDeactivate(ruleId: string) {
-    if (!merchantId) return
-    setPendingDeactivateId(ruleId)
-  }
-
-  async function doDeactivate(ruleId: string) {
-    setDeactivatingRuleId(ruleId)
-    setError(null)
-    setSuccess(null)
-    setCreatedId(null)
-    try {
-      await apiPost('/routing/deactivate', { created_by: merchantId, routing_algorithm_id: ruleId })
-      await Promise.all([
-        mutateActive(),
-        mutateCache(['routing-list', merchantId]),
-      ])
-      setSuccess('Rule deactivated.')
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to deactivate')
-    } finally {
-      setDeactivatingRuleId(null)
-    }
-  }
+    return true
+  })
 
   function toggleRuleExpand(id: string) {
-    setExpandedRuleIds(prev => {
+    setExpandedRuleIds((prev) => {
       const next = new Set(prev)
       if (next.has(id)) next.delete(id)
       else next.add(id)
@@ -208,12 +94,68 @@ export function VolumeSplitPage() {
     })
   }
 
+  async function handleActivate(id: string) {
+    if (!merchantId) return
+    if (activeRuleBased) {
+      setPendingActivateId(id)
+      return
+    }
+    await doActivate(id)
+  }
+
+  async function doActivate(id: string) {
+    setActivating(true)
+    setActionError(null)
+    setActionSuccess(null)
+    try {
+      await apiPost('/routing/activate', { created_by: merchantId, routing_algorithm_id: id })
+      setActionSuccess('Rule activated.')
+      await Promise.all([mutateRules(), mutateActive()])
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Failed to activate')
+    } finally {
+      setActivating(false)
+    }
+  }
+
+  async function doDeactivate(id: string) {
+    setDeactivatingId(id)
+    setActionError(null)
+    setActionSuccess(null)
+    try {
+      await apiPost('/routing/deactivate', { created_by: merchantId, routing_algorithm_id: id })
+      setActionSuccess('Rule deactivated.')
+      await Promise.all([mutateRules(), mutateActive()])
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Failed to deactivate')
+    } finally {
+      setDeactivatingId(null)
+    }
+  }
+
+  async function doDelete(id: string) {
+    if (!merchantId) return
+    setActionError(null)
+    setActionSuccess(null)
+    try {
+      await apiPost('/routing/delete', { created_by: merchantId, routing_algorithm_id: id })
+      setActionSuccess('Rule deleted.')
+      await Promise.all([mutateRules(), mutateActive()])
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Failed to delete')
+    } finally {
+      setPendingDeleteId(null)
+    }
+  }
+
+  const pendingDeleteRule = volumeRules.find((r) => r.id === pendingDeleteId)
+
   return (
     <div className="space-y-6">
       <ConfirmDialog
         open={pendingActivateId !== null}
         title="Switch to Volume Split Routing?"
-        description={`"${activeRuleBased?.name}" (Rule-Based) is currently active. Activating this rule will replace it.`}
+        description={`"${activeRuleBased?.name}" is currently active. Activating this rule will replace it.`}
         confirmLabel="Yes, activate"
         variant="primary"
         onConfirm={() => { const id = pendingActivateId!; setPendingActivateId(null); doActivate(id) }}
@@ -228,311 +170,222 @@ export function VolumeSplitPage() {
         onConfirm={() => { const id = pendingDeactivateId!; setPendingDeactivateId(null); doDeactivate(id) }}
         onCancel={() => setPendingDeactivateId(null)}
       />
+      <ConfirmDialog
+        open={pendingDeleteId !== null}
+        title="Delete this rule?"
+        description={`"${pendingDeleteRule?.name}" will be permanently deleted. This cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => doDelete(pendingDeleteId!)}
+        onCancel={() => setPendingDeleteId(null)}
+      />
 
-      <div>
-        <h1 className="text-lg font-semibold text-slate-900 dark:text-white">Volume Split Routing</h1>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Volume Split Routing</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-[#8d96a8]">
+            Divide payment traffic across gateways by fixed percentages, independent of transaction
+            attributes.
+          </p>
+        </div>
+        <Button onClick={() => navigate('/routing/volume/new')} disabled={!canEditRouting}>
+          <Plus size={15} /> Create Rule
+        </Button>
       </div>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-
-        {/* ── Left: saved rules list ───────────────────────────── */}
-        <div className="space-y-3 lg:col-span-1">
-          <SavedRulesList
-            merchantId={merchantId}
-            activeRuleId={activeVol?.id}
-            onActivate={handleActivate}
-            onDeactivate={handleDeactivate}
-            deactivatingRuleId={deactivatingRuleId}
-            expandedRuleIds={expandedRuleIds}
-            onToggleExpand={toggleRuleExpand}
-          />
-          {activeRuleBased && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
-              <strong>Rule-Based routing is active</strong> — activating a volume split rule will automatically deactivate it.
-            </div>
-          )}
-          {error && <ErrorMessage error={error} />}
-          {success && (
-            <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-200">
-              <span className="min-w-0">
-                {createdId ? <>Rule created: <span className="font-mono">{createdId}</span></> : success}
-              </span>
-              {createdId ? (
-                <Button type="button" size="sm" onClick={() => handleActivate(createdId)} disabled={!canEditRouting}>
-                  Activate Now
-                </Button>
-              ) : null}
-            </div>
-          )}
+      {actionError && <ErrorMessage error={actionError} />}
+      {actionSuccess && (
+        <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-3 py-2 text-sm text-emerald-600 dark:text-emerald-400">
+          {actionSuccess}
         </div>
+      )}
 
-        {/* ── Right: create form ───────────────────────────────── */}
-        <div className="space-y-4 lg:col-span-2">
-          <Card>
-            <CardHeader>
-              <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Create Volume Split Rule</h2>
-            </CardHeader>
-            <CardBody className="space-y-4">
-              <div>
-                <label className="mb-1 block text-xs text-slate-500 dark:text-[#8a8a93]">Rule Name *</label>
-                <input
-                  value={ruleName}
-                  onChange={e => setRuleName(e.target.value)}
-                  placeholder="e.g. ab-test-split"
-                  className="w-64 rounded-lg border border-slate-200 bg-transparent px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <div className="hidden grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(260px,320px)_32px] gap-2 px-1 text-xs font-medium text-slate-500 md:grid">
-                  <span>Gateway Name</span>
-                  <span>Gateway ID</span>
-                  <span>Split %</span>
-                  <span />
-                </div>
-                {gateways.map((g, index) => {
-                  const isInferred = g.id === inferredGatewayId
-                  const label = g.gatewayName.trim() || `Gateway ${index + 1}`
-                  return (
-                    <div key={g.id} className="grid grid-cols-1 gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(260px,320px)_32px] md:items-center">
-                      <input
-                        value={g.gatewayName}
-                        onChange={e => updateGateway(g.id, 'gatewayName', e.target.value)}
-                        placeholder="e.g. stripe"
-                        className="rounded-lg border border-slate-200 bg-transparent px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
-                      />
-                      <input
-                        value={g.gatewayId}
-                        onChange={e => updateGateway(g.id, 'gatewayId', e.target.value)}
-                        placeholder="optional gateway_id"
-                        className="rounded-lg border border-slate-200 bg-transparent px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
-                      />
-                      <div className="flex min-w-0 items-center gap-2 rounded-lg border border-slate-200 bg-transparent px-2 py-1.5 focus-within:ring-1 focus-within:ring-brand-500 dark:border-[#222226]">
-                        <span
-                          className="h-2.5 w-2.5 shrink-0 rounded-full"
-                          style={{ backgroundColor: COLORS[index % COLORS.length] }}
-                        />
-                        <input
-                          type="range"
-                          min={0}
-                          max={100}
-                          value={g.split}
-                          disabled={isInferred}
-                          onChange={e => updateGateway(g.id, 'split', Number(e.target.value))}
-                          aria-label={`${label} allocation slider`}
-                          className="h-2 min-w-0 flex-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
-                          style={{ accentColor: COLORS[index % COLORS.length] }}
-                        />
-                        <input
-                          type="number"
-                          min={0}
-                          max={100}
-                          value={g.split}
-                          onChange={e => updateGateway(g.id, 'split', Number(e.target.value))}
-                          disabled={isInferred}
-                          aria-label={`${label} split percentage`}
-                          className="w-12 border-0 bg-transparent p-0 text-right text-sm tabular-nums focus:outline-none disabled:cursor-not-allowed disabled:opacity-70"
-                        />
-                        <span className="text-xs text-slate-500">%</span>
-                        {isInferred && gateways.length > 1 && (
-                          <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-600 dark:bg-[#1a1a22] dark:text-slate-300">
-                            Auto
-                          </span>
-                        )}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => removeGateway(g.id)}
-                        disabled={gateways.length === 1}
-                        className="text-slate-400 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-40"
-                      >
-                        <Trash2 size={15} />
-                      </button>
-                    </div>
-                  )
-                })}
-                <div className="flex items-center gap-3">
-                  <button type="button" onClick={addGateway} className="flex items-center gap-1 text-sm text-brand-500 hover:text-brand-600">
-                    <Plus size={14} /> Add Gateway
-                  </button>
-                  <span className={`text-xs font-medium ${total === 100 ? 'text-emerald-400' : 'text-red-400'}`}>
-                    Total: {total}%{overAllocated ? ` (reduce fixed splits by ${overAllocated}%)` : total !== 100 ? ' (must be 100)' : ''}
-                  </span>
-                </div>
-              </div>
-
-              <Button onClick={handleCreate} disabled={saving || !merchantId || !canEditRouting}>
-                {saving ? <><Spinner size={14} /> Creating…</> : 'Create Rule'}
-              </Button>
-            </CardBody>
-          </Card>
-        </div>
-
-      </div>
-    </div>
-  )
-}
-
-function SavedRulesList({
-  merchantId,
-  activeRuleId,
-  onActivate,
-  onDeactivate,
-  deactivatingRuleId,
-  expandedRuleIds,
-  onToggleExpand,
-}: {
-  merchantId: string
-  activeRuleId?: string
-  onActivate: (id: string) => void
-  onDeactivate: (id: string) => void
-  deactivatingRuleId: string | null
-  expandedRuleIds: Set<string>
-  onToggleExpand: (id: string) => void
-}) {
-  // Read-only sessions still see everything; the controls that would change it are inert.
-  const canEditRouting = useCanEditRouting()
-  const { data: rules, isLoading } = useSWR<RoutingAlgorithm[]>(
-    merchantId ? ['routing-list', merchantId] : null,
-    () => apiPost(`/routing/list/${merchantId}`)
-  )
-
-  const volRules = rules?.filter(r => (r.algorithm_data || r.algorithm)?.type === 'volume_split') ?? []
-
-  return (
-    <Card>
-      <CardHeader>
-        <h2 className="text-sm font-semibold text-slate-800 dark:text-white">Saved Rules</h2>
-      </CardHeader>
-      <div>
+      <Card className="!rounded-[18px]">
         {!merchantId ? (
-          <p className="px-6 py-3 text-sm text-slate-400">Set merchant ID to load rules.</p>
-        ) : isLoading ? (
-          <div className="flex justify-center py-4"><Spinner /></div>
-        ) : volRules.length === 0 ? (
-          <p className="px-6 py-3 text-sm text-slate-400">No volume split rules yet.</p>
+          <p className="px-4 py-6 text-sm text-slate-400">Set merchant ID to load rules.</p>
+        ) : !allRules ? (
+          <p className="px-4 py-6 text-sm text-slate-400">Loading...</p>
+        ) : volumeRules.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-slate-400">No volume split rules yet.</p>
         ) : (
-          <div>
-            {volRules.map((r) => {
-              const isActive = activeRuleId === r.id
-              const isExpanded = expandedRuleIds.has(r.id)
-              const details = toVolumeSplitRuleDetailsState(r)
-              const splitText = details?.gateways
-                .map(g => `${g.gatewayName}: ${g.split}%`)
-                .join(' · ')
-
-              return (
-                <div
-                  key={r.id}
-                  className={`border-b border-slate-100 dark:border-[#1e2330] last:border-b-0 transition-colors ${
-                    isActive ? 'bg-emerald-50/50 dark:bg-emerald-900/10' : ''
-                  }`}
-                >
-                  <div className="px-6 pt-3 pb-2">
-                    <div className="flex items-center justify-between gap-2">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[880px] text-left">
+              <thead>
+                <tr className="border-b border-slate-100 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:border-[#1e2330] dark:text-[#6d7a8d]">
+                  <th className="px-5 py-3.5">
+                    <HeaderSearch
+                      label="Rule Name & ID"
+                      value={nameFilter}
+                      onChange={setNameFilter}
+                      ariaLabel="Filter rules by name"
+                    />
+                  </th>
+                  <th className="px-5 py-3.5">
+                    <HeaderFilter
+                      label="Status"
+                      value={statusFilter}
+                      options={[
+                        { value: 'all', label: 'All statuses' },
+                        { value: 'active', label: 'Active' },
+                        { value: 'inactive', label: 'Inactive' },
+                      ]}
+                      onChange={(v) => setStatusFilter(v as StatusFilter)}
+                      ariaLabel="Filter by status"
+                    />
+                  </th>
+                  <th className="px-5 py-3.5">
+                    <HeaderFilter
+                      label="Distribution"
+                      value={gatewayFilter}
+                      options={[
+                        { value: 'all', label: 'All gateways' },
+                        ...gatewayOptions.map((g) => ({ value: g, label: g })),
+                      ]}
+                      onChange={setGatewayFilter}
+                      ariaLabel="Filter by gateway"
+                    />
+                  </th>
+                  <th className="px-5 py-3.5">Last Modified</th>
+                  <th className="px-5 py-3.5 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleRules.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-8 text-center">
+                      <p className="text-sm text-slate-400">No rules match these filters.</p>
                       <button
                         type="button"
-                        onClick={() => onToggleExpand(r.id)}
-                        className="group min-w-0 flex-1 text-left"
+                        onClick={() => { setStatusFilter('all'); setGatewayFilter('all'); setNameFilter('') }}
+                        className="mt-1.5 text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400"
                       >
-                        <div className="flex items-center gap-1.5">
-                          <p className={`truncate font-medium transition-colors group-hover:text-brand-600 dark:group-hover:text-brand-400 ${
-                            isActive ? 'text-emerald-900 dark:text-emerald-100' : 'text-slate-900 dark:text-white'
-                          }`}>
-                            {r.name}
-                          </p>
-                          {isActive && (
-                            <span className="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400">
-                              ● Active
-                            </span>
-                          )}
-                          {isExpanded
-                            ? <ChevronUp size={12} className="ml-auto shrink-0 text-slate-400" />
-                            : <ChevronDown size={12} className="ml-auto shrink-0 text-slate-400" />
-                          }
-                        </div>
-                        <div className="mt-0.5 flex items-center gap-2">
-                          {splitText && (
-                            <p className="min-w-0 truncate text-[11px] text-slate-500 dark:text-[#6d7a8d]">
-                              {splitText}
-                            </p>
-                          )}
-                          {r.created_at && (
-                            <span className="ml-auto shrink-0 text-[10px] text-slate-400 dark:text-[#4e5870]">
-                              {new Date(r.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
-                            </span>
-                          )}
-                        </div>
+                        Clear filters
                       </button>
+                    </td>
+                  </tr>
+                )}
+                {visibleRules.map((algo) => {
+                  const isActive = activeIds.has(algo.id)
+                  const isExpanded = expandedRuleIds.has(algo.id)
+                  const distribution = describeSplit(algo)
+                  // Both /routing/update and /routing/delete reject an active algorithm.
+                  const lockedReason = isActive
+                    ? 'Deactivate this rule first'
+                    : !canEditRouting
+                    ? 'You do not have permission to change routing'
+                    : undefined
 
-                      <div className="flex shrink-0 items-center gap-1.5">
-                        {isActive ? (
-                          <Button
-                            size="sm"
-                            variant="danger"
-                            onClick={() => onDeactivate(r.id)}
-                            disabled={deactivatingRuleId === r.id}
-                          >
-                            <PowerOff size={13} />
-                            {deactivatingRuleId === r.id ? 'Deactivating' : 'Deactivate'}
-                          </Button>
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={() => onActivate(r.id)}
-                            disabled={!canEditRouting}
-                            className="inline-flex min-w-[68px] items-center justify-center rounded-full border border-slate-200 bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-500 transition-colors duration-150 hover:border-brand-200 hover:bg-brand-50 hover:text-brand-600 dark:border-[#2a3040] dark:bg-[#1a1f2a] dark:text-[#8090a8] dark:hover:border-brand-800 dark:hover:bg-brand-900/20 dark:hover:text-brand-400"
-                          >
-                            Activate
-                          </button>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-
-                  {isExpanded && (() => {
-                    const pieData = details?.gateways.map(g => ({
-                      name: g.gatewayName + (g.gatewayId ? ` (${g.gatewayId})` : ''),
-                      value: g.split,
-                    })) ?? []
-                    return (
-                      <div className="border-t border-slate-100 bg-slate-50/60 px-6 py-4 dark:border-[#1e2330] dark:bg-[#0c0f17]">
-                        {pieData.length > 0 && (
-                          <ResponsiveContainer width="100%" height={200}>
-                            <PieChart>
-                              <Pie
-                                data={pieData}
-                                dataKey="value"
-                                nameKey="name"
-                                cx="50%"
-                                cy="50%"
-                                outerRadius={72}
-                                isAnimationActive={false}
-                                label={({ name, value }) => `${name}: ${value}%`}
-                                labelLine={{ stroke: '#45454f' }}
-                              >
-                                {pieData.map((_, i) => (
-                                  <Cell key={i} fill={COLORS[i % COLORS.length]} />
-                                ))}
-                              </Pie>
-                              <Tooltip
-                                formatter={(v) => `${v}%`}
-                                contentStyle={CHART_TOOLTIP_STYLE}
-                                labelStyle={CHART_TOOLTIP_LABEL_STYLE}
-                                itemStyle={CHART_TOOLTIP_ITEM_STYLE}
-                              />
-                            </PieChart>
-                          </ResponsiveContainer>
-                        )}
-                      </div>
-                    )
-                  })()}
-                </div>
-              )
-            })}
+                  return [
+                    <tr
+                      key={algo.id}
+                      data-testid="rule-row"
+                      data-rule-name={algo.name}
+                      onClick={() => toggleRuleExpand(algo.id)}
+                      className={`cursor-pointer border-b border-slate-100 align-middle transition-colors hover:bg-slate-50 dark:border-[#1e2330] dark:hover:bg-[#11151d] ${
+                        isActive ? 'bg-emerald-50/50 dark:bg-emerald-900/10' : ''
+                      }`}
+                    >
+                      <td className="px-5 py-4">
+                        <div className="flex items-start gap-2">
+                          {isExpanded
+                            ? <ChevronDown size={14} className="mt-1 shrink-0 text-slate-400" />
+                            : <ChevronRight size={14} className="mt-1 shrink-0 text-slate-400" />
+                          }
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
+                              {algo.name}
+                            </p>
+                            <p className="mt-0.5 truncate font-mono text-xs text-slate-400 dark:text-[#6d7a8d]">
+                              {algo.id}
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-5 py-4">
+                        <span className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-1 text-[11px] font-semibold ${
+                          isActive
+                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                            : 'bg-slate-100 text-slate-500 dark:bg-[#1a1f2a] dark:text-[#8090a8]'
+                        }`}>
+                          {isActive ? 'Active' : 'Inactive'}
+                        </span>
+                      </td>
+                      <td className="max-w-[320px] px-5 py-4">
+                        <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200" title={distribution}>
+                          {distribution}
+                        </p>
+                      </td>
+                      <td className="whitespace-nowrap px-5 py-4 text-[13px] text-slate-500 dark:text-[#6d7a8d]">
+                        {algo.created_at
+                          ? new Date(algo.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+                          : '—'}
+                      </td>
+                      <td className="px-5 py-4" onClick={(e) => e.stopPropagation()}>
+                        <RowMenu
+                          items={[
+                            isActive
+                              ? {
+                                  label: deactivatingId === algo.id ? 'Deactivating…' : 'Deactivate',
+                                  icon: PowerOff,
+                                  onSelect: () => setPendingDeactivateId(algo.id),
+                                  disabled: deactivatingId === algo.id || !canEditRouting,
+                                }
+                              : {
+                                  label: 'Activate',
+                                  icon: Zap,
+                                  tone: 'positive',
+                                  onSelect: () => handleActivate(algo.id),
+                                  disabled: activating || !canEditRouting,
+                                },
+                            {
+                              label: 'Edit',
+                              icon: Pencil,
+                              onSelect: () => navigate(`/routing/volume/${algo.id}/edit`),
+                              disabled: Boolean(lockedReason),
+                              hint: lockedReason,
+                            },
+                            {
+                              label: 'Duplicate',
+                              icon: Copy,
+                              onSelect: () => navigate(`/routing/volume/new?cloneFrom=${algo.id}`),
+                              disabled: !canEditRouting,
+                            },
+                            {
+                              label: 'Delete',
+                              icon: Trash2,
+                              tone: 'danger',
+                              onSelect: () => setPendingDeleteId(algo.id),
+                              disabled: Boolean(lockedReason),
+                              hint: lockedReason,
+                            },
+                          ]}
+                        />
+                      </td>
+                    </tr>,
+                    isExpanded ? (
+                      <tr key={`${algo.id}-detail`} className="border-b border-slate-100 dark:border-[#1e2330]">
+                        <td colSpan={5} className="bg-slate-50/60 px-6 py-5 dark:bg-[#0c0f17]">
+                          {algo.description && algo.description !== 'N/A' && (
+                            <p className="mb-3 text-sm text-slate-500 dark:text-[#6d7a8d]">{algo.description}</p>
+                          )}
+                          <SplitBreakdown gateways={toVolumeSplitRuleDetailsState(algo)?.gateways ?? []} />
+                        </td>
+                      </tr>
+                    ) : null,
+                  ]
+                })}
+              </tbody>
+            </table>
           </div>
         )}
-      </div>
-    </Card>
+      </Card>
+
+      {activeRuleBased && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+          <strong>"{activeRuleBased.name}" is active</strong> — activating a volume split rule will
+          automatically deactivate it.
+        </div>
+      )}
+    </div>
   )
 }

--- a/website/src/components/routing/euclid/RuleBreakdown.tsx
+++ b/website/src/components/routing/euclid/RuleBreakdown.tsx
@@ -1,0 +1,173 @@
+import { RoutingAlgorithm, EuclidAlgorithmData, EuclidCondition, EuclidStatement } from '../../../types/api'
+import { toLabel, formatOp } from '../../../features/routing/euclid/state'
+import { normalizeRuleOutput } from '../../../features/routing/euclid/summarize'
+
+export function RuleBreakdown({ algo }: { algo: RoutingAlgorithm }) {
+  const algorithm = algo.algorithm_data || algo.algorithm
+  const data = algorithm?.data as EuclidAlgorithmData | undefined
+  const defaultSel = data?.default_selection || data?.defaultSelection
+
+  return (
+    <div className="space-y-2.5">
+      {(data?.rules ?? []).map((rule, i) => {
+        const {
+          priorityGateways, volumeSplits, volumeSplitPriorityEntries,
+          isVolumeSplit, isVolumeSplitPriority,
+        } = normalizeRuleOutput(rule)
+
+        return (
+          <div key={i} className="overflow-hidden rounded-xl border border-slate-200 dark:border-[#1e2330] bg-white dark:bg-[#0d1018]">
+            <div className="flex items-center justify-between gap-2 border-b border-slate-100 dark:border-[#1e2330] bg-slate-50 dark:bg-[#10131c] px-3 py-1.5">
+              <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400 dark:text-[#4e5870]">
+                {rule.name || `Rule ${i + 1}`}
+              </span>
+              {rule.routing_type && (
+                <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
+                  rule.routing_type === 'volume_split_priority'
+                    ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400'
+                    : rule.routing_type === 'volume_split'
+                    ? 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400'
+                    : 'bg-brand-100 dark:bg-brand-900/30 text-brand-600 dark:text-brand-400'
+                }`}>
+                  {rule.routing_type === 'volume_split_priority' ? 'Split + Priority'
+                    : rule.routing_type === 'volume_split' ? 'Volume Split'
+                    : 'Priority'}
+                </span>
+              )}
+            </div>
+            <div className="space-y-1.5 px-3 py-2.5">
+              {(rule.statements ?? []).map((statement, gi) => (
+                <div key={gi}>
+                  {gi > 0 && (
+                    <div className="flex items-center gap-2 my-1.5">
+                      <span className="h-px flex-1 bg-slate-200 dark:bg-[#1e2330]" />
+                      <span className="text-[10px] font-bold text-sky-500">OR</span>
+                      <span className="h-px flex-1 bg-slate-200 dark:bg-[#1e2330]" />
+                    </div>
+                  )}
+                  <StatementView statement={statement} />
+                </div>
+              ))}
+              <div className="flex items-start gap-2 pt-0.5 text-xs">
+                <span className="w-7 shrink-0 text-right text-[10px] font-bold text-brand-500 select-none">→</span>
+                <div className="flex flex-wrap gap-1">
+                  {isVolumeSplitPriority
+                    ? volumeSplitPriorityEntries.map((e, j) => (
+                        <span key={j} className="rounded-full bg-purple-50 dark:bg-purple-900/20 px-2 py-0.5 text-[11px] font-medium text-purple-700 dark:text-purple-300">
+                          {e.split}%: {e.output.map(g => g.gateway_name).join(', ')}
+                        </span>
+                      ))
+                    : isVolumeSplit
+                    ? volumeSplits.map((s, j) => (
+                        <span key={j} className="rounded-full bg-emerald-50 dark:bg-emerald-900/20 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+                          {s.output.gateway_name} {s.split}%
+                        </span>
+                      ))
+                    : priorityGateways.map((g, j) => (
+                        <span key={j} className="rounded-full bg-brand-50 dark:bg-brand-900/20 px-2 py-0.5 text-[11px] font-medium text-brand-700 dark:text-brand-300">
+                          {j + 1}. {g.gateway_name}
+                        </span>
+                      ))
+                  }
+                  {!isVolumeSplitPriority && !isVolumeSplit && priorityGateways.length === 0 && (
+                    <span className="text-slate-400 italic">No output configured</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+
+      {(() => {
+        const defRaw = defaultSel as Record<string, unknown> | undefined
+        const defGateways = (Array.isArray(defRaw?.priority) ? defRaw!.priority : Array.isArray(defRaw?.data) ? defRaw!.data : []) as { gateway_name: string }[]
+        // An empty default_selection is accepted by the API but leaves unmatched payments with a
+        // blank gateway (interpreter.rs evaluates Priority([]) to a default-constructed connector),
+        // so call it out rather than rendering nothing.
+        return defGateways.length > 0 ? (
+          <div className="flex items-center gap-2 px-1 text-xs">
+            <span className="text-slate-400 dark:text-[#4e5870]">Default:</span>
+            <div className="flex flex-wrap gap-1">
+              {defGateways.map((g, i) => (
+                <span key={i} className="rounded-full bg-slate-100 dark:bg-[#1a1f2a] px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:text-[#8090a8]">
+                  {g.gateway_name}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 px-1 text-xs">
+            <span className="text-slate-400 dark:text-[#4e5870]">Default:</span>
+            <span className="font-medium text-amber-600 dark:text-amber-400">
+              Not set — unmatched payments have no gateway
+            </span>
+          </div>
+        )
+      })()}
+
+      {(!data?.rules || data.rules.length === 0) && (
+        <p className="text-xs text-slate-400 italic">No rules configured.</p>
+      )}
+    </div>
+  )
+}
+
+/** One condition chip: `Payment Method = Card`. */
+function ConditionChip({ cond, op }: { cond: EuclidCondition; op: string }) {
+  return (
+    <div className="flex items-center gap-2 px-2 py-1.5 text-xs">
+      <span className="w-7 shrink-0 select-none text-right text-[10px] font-bold text-slate-300 dark:text-[#3a4258]">
+        {op}
+      </span>
+      <span className="rounded-md bg-slate-100 px-2 py-1 text-slate-700 dark:bg-[#1a1f2a] dark:text-[#c8d0de]">
+        {toLabel(String(cond.lhs ?? ''))}{' '}
+        <span className="font-mono text-slate-400 dark:text-[#5d6880]">{formatOp(String(cond.comparison ?? ''))}</span>{' '}
+        <span className="font-medium">
+          {cond.value?.type === 'metadata_variant' && cond.value.value && typeof cond.value.value === 'object'
+            ? `{ "${(cond.value.value as { key?: string }).key ?? ''}" : "${(cond.value.value as { value?: string }).value ?? ''}" }`
+            : toLabel(String(cond.value?.value ?? ''))}
+        </span>
+      </span>
+    </div>
+  )
+}
+
+/**
+ * A statement, drawn the way the interpreter reads it: the `condition` list is ANDed, and when
+ * `nested` is present at least one nested branch must also match. Flattening the branches into the
+ * same list — as this panel used to — turns `A and B and ((C and D) or E)` into
+ * `A and B and C and D or E`, which is a different rule.
+ */
+function StatementView({ statement }: { statement: EuclidStatement }) {
+  const conditions = statement.condition ?? []
+  const nested = statement.nested ?? []
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 dark:border-[#1e2330]">
+      <div className="divide-y divide-slate-100 dark:divide-[#1e2330]">
+        {conditions.map((cond, ci) => (
+          <ConditionChip key={ci} cond={cond} op={ci === 0 ? 'IF' : 'AND'} />
+        ))}
+      </div>
+
+      {nested.length > 0 && (
+        <div className="border-t border-slate-100 px-2 py-2 dark:border-[#1e2330]">
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-[#4e5870]">
+            {conditions.length > 0 ? 'and any of' : 'any of'}
+          </p>
+          <div className="space-y-1.5">
+            {nested.map((branch, ni) => (
+              <div key={ni}>
+                {ni > 0 && <p className="mb-1 text-[10px] font-bold text-sky-500">OR</p>}
+                <div className="border-l-2 border-sky-200 pl-2 dark:border-sky-800">
+                  <StatementView statement={branch} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/website/src/components/routing/euclid/RuleBreakdown.tsx
+++ b/website/src/components/routing/euclid/RuleBreakdown.tsx
@@ -134,10 +134,10 @@ function ConditionChip({ cond, op }: { cond: EuclidCondition; op: string }) {
 }
 
 /**
- * A statement, drawn the way the interpreter reads it: the `condition` list is ANDed, and when
- * `nested` is present at least one nested branch must also match. Flattening the branches into the
- * same list — as this panel used to — turns `A and B and ((C and D) or E)` into
- * `A and B and C and D or E`, which is a different rule.
+ * A statement, drawn the way the interpreter reads it: the `condition` list is joined with AND,
+ * and when `nested` is present at least one nested branch must also match. Flattening the branches
+ * into the same list would turn `A and B and ((C and D) or E)` into `A and B and C and D or E`,
+ * which is a different rule.
  */
 function StatementView({ statement }: { statement: EuclidStatement }) {
   const conditions = statement.condition ?? []

--- a/website/src/components/routing/euclid/editors.tsx
+++ b/website/src/components/routing/euclid/editors.tsx
@@ -469,7 +469,7 @@ export function ConditionGroupEditor({
     <div className="rounded-lg border border-slate-200 dark:border-[#222733] bg-white dark:bg-[#0f141d]">
       <div className="space-y-0 divide-y divide-slate-100 dark:divide-[#1c1c24]">
         {group.conditions.map((cond, idx) => (
-          <div key={cond.id} className="flex items-center gap-3 px-4 py-3">
+          <div key={cond.id} data-testid="condition-row" className="flex items-center gap-3 px-4 py-3">
             {group.conditions.length > 1 && (
               <span className="w-10 shrink-0 text-[11px] font-bold uppercase tracking-widest text-sky-500 select-none">
                 {idx === 0 ? 'IF' : 'AND'}

--- a/website/src/components/routing/euclid/editors.tsx
+++ b/website/src/components/routing/euclid/editors.tsx
@@ -1,0 +1,721 @@
+import { useRef, useState } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Plus, Trash2, GripVertical, CornerDownRight, ChevronDown, ChevronUp } from 'lucide-react'
+import { Button } from '../../ui/Button'
+import { SearchableSelect } from '../../ui/SearchableSelect'
+import { SearchableMultiSelect } from '../../ui/SearchableMultiSelect'
+import { RoutingKeyConfig } from '../../../hooks/useDynamicRoutingConfig'
+import type {
+  RuleBlock, StatementGroup, ConditionRow,
+  GatewayEntry, VolumeSplitEntry, VolumeSplitPriorityEntry,
+} from '../../ui/RuleCodeEditor'
+import {
+  OPERATOR_LABELS, toLabel, createCondition, createStatementGroup,
+} from '../../../features/routing/euclid/state'
+
+// ---- Sortable gateway item ----
+export function SortableGatewayItem({
+  id,
+  name,
+  onRemove,
+}: {
+  id: string
+  name: string
+  onRemove: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
+  const style = { transform: CSS.Transform.toString(transform), transition }
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 bg-slate-100 dark:bg-[#111118] border border-slate-200 dark:border-[#1c1c24] rounded-lg px-2 py-1.5"
+    >
+      <span {...attributes} {...listeners} className="cursor-grab text-slate-400">
+        <GripVertical size={14} />
+      </span>
+      <span className="text-sm flex-1 font-mono">{name}</span>
+      <button type="button" onClick={onRemove} className="text-red-400 hover:text-red-600">
+        <Trash2 size={12} />
+      </button>
+    </div>
+  )
+}
+
+// ---- Priority output editor ----
+export function PriorityEditor({
+  gateways,
+  onChange,
+  suggestions = [],
+}: {
+  gateways: GatewayEntry[]
+  onChange: (gws: GatewayEntry[]) => void
+  suggestions?: string[]
+}) {
+  const [newGatewayName, setNewGatewayName] = useState('')
+  const [newGatewayId, setNewGatewayId] = useState('')
+  const listId = useRef(`gateway-suggestions-${Math.random().toString(36).slice(2)}`).current
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      const oldIndex = gateways.findIndex((g) => g.id === active.id)
+      const newIndex = gateways.findIndex((g) => g.id === over.id)
+      onChange(arrayMove(gateways, oldIndex, newIndex))
+    }
+  }
+
+  function add() {
+    if (!newGatewayName.trim()) return
+    onChange([
+      ...gateways,
+      { id: crypto.randomUUID(), gatewayName: newGatewayName.trim(), gatewayId: newGatewayId.trim() },
+    ])
+    setNewGatewayName('')
+    setNewGatewayId('')
+  }
+
+  const unusedSuggestions = suggestions.filter((s) => !gateways.some((g) => g.gatewayName === s))
+
+  return (
+    <div className="space-y-2">
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={gateways.map((g) => g.id)} strategy={verticalListSortingStrategy}>
+          {gateways.map((gw, idx) => (
+            <SortableGatewayItem
+              key={gw.id}
+              id={gw.id}
+              name={`${idx + 1}. ${gw.gatewayName}${gw.gatewayId ? ` (${gw.gatewayId})` : ''}`}
+              onRemove={() => onChange(gateways.filter((g) => g.id !== gw.id))}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
+      <datalist id={listId}>
+        {unusedSuggestions.map((s) => <option key={s} value={s} />)}
+      </datalist>
+      {/* Enter and the Add button are shortcuts, not requirements: whatever has been typed is
+          committed as soon as focus leaves the row, so a gateway typed but never explicitly added
+          is not silently dropped on save. Tabbing between fields inside the row does not commit,
+          and a following Add click is a no-op because add() clears the inputs. */}
+      <div className="flex gap-2"
+        onBlur={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) add() }}
+      >
+        <input
+          value={newGatewayName}
+          onChange={(e) => setNewGatewayName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
+          list={listId}
+          placeholder="Gateway name"
+          className="flex-1 rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+        />
+        <input
+          value={newGatewayId}
+          onChange={(e) => setNewGatewayId(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
+          placeholder="Gateway ID (optional)"
+          className="flex-1 rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+        />
+        <Button type="button" size="sm" variant="secondary" onClick={add}>
+          <Plus size={13} /> Add
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ---- Volume split editor ----
+export function VolumeSplitEditor({
+  entries,
+  onChange,
+  suggestions = [],
+}: {
+  entries: VolumeSplitEntry[]
+  onChange: (e: VolumeSplitEntry[]) => void
+  suggestions?: string[]
+}) {
+  const [newSplit, setNewSplit] = useState('')
+  const [newName, setNewName] = useState('')
+  const [newId, setNewId] = useState('')
+  const listId = `vs-suggestions-${Math.random().toString(36).slice(2)}`
+
+  const total = entries.reduce((s, e) => s + e.split, 0)
+
+  function add() {
+    if (!newName.trim() || !newSplit) return
+    onChange([
+      ...entries,
+      { id: crypto.randomUUID(), split: Number(newSplit), gatewayName: newName.trim(), gatewayId: newId.trim() },
+    ])
+    setNewSplit('')
+    setNewName('')
+    setNewId('')
+  }
+
+  const unusedSuggestions = suggestions.filter((s) => !entries.some((e) => e.gatewayName === s))
+
+  return (
+    <div className="space-y-2">
+      {entries.map((e) => (
+        <div
+          key={e.id}
+          className="flex items-center gap-2 bg-slate-100 dark:bg-[#111118] border border-slate-200 dark:border-[#1c1c24] rounded-lg px-2 py-1.5"
+        >
+          <span className="text-xs font-bold text-brand-500 w-10 shrink-0 tabular-nums">{e.split}%</span>
+          <span className="text-sm flex-1 font-mono">
+            {e.gatewayName}{e.gatewayId ? ` (${e.gatewayId})` : ''}
+          </span>
+          <button type="button" onClick={() => onChange(entries.filter((x) => x.id !== e.id))} className="text-red-400 hover:text-red-600">
+            <Trash2 size={12} />
+          </button>
+        </div>
+      ))}
+      {entries.length > 0 && (
+        <p className={`text-xs font-medium ${total === 100 ? 'text-emerald-500' : 'text-amber-500'}`}>
+          Total: {total}%{total !== 100 ? ' (must equal 100%)' : ' ✓'}
+        </p>
+      )}
+      <datalist id={listId}>
+        {unusedSuggestions.map((s) => <option key={s} value={s} />)}
+      </datalist>
+      {/* Same commit-on-leave behaviour as the priority editor above. */}
+      <div
+        className="flex gap-2"
+        onBlur={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) add() }}
+      >
+        <input
+          type="number"
+          value={newSplit}
+          onChange={(e) => setNewSplit(e.target.value)}
+          placeholder="Split %"
+          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm w-20 focus:outline-none focus:ring-1 focus:ring-brand-500"
+        />
+        <input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
+          list={listId}
+          placeholder="Gateway name"
+          className="flex-1 rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+        />
+        <input
+          value={newId}
+          onChange={(e) => setNewId(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
+          placeholder="Gateway ID (optional)"
+          className="flex-1 rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226]"
+        />
+        <Button type="button" size="sm" variant="secondary" onClick={add}>
+          <Plus size={13} /> Add
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ---- Volume split priority editor ----
+export function VolumeSplitPriorityEditor({
+  entries,
+  onChange,
+  suggestions = [],
+}: {
+  entries: VolumeSplitPriorityEntry[]
+  onChange: (e: VolumeSplitPriorityEntry[]) => void
+  suggestions?: string[]
+}) {
+  const [newSplit, setNewSplit] = useState('')
+
+  const total = entries.reduce((s, e) => s + e.split, 0)
+
+  function addSplit() {
+    if (!newSplit) return
+    onChange([...entries, { id: crypto.randomUUID(), split: Number(newSplit), gateways: [] }])
+    setNewSplit('')
+  }
+
+  function updateEntry(id: string, patch: Partial<VolumeSplitPriorityEntry>) {
+    onChange(entries.map((e) => (e.id === id ? { ...e, ...patch } : e)))
+  }
+
+  return (
+    <div className="space-y-3">
+      {entries.length > 0 && (
+        <p className={`text-xs font-medium ${total === 100 ? 'text-emerald-500' : 'text-amber-500'}`}>
+          Total: {total}%{total !== 100 ? ' (must equal 100%)' : ' ✓'}
+        </p>
+      )}
+      {entries.map((entry, idx) => (
+        <div
+          key={entry.id}
+          className="rounded-lg border border-slate-200 dark:border-[#222226] overflow-hidden"
+        >
+          <div className="flex items-center gap-2 px-3 py-2 bg-slate-50 dark:bg-[#111118] border-b border-slate-200 dark:border-[#1c1c24]">
+            <span className="text-xs text-slate-400 font-medium shrink-0">Split {idx + 1}:</span>
+            <input
+              type="number"
+              value={entry.split}
+              onChange={(e) => updateEntry(entry.id, { split: Number(e.target.value) })}
+              className="border border-slate-200 dark:border-[#222226] bg-transparent rounded px-2 py-0.5 text-xs w-16 focus:outline-none"
+            />
+            <span className="text-xs text-slate-400">%</span>
+            <button
+              type="button"
+              onClick={() => onChange(entries.filter((e) => e.id !== entry.id))}
+              className="ml-auto text-red-400 hover:text-red-600"
+            >
+              <Trash2 size={12} />
+            </button>
+          </div>
+          <div className="p-3">
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-widest text-slate-500 dark:text-[#8d96a8]">Priority list for this split</p>
+            <PriorityEditor
+              gateways={entry.gateways}
+              suggestions={suggestions}
+              onChange={(gws) => updateEntry(entry.id, { gateways: gws })}
+            />
+          </div>
+        </div>
+      ))}
+      {/* Same commit-on-leave behaviour as the editors above. */}
+      <div
+        className="flex gap-2 items-center"
+        onBlur={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) addSplit() }}
+      >
+        <input
+          type="number"
+          value={newSplit}
+          onChange={(e) => setNewSplit(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addSplit())}
+          placeholder="Split %"
+          className="border border-slate-200 dark:border-[#222226] bg-transparent rounded-lg px-2 py-1 text-sm w-24 focus:outline-none focus:ring-1 focus:ring-brand-500"
+        />
+        <Button type="button" size="sm" variant="secondary" onClick={addSplit}>
+          <Plus size={13} /> Add split
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ---- Condition row ----
+export function ConditionRowEditor({
+  row,
+  onChange,
+  onRemove,
+  routingKeys,
+}: {
+  row: ConditionRow
+  onChange: (r: ConditionRow) => void
+  onRemove: () => void
+  routingKeys: Record<string, RoutingKeyConfig>
+}) {
+  const keyInfo = routingKeys[row.lhs]
+  const isEnum = keyInfo?.type === 'enum'
+  const isInt = keyInfo?.type === 'integer'
+  const isMetadata = keyInfo?.type === 'udf' || keyInfo?.type === 'global_ref'
+  const isMulti = row.operator === 'in' || row.operator === 'not_in'
+
+  const operators = isInt
+    ? ['>', '<', '>=', '<=', '==', '!=']
+    : isEnum
+    ? ['==', '!=', 'in', 'not_in']
+    : ['==', '!=']
+
+  const selectedValues = Array.isArray(row.value) ? row.value : []
+
+  function handleOperatorChange(op: string) {
+    const switchingToMulti = op === 'in' || op === 'not_in'
+    const switchingFromMulti = row.operator === 'in' || row.operator === 'not_in'
+    let newValue: string | string[] = row.value
+    if (switchingToMulti && !Array.isArray(row.value)) {
+      newValue = row.value ? [row.value as string] : []
+    } else if (!switchingToMulti && switchingFromMulti) {
+      newValue = Array.isArray(row.value) ? (row.value[0] ?? '') : ''
+    }
+    onChange({ ...row, operator: op, value: newValue })
+  }
+
+  return (
+    // Fixed tracks so the columns line up down the whole rule. Widths are sized to the content a
+    // field actually holds — a stretched box for a two-digit amount reads worse than a small one.
+    <div className="flex items-center gap-3">
+      <SearchableSelect
+        className="w-[13.5rem] shrink-0"
+        dataCy="cond-lhs"
+        value={row.lhs}
+        onChange={(newKey) => {
+          const newConfig = routingKeys[newKey]
+          const defaultValue = newConfig?.type === 'enum' ? (newConfig.values?.[0] ?? '') : ''
+          onChange({ ...row, lhs: newKey, value: defaultValue, operator: '==' })
+        }}
+        options={Object.keys(routingKeys).map((k) => ({ value: k, label: toLabel(k) }))}
+      />
+      <select
+        value={row.operator}
+        onChange={(e) => handleOperatorChange(e.target.value)}
+        aria-label="Condition operator"
+        className="cond-select w-[10.5rem] shrink-0"
+      >
+        {operators.map((op) => (
+          <option key={op} value={op}>{OPERATOR_LABELS[op] || op}</option>
+        ))}
+      </select>
+      <div className="flex items-center gap-2">
+        {isEnum && isMulti ? (
+          <div data-cy="cond-val" className="w-[14rem]">
+            <SearchableMultiSelect
+              values={selectedValues}
+              onChange={(vals) => onChange({ ...row, value: vals })}
+              options={(keyInfo?.values || []).map((v: string) => ({ value: v, label: toLabel(v) }))}
+              placeholder="Select values…"
+            />
+          </div>
+        ) : isEnum ? (
+          <SearchableSelect
+            className="w-[12rem]"
+            dataCy="cond-val"
+            value={row.value as string}
+            onChange={(v) => onChange({ ...row, value: v })}
+            options={(keyInfo?.values || []).map((v: string) => ({ value: v, label: toLabel(v) }))}
+          />
+        ) : isInt ? (
+          <input
+            type="number"
+            value={row.value as string}
+            onChange={(e) => onChange({ ...row, value: e.target.value })}
+            placeholder="value"
+            className="rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none dark:border-[#222226] w-32"
+          />
+        ) : isMetadata ? (
+          <>
+            <input
+              type="text"
+              value={row.metadataKey || ''}
+              onChange={(e) => onChange({ ...row, metadataKey: e.target.value })}
+              placeholder="key"
+              className="rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none dark:border-[#222226] w-40"
+            />
+            <span className="shrink-0 text-sm text-slate-400 dark:text-slate-500 select-none">=</span>
+            <input
+              type="text"
+              value={row.value as string}
+              onChange={(e) => onChange({ ...row, value: e.target.value })}
+              placeholder="value"
+              className="rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none dark:border-[#222226] w-44"
+            />
+          </>
+        ) : (
+          <input
+            type="text"
+            value={row.value as string}
+            onChange={(e) => onChange({ ...row, value: e.target.value })}
+            placeholder="value"
+            className="rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm focus:outline-none dark:border-[#222226] w-52"
+          />
+        )}
+      </div>
+      <button type="button" onClick={onRemove} aria-label="Remove condition" className="shrink-0 text-red-400 transition-colors hover:text-red-600">
+        <Trash2 size={15} />
+      </button>
+    </div>
+  )
+}
+
+// ---- Condition group ----
+export function ConditionGroupEditor({
+  group,
+  onChange,
+  onRemove,
+  canRemove,
+  routingKeys,
+  depth = 0,
+}: {
+  group: StatementGroup
+  onChange: (g: StatementGroup) => void
+  onRemove: () => void
+  canRemove: boolean
+  routingKeys: Record<string, RoutingKeyConfig>
+  depth?: number
+}) {
+  function addCondition() {
+    onChange({ ...group, conditions: [...group.conditions, createCondition(routingKeys)] })
+  }
+
+  function addNestedBranch() {
+    onChange({ ...group, nested: [...group.nested, createStatementGroup(routingKeys)] })
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-[#222733] bg-white dark:bg-[#0f141d]">
+      <div className="space-y-0 divide-y divide-slate-100 dark:divide-[#1c1c24]">
+        {group.conditions.map((cond, idx) => (
+          <div key={cond.id} className="flex items-center gap-3 px-4 py-3">
+            {group.conditions.length > 1 && (
+              <span className="w-10 shrink-0 text-[11px] font-bold uppercase tracking-widest text-sky-500 select-none">
+                {idx === 0 ? 'IF' : 'AND'}
+              </span>
+            )}
+            <ConditionRowEditor
+              row={cond}
+              routingKeys={routingKeys}
+              onChange={(updated) =>
+                onChange({ ...group, conditions: group.conditions.map((c) => (c.id === cond.id ? updated : c)) })
+              }
+              onRemove={() =>
+                onChange({
+                  ...group,
+                  conditions: group.conditions.length > 1
+                    ? group.conditions.filter((c) => c.id !== cond.id)
+                    : group.conditions,
+                })
+              }
+            />
+          </div>
+        ))}
+        {/* Sits directly under the last condition, because that is where a new row lands — below
+            the nested branches it would point at the wrong insertion point. */}
+        <div className="flex items-center gap-4 px-4 py-2.5">
+          <button
+            type="button"
+            onClick={addCondition}
+            className="flex items-center gap-1 text-[13px] font-medium text-brand-600 transition-colors hover:text-brand-700 dark:text-brand-400"
+          >
+            <Plus size={13} /> Add condition
+          </button>
+          {/* A nested branch has no group-level footer, so its remove control rides along here. */}
+          {depth > 0 && canRemove && (
+            <button
+              type="button"
+              onClick={onRemove}
+              className="ml-auto flex items-center gap-1 text-[13px] font-medium text-red-500 transition-colors hover:text-red-600"
+            >
+              <Trash2 size={13} /> Remove group
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Nested OR branches — shown only at depth 0 */}
+      {depth === 0 && group.nested.length > 0 && (
+        <div className="border-t border-slate-100 dark:border-[#1c1c24] px-3 pt-3 pb-2 space-y-2">
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-widest text-slate-500 dark:text-[#8d96a8]">
+            <CornerDownRight size={11} />
+            Then match any of (nested OR)
+          </div>
+          {group.nested.map((nestedGroup, nIdx) => (
+            <div key={nestedGroup.id} className="pl-3 border-l-2 border-sky-200 dark:border-sky-800">
+              {nIdx > 0 && (
+                <p className="mb-1 text-[11px] font-bold text-sky-500">OR</p>
+              )}
+              <ConditionGroupEditor
+                group={nestedGroup}
+                routingKeys={routingKeys}
+                canRemove={true}
+                depth={1}
+                onChange={(updated) =>
+                  onChange({ ...group, nested: group.nested.map((n) => (n.id === nestedGroup.id ? updated : n)) })
+                }
+                onRemove={() =>
+                  onChange({ ...group, nested: group.nested.filter((n) => n.id !== nestedGroup.id) })
+                }
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Group-level actions only — "Add condition" lives with the conditions above. */}
+      {depth === 0 && (
+        <div className="flex flex-wrap items-center gap-4 border-t border-slate-100 px-4 py-2.5 dark:border-[#1c1c24]">
+          {depth === 0 && (
+            <button
+              type="button"
+              onClick={addNestedBranch}
+              className="flex items-center gap-1 text-[13px] font-medium text-brand-600 transition-colors hover:text-brand-700 dark:text-brand-400"
+            >
+              <CornerDownRight size={13} /> Add nested branch
+            </button>
+          )}
+          {canRemove && (
+            <button
+              type="button"
+              onClick={onRemove}
+              className="ml-auto flex items-center gap-1 text-[13px] font-medium text-red-500 transition-colors hover:text-red-600"
+            >
+              <Trash2 size={13} /> Remove group
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const OUTPUT_TYPE_LABELS: Record<string, string> = {
+  priority: 'Priority',
+  volume_split: 'Volume Split',
+}
+
+// ---- Rule block ----
+export function RuleBlockEditor({
+  block,
+  index,
+  onChange,
+  onRemove,
+  routingKeys,
+  gatewaySuggestions = [],
+}: {
+  block: RuleBlock
+  index?: number
+  onChange: (b: RuleBlock) => void
+  onRemove: () => void
+  routingKeys: Record<string, RoutingKeyConfig>
+  gatewaySuggestions?: string[]
+}) {
+  const [collapsed, setCollapsed] = useState(false)
+
+  function addGroup() {
+    onChange({ ...block, statements: [...block.statements, createStatementGroup(routingKeys)] })
+  }
+
+  return (
+    <div className="border border-slate-200 dark:border-[#1c1c24] rounded-xl overflow-hidden">
+      {/* Header — clicking anywhere on it collapses the block, except the name field and the
+          action buttons, which stop the click from reaching it. */}
+      <div
+        onClick={() => setCollapsed(!collapsed)}
+        className="flex cursor-pointer items-center justify-between gap-3 border-b border-slate-200 bg-slate-50 px-5 py-3 dark:border-[#1c1c24] dark:bg-[#111118]"
+      >
+        <div className="flex min-w-0 flex-1 items-baseline gap-2">
+          <input
+            value={block.name}
+            onChange={(e) => onChange({ ...block, name: e.target.value })}
+            onClick={(e) => e.stopPropagation()}
+            placeholder="Rule name"
+            className="input-bare min-w-0 max-w-[16rem] flex-1 cursor-text text-[15px] font-semibold text-slate-800 focus:outline-none dark:text-slate-100"
+          />
+          {/* Rules are evaluated top-down, so the first match wins — say so where it matters. */}
+          <span className="shrink-0 truncate text-xs text-slate-400 dark:text-[#6d7a8d]">
+            {index === 0 ? '(Highest priority matching check)' : index !== undefined ? `(Checked if rule ${index} does not match)` : ''}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <button type="button" onClick={(e) => { e.stopPropagation(); onRemove() }} aria-label="Delete rule" className="text-red-400 transition-colors hover:text-red-600">
+            <Trash2 size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setCollapsed(!collapsed) }}
+            aria-label={collapsed ? 'Expand rule' : 'Collapse rule'}
+            className="text-slate-400 transition-colors hover:text-slate-600"
+          >
+            {collapsed ? <ChevronDown size={15} /> : <ChevronUp size={15} />}
+          </button>
+        </div>
+      </div>
+
+      {!collapsed && (
+        <div className="divide-y divide-slate-100 dark:divide-[#1c1c24]">
+          {/* IF section */}
+          <div className="space-y-2.5 px-5 py-5">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-[#8d96a8]">If</p>
+            {block.statements.map((group, idx) => (
+              <div key={group.id} className="space-y-2">
+                {idx > 0 && (
+                  <div className="flex items-center gap-3">
+                    <span className="h-px flex-1 bg-slate-200 dark:bg-[#222]" />
+                    <span className="text-[11px] font-bold uppercase tracking-widest text-sky-500 px-1">or</span>
+                    <span className="h-px flex-1 bg-slate-200 dark:bg-[#222]" />
+                  </div>
+                )}
+                <ConditionGroupEditor
+                  group={group}
+                  routingKeys={routingKeys}
+                  canRemove={block.statements.length > 1}
+                  onChange={(updated) =>
+                    onChange({ ...block, statements: block.statements.map((s) => (s.id === group.id ? updated : s)) })
+                  }
+                  onRemove={() =>
+                    onChange({ ...block, statements: block.statements.filter((s) => s.id !== group.id) })
+                  }
+                />
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addGroup}
+              className="mt-1 flex items-center gap-1 text-[13px] font-medium text-brand-600 transition-colors hover:text-brand-700 dark:text-brand-400"
+            >
+              <Plus size={13} /> Add OR group
+            </button>
+          </div>
+
+          {/* THEN section */}
+          <div data-cy="then-section" className="px-5 py-5">
+            <div className="mb-3 flex items-center gap-3">
+              <p className="shrink-0 text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-[#8d96a8]">Then route</p>
+              <div className="flex overflow-hidden rounded-lg border border-slate-200 text-xs dark:border-[#222226]">
+                {Object.keys(OUTPUT_TYPE_LABELS).map((type) => (
+                  <button
+                    key={type}
+                    type="button"
+                    onClick={() => onChange({ ...block, outputType: type as RuleBlock['outputType'] })}
+                    className={`px-2.5 py-1 transition-colors ${
+                      block.outputType === type
+                        ? 'bg-brand-500 text-white font-semibold'
+                        : 'text-slate-500 hover:bg-slate-100 dark:hover:bg-[#1c1c24]'
+                    }`}
+                  >
+                    {OUTPUT_TYPE_LABELS[type]}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {block.outputType === 'priority' && (
+              <PriorityEditor
+                gateways={block.priorityGateways}
+                suggestions={gatewaySuggestions}
+                onChange={(gws) => onChange({ ...block, priorityGateways: gws })}
+              />
+            )}
+            {block.outputType === 'volume_split' && (
+              <VolumeSplitEditor
+                entries={block.volumeSplitEntries}
+                suggestions={gatewaySuggestions}
+                onChange={(entries) => onChange({ ...block, volumeSplitEntries: entries })}
+              />
+            )}
+            {block.outputType === 'volume_split_priority' && (
+              <VolumeSplitPriorityEditor
+                entries={block.volumeSplitPriorityEntries}
+                suggestions={gatewaySuggestions}
+                onChange={(entries) => onChange({ ...block, volumeSplitPriorityEntries: entries })}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/website/src/components/routing/volumeSplit/SplitBreakdown.tsx
+++ b/website/src/components/routing/volumeSplit/SplitBreakdown.tsx
@@ -1,0 +1,77 @@
+import { VolumeSplitGatewayFormEntry } from '../../../features/routing/volumeSplit/types'
+
+/** Slot colours, indexed by position so a gateway keeps its colour across the editor and the bar. */
+export const SPLIT_COLORS = ['#0069ED', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899']
+
+/**
+ * How a volume-split rule divides traffic, drawn once for every surface that shows it — the
+ * expanded row on the rules list and the builder's live rail.
+ *
+ * Part-to-whole with long, variable-length category names, so it is a horizontal 100% bar with the
+ * names in a legend beneath. Pie labels for these would overflow their container.
+ */
+export function SplitBreakdown({ gateways }: { gateways: VolumeSplitGatewayFormEntry[] }) {
+  const named = gateways.filter((g) => g.gatewayName.trim())
+  if (named.length === 0) {
+    return (
+      <p className="text-[13px] text-slate-400 dark:text-[#6d7a8d]">
+        No gateways yet — add at least one to split traffic across.
+      </p>
+    )
+  }
+
+  const total = named.reduce((sum, g) => sum + g.split, 0)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex h-3 w-full gap-[2px] overflow-hidden rounded-full">
+        {named.map((g, i) => (
+          <div
+            key={g.id}
+            className="h-full"
+            style={{
+              // flex-grow rather than width, so the 2px gaps come out of the available space
+              // instead of pushing the last segment past the rounded clip.
+              flex: `${total > 0 ? g.split : 1} 1 0`,
+              backgroundColor: SPLIT_COLORS[i % SPLIT_COLORS.length],
+            }}
+            title={`${g.gatewayName}: ${g.split}%`}
+          />
+        ))}
+      </div>
+
+      <div className="space-y-1.5">
+        {named.map((g, i) => (
+          <div key={g.id} className="flex items-center gap-2 text-xs">
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: SPLIT_COLORS[i % SPLIT_COLORS.length] }}
+            />
+            <span className="min-w-0 truncate font-medium text-slate-700 dark:text-slate-200" title={g.gatewayName}>
+              {g.gatewayName}
+            </span>
+            {g.gatewayId && (
+              <span
+                className="min-w-0 truncate font-mono text-[11px] text-slate-400 dark:text-[#6d7a8d]"
+                title={g.gatewayId}
+              >
+                {g.gatewayId}
+              </span>
+            )}
+            <span className="ml-auto shrink-0 pl-2 font-semibold tabular-nums text-slate-700 dark:text-slate-200">
+              {g.split}%
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* A split that misses 100% silently drops or double-counts traffic, so surface it wherever
+          the distribution is shown — not just in the editor. */}
+      {total !== 100 && (
+        <p className="text-[11px] font-medium text-amber-600 dark:text-amber-400">
+          Splits total {total}% — must add up to 100%.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/website/src/components/ui/RuleCodeEditor.tsx
+++ b/website/src/components/ui/RuleCodeEditor.tsx
@@ -99,7 +99,7 @@ function condToDSL(c: ConditionRow): string {
 }
 
 /**
- * One nested branch. Its conditions are ANDed together and the branches are ORed, so a branch with
+ * One nested branch. Its conditions are joined with AND and the branches with OR, so a branch with
  * more than one condition gets its own brackets — `a and b or c` would otherwise read as a
  * different rule than the interpreter evaluates.
  */

--- a/website/src/components/ui/RuleCodeEditor.tsx
+++ b/website/src/components/ui/RuleCodeEditor.tsx
@@ -98,6 +98,16 @@ function condToDSL(c: ConditionRow): string {
   return `${lhsPart} ${DSL_OP_TO_SYM[c.operator] ?? c.operator} ${c.value}`
 }
 
+/**
+ * One nested branch. Its conditions are ANDed together and the branches are ORed, so a branch with
+ * more than one condition gets its own brackets — `a and b or c` would otherwise read as a
+ * different rule than the interpreter evaluates.
+ */
+function nestedToDSL(n: StatementGroup): string {
+  const text = n.conditions.map(condToDSL).join(' and ')
+  return n.conditions.length > 1 ? `(${text})` : text
+}
+
 function stmtToDSLLines(stmt: StatementGroup): string[] {
   const lines: string[] = []
   if (stmt.conditions.length === 0 && stmt.nested.length > 0) {
@@ -107,14 +117,13 @@ function stmtToDSLLines(stmt: StatementGroup): string[] {
       : promoted.length === 1 ? condToDSL(promoted[0]) : '')
     const remaining = stmt.nested.slice(1)
     if (remaining.length > 0) {
-      lines.push(`and (${remaining.map(n => n.conditions.map(condToDSL).join(' and ')).join(' or ')})`)
+      lines.push(`and (${remaining.map(nestedToDSL).join(' or ')})`)
     }
     return lines.filter(Boolean)
   }
   stmt.conditions.forEach((c, i) => lines.push(i === 0 ? condToDSL(c) : `and ${condToDSL(c)}`))
   if (stmt.nested.length > 0) {
-    const inner = stmt.nested.map(n => n.conditions.map(condToDSL).join(' and ')).join(' or ')
-    lines.push(`and (${inner})`)
+    lines.push(`and (${stmt.nested.map(nestedToDSL).join(' or ')})`)
   }
   return lines
 }

--- a/website/src/components/ui/SearchableMultiSelect.tsx
+++ b/website/src/components/ui/SearchableMultiSelect.tsx
@@ -59,13 +59,26 @@ export function SearchableMultiSelect({
     function onOutside(e: MouseEvent) {
       const target = e.target as Node
       if (!triggerRef.current?.contains(target) && !dropdownRef.current?.contains(target)) {
-        setOpen(false)
-        setQuery('')
+        close()
       }
     }
+    // Listens on the document rather than the search input: focus moves to an option button as soon
+    // as one is toggled, and Escape has to close the list from there too.
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') close()
+    }
     document.addEventListener('mousedown', onOutside)
-    return () => document.removeEventListener('mousedown', onOutside)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onOutside)
+      document.removeEventListener('keydown', onKey)
+    }
   }, [open])
+
+  function close() {
+    setOpen(false)
+    setQuery('')
+  }
 
   function toggle(val: string) {
     onChange(values.includes(val) ? values.filter(v => v !== val) : [...values, val])
@@ -80,7 +93,7 @@ export function SearchableMultiSelect({
     <div className={`relative ${className}`}>
       <div
         ref={triggerRef}
-        onClick={() => open ? (setOpen(false), setQuery('')) : openDropdown()}
+        onClick={() => (open ? close() : openDropdown())}
         className="flex w-full min-w-0 cursor-pointer flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm dark:border-[#222226]"
       >
         {values.length === 0 && (
@@ -122,7 +135,6 @@ export function SearchableMultiSelect({
               type="text"
               value={query}
               onChange={e => setQuery(e.target.value)}
-              onKeyDown={e => e.key === 'Escape' && (setOpen(false), setQuery(''))}
               placeholder="Search…"
               className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0f0f11]"
             />

--- a/website/src/components/ui/SearchableMultiSelect.tsx
+++ b/website/src/components/ui/SearchableMultiSelect.tsx
@@ -81,7 +81,7 @@ export function SearchableMultiSelect({
       <div
         ref={triggerRef}
         onClick={() => open ? (setOpen(false), setQuery('')) : openDropdown()}
-        className="flex min-w-[8rem] cursor-pointer flex-wrap items-center gap-1 rounded-lg border border-slate-200 dark:border-[#222226] bg-transparent px-2 py-1 text-xs"
+        className="flex w-full min-w-0 cursor-pointer flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm dark:border-[#222226]"
       >
         {values.length === 0 && (
           <span className="text-slate-400">{placeholder}</span>
@@ -114,7 +114,7 @@ export function SearchableMultiSelect({
         <div
           ref={dropdownRef}
           style={dropdownStyle}
-          className="w-max max-w-[240px] rounded-lg border border-slate-200 dark:border-[#222226] bg-white dark:bg-[#111118] shadow-lg"
+          className="w-max min-w-[13rem] max-w-[320px] rounded-lg border border-slate-200 dark:border-[#222226] bg-white dark:bg-[#111118] shadow-lg"
         >
           <div className="border-b border-slate-100 dark:border-[#1c1c24] p-1.5">
             <input
@@ -124,12 +124,12 @@ export function SearchableMultiSelect({
               onChange={e => setQuery(e.target.value)}
               onKeyDown={e => e.key === 'Escape' && (setOpen(false), setQuery(''))}
               placeholder="Search…"
-              className="w-full rounded bg-slate-50 dark:bg-[#0f0f11] border border-slate-200 dark:border-[#222226] px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0f0f11]"
             />
           </div>
           <div className="max-h-52 overflow-y-auto py-0.5">
             {filtered.length === 0 ? (
-              <p className="px-3 py-2 text-xs text-slate-400">No matches</p>
+              <p className="px-3 py-2.5 text-sm text-slate-400">No matches</p>
             ) : (
               filtered.map(o => {
                 const checked = values.includes(o.value)
@@ -139,7 +139,7 @@ export function SearchableMultiSelect({
                     type="button"
                     data-value={o.value}
                     onClick={() => toggle(o.value)}
-                    className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-slate-50 dark:hover:bg-[#1c1c24] ${checked ? 'text-brand-600 dark:text-brand-400' : 'text-slate-700 dark:text-[#c8d0de]'}`}
+                    className={`flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm transition-colors hover:bg-slate-50 dark:hover:bg-[#1c1c24] ${checked ? 'text-brand-600 dark:text-brand-400' : 'text-slate-700 dark:text-[#c8d0de]'}`}
                   >
                     <span className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border ${checked ? 'border-brand-500 bg-brand-500 text-white' : 'border-slate-300 dark:border-[#3a4258]'}`}>
                       {checked && (

--- a/website/src/components/ui/SearchableSelect.tsx
+++ b/website/src/components/ui/SearchableSelect.tsx
@@ -69,8 +69,17 @@ export function SearchableSelect({
         close()
       }
     }
+    // Listens on the document rather than the search input, so Escape still closes the list once
+    // focus has moved off the input.
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') close()
+    }
     document.addEventListener('mousedown', onOutside)
-    return () => document.removeEventListener('mousedown', onOutside)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onOutside)
+      document.removeEventListener('keydown', onKey)
+    }
   }, [open])
 
   function close() {
@@ -113,7 +122,6 @@ export function SearchableSelect({
               type="text"
               value={query}
               onChange={e => setQuery(e.target.value)}
-              onKeyDown={e => e.key === 'Escape' && close()}
               placeholder="Search…"
               className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0f0f11]"
             />

--- a/website/src/components/ui/SearchableSelect.tsx
+++ b/website/src/components/ui/SearchableSelect.tsx
@@ -84,17 +84,17 @@ export function SearchableSelect({
   }
 
   return (
-    <div className={`relative inline-block ${className}`} data-cy={dataCy}>
+    <div className={`relative ${className || 'inline-block'}`} data-cy={dataCy}>
       <button
         ref={triggerRef}
         type="button"
         disabled={disabled}
         onClick={() => open ? close() : openDropdown()}
-        className="cond-select flex items-center gap-1 pr-2"
+        className="cond-select flex w-full items-center justify-between gap-1 pr-2"
         style={{ backgroundImage: 'none', display: 'flex', alignItems: 'center' }}
         data-value={value}
       >
-        <span className="truncate max-w-[10rem]">{selectedLabel || <span className="text-slate-400">select...</span>}</span>
+        <span className="min-w-0 truncate text-left">{selectedLabel || <span className="text-slate-400">select...</span>}</span>
         <ChevronDown
           size={11}
           className={`shrink-0 text-slate-400 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
@@ -105,7 +105,7 @@ export function SearchableSelect({
         <div
           ref={dropdownRef}
           style={dropdownStyle}
-          className="w-max max-w-[240px] rounded-lg border border-slate-200 dark:border-[#222226] bg-white dark:bg-[#111118] shadow-lg"
+          className="w-max min-w-[13rem] max-w-[320px] rounded-lg border border-slate-200 dark:border-[#222226] bg-white dark:bg-[#111118] shadow-lg"
         >
           <div className="p-1.5 border-b border-slate-100 dark:border-[#1c1c24]">
             <input
@@ -115,7 +115,7 @@ export function SearchableSelect({
               onChange={e => setQuery(e.target.value)}
               onKeyDown={e => e.key === 'Escape' && close()}
               placeholder="Search…"
-              className="w-full rounded px-2 py-1 text-xs bg-slate-50 dark:bg-[#0f0f11] border border-slate-200 dark:border-[#222226] focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-[#222226] dark:bg-[#0f0f11]"
             />
           </div>
           <div
@@ -123,7 +123,7 @@ export function SearchableSelect({
             style={{ maxHeight: `${Math.min(filtered.length * 32 + 8, 272)}px` }}
           >
             {filtered.length === 0 ? (
-              <p className="px-3 py-2 text-xs text-slate-400">No matches</p>
+              <p className="px-3 py-2.5 text-sm text-slate-400">No matches</p>
             ) : (
               filtered.map(o => (
                 <button
@@ -131,7 +131,7 @@ export function SearchableSelect({
                   type="button"
                   data-value={o.value}
                   onClick={() => select(o.value)}
-                  className={`w-full text-left px-3 py-2 text-xs transition-colors hover:bg-slate-50 dark:hover:bg-[#1c1c24] ${
+                  className={`w-full px-3 py-2.5 text-left text-sm transition-colors hover:bg-slate-50 dark:hover:bg-[#1c1c24] ${
                     o.value === value
                       ? 'text-brand-600 dark:text-brand-400 font-medium bg-brand-50/50 dark:bg-brand-900/10'
                       : ''

--- a/website/src/components/ui/TableControls.tsx
+++ b/website/src/components/ui/TableControls.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { ChevronDown, Search, Check, X, MoreVertical, type LucideIcon } from 'lucide-react'
+
+/**
+ * A column header that doubles as its own filter. `all` is the unfiltered state; any other value
+ * renders in the header itself so a narrowed table always says why it is short.
+ */
+export function HeaderFilter({
+  label,
+  value,
+  options,
+  onChange,
+  ariaLabel,
+}: {
+  label: string
+  value: string
+  options: { value: string; label: string }[]
+  onChange: (value: string) => void
+  ariaLabel: string
+}) {
+  const [open, setOpen] = useState(false)
+  const isFiltered = value !== 'all'
+  const current = options.find((o) => o.value === value)
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={`inline-flex items-center gap-1 rounded uppercase tracking-wide transition-colors ${
+          isFiltered
+            ? 'text-brand-600 dark:text-brand-400'
+            : 'text-slate-400 hover:text-slate-600 dark:text-[#4e5870] dark:hover:text-[#8d96a8]'
+        }`}
+      >
+        {isFiltered ? `${label}: ${current?.label ?? value}` : label}
+        <ChevronDown size={13} className="shrink-0" />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute left-0 top-full z-20 mt-1.5 max-h-64 min-w-[170px] overflow-y-auto rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-[#2a303a] dark:bg-[#11151d]">
+            {options.map((o) => (
+              <button
+                key={o.value}
+                type="button"
+                onClick={() => { onChange(o.value); setOpen(false) }}
+                className={`flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-xs normal-case tracking-normal transition-colors hover:bg-slate-50 dark:hover:bg-[#1c2030] ${
+                  o.value === value
+                    ? 'font-semibold text-brand-600 dark:text-brand-400'
+                    : 'text-slate-600 dark:text-slate-300'
+                }`}
+              >
+                <span className="truncate">{o.label}</span>
+                {o.value === value && <Check size={12} className="shrink-0" />}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+/** The name column's header, which swaps its label for a filter input on demand. */
+export function HeaderSearch({
+  label,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  ariaLabel: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  if (!open && !value) {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1 uppercase tracking-wide text-slate-400 transition-colors hover:text-slate-600 dark:text-[#4e5870] dark:hover:text-[#8d96a8]"
+      >
+        {label}
+        <Search size={13} className="shrink-0" />
+      </button>
+    )
+  }
+
+  return (
+    // The input itself is the field: the global input styling in index.css already gives it a
+    // border, radius and focus ring, so a bordered wrapper would draw a second outline around it.
+    // The icons sit on top of the single input instead.
+    <div className="relative w-[240px] max-w-full">
+      <Search
+        size={14}
+        className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400"
+      />
+      <input
+        autoFocus
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Filter by name or ID"
+        aria-label={ariaLabel}
+        className="w-full rounded-lg border border-slate-200 bg-white py-1.5 pl-8 pr-8 text-sm font-normal normal-case tracking-normal text-slate-800 placeholder:text-slate-400 focus:border-brand-500 dark:border-[#2a303a] dark:bg-[#0d1018] dark:text-slate-100 dark:placeholder:text-[#5b6577]"
+      />
+      <button
+        type="button"
+        aria-label="Clear name filter"
+        onClick={() => { onChange(''); setOpen(false) }}
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 transition-colors hover:text-slate-700 dark:hover:text-slate-200"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  )
+}
+
+export type RowMenuItem = {
+  label: string
+  icon: LucideIcon
+  onSelect: () => void
+  disabled?: boolean
+  /** Why the item is unavailable — shown in place of the label's hover title. */
+  hint?: string
+  tone?: 'default' | 'positive' | 'danger'
+}
+
+/**
+ * Per-row action menu.
+ *
+ * The panel is portalled and positioned from the trigger's rect rather than absolutely placed:
+ * the table lives in an `overflow-x-auto` wrapper, and once one axis is not `visible` the other
+ * computes to `auto`, so an in-flow dropdown would be clipped by the scroll container.
+ */
+export function RowMenu({ items }: { items: RowMenuItem[] }) {
+  const [open, setOpen] = useState(false)
+  const [style, setStyle] = useState<React.CSSProperties>({})
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onOutside(e: MouseEvent) {
+      const target = e.target as Node
+      if (!triggerRef.current?.contains(target) && !panelRef.current?.contains(target)) setOpen(false)
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    // A menu anchored to a rect goes stale the moment anything moves underneath it.
+    function onReflow() { setOpen(false) }
+    document.addEventListener('mousedown', onOutside)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('resize', onReflow)
+    window.addEventListener('scroll', onReflow, true)
+    return () => {
+      document.removeEventListener('mousedown', onOutside)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('resize', onReflow)
+      window.removeEventListener('scroll', onReflow, true)
+    }
+  }, [open])
+
+  function toggle() {
+    if (open) { setOpen(false); return }
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const width = 190
+    const estimatedHeight = items.length * 38 + 8
+    // Flip above the trigger when there is not room below it.
+    const flip = rect.bottom + estimatedHeight > window.innerHeight - 8
+    setStyle({
+      position: 'fixed',
+      top: flip ? Math.max(8, rect.top - estimatedHeight - 4) : rect.bottom + 4,
+      left: Math.max(8, rect.right - width),
+      width,
+      zIndex: 9999,
+    })
+    setOpen(true)
+  }
+
+  const toneClasses: Record<string, string> = {
+    default: 'text-slate-700 dark:text-slate-300',
+    positive: 'text-emerald-600 dark:text-emerald-400',
+    danger: 'text-red-600 dark:text-red-400',
+  }
+
+  return (
+    <div className="flex justify-end">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={toggle}
+        aria-label="Rule actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className={`rounded-md p-1.5 transition-colors ${
+          open
+            ? 'bg-slate-100 text-slate-700 dark:bg-[#1c2030] dark:text-white'
+            : 'text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-[#1c2030] dark:hover:text-white'
+        }`}
+      >
+        <MoreVertical size={16} />
+      </button>
+
+      {open && createPortal(
+        <div
+          ref={panelRef}
+          role="menu"
+          style={style}
+          className="overflow-hidden rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-[#2a303a] dark:bg-[#11151d]"
+        >
+          {items.map((item) => {
+            const Icon = item.icon
+            return (
+              <button
+                key={item.label}
+                type="button"
+                role="menuitem"
+                disabled={item.disabled}
+                title={item.disabled ? item.hint : undefined}
+                onClick={() => { setOpen(false); item.onSelect() }}
+                className={`flex w-full items-center gap-2.5 px-3 py-2 text-left text-[13px] font-medium transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent dark:hover:bg-[#1c2030] ${
+                  toneClasses[item.tone ?? 'default']
+                }`}
+              >
+                <Icon size={14} className="shrink-0" />
+                {item.label}
+              </button>
+            )
+          })}
+        </div>,
+        document.body
+      )}
+    </div>
+  )
+}

--- a/website/src/features/routing/euclid/describe.ts
+++ b/website/src/features/routing/euclid/describe.ts
@@ -1,0 +1,101 @@
+import { EuclidCondition, EuclidStatement, EuclidRule } from '../../../types/api'
+import { toLabel, OPERATOR_LABELS } from './state'
+
+/**
+ * The one place a rule is turned into words.
+ *
+ * Every surface that shows a rule — the list table, the expandable breakdown, the builder's
+ * summary rail — used to format it independently, and they disagreed about what nesting meant.
+ * The authority is the interpreter (`src/euclid/interpreter.rs`, `eval_if_statement`):
+ *
+ *   a statement matches when EVERY entry in `condition` matches (AND)
+ *   AND, when `nested` is present, at least ONE nested statement matches (OR)
+ *
+ * so `A, B` with nested `[C+D, E]` means `A and B and ((C and D) or E)` — not the flat
+ * `A and B and C and D or E` that a naive walk produces, which is a different rule.
+ */
+
+const API_OP_TO_WORDS: Record<string, string> = {
+  equal: 'equals',
+  not_equal: 'does not equal',
+  greater_than: 'greater than',
+  less_than: 'less than',
+  greater_than_equal: 'at least',
+  less_than_equal: 'at most',
+}
+
+function operatorWords(comparison: string, isArray: boolean): string {
+  if (isArray) return comparison === 'not_equal' ? 'is not one of' : 'is one of'
+  return API_OP_TO_WORDS[comparison] ?? OPERATOR_LABELS[comparison] ?? comparison.replace(/_/g, ' ')
+}
+
+/** Enum values arrive as raw slugs (`three_ds`); show them the way the editor does. */
+function valueWords(cond: EuclidCondition): string {
+  const wrapper = cond.value as { type?: string; value?: unknown } | undefined
+  const raw = wrapper?.value
+  const type = wrapper?.type
+
+  if (type === 'metadata_variant' && raw && typeof raw === 'object') {
+    const meta = raw as { value?: unknown }
+    return String(meta.value ?? '')
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((v) => toLabel(String(v))).join(', ')
+  }
+  if (type === 'enum_variant' || type === 'enum_variant_array') {
+    return toLabel(String(raw ?? ''))
+  }
+  return String(raw ?? '')
+}
+
+function fieldWords(cond: EuclidCondition): string {
+  const wrapper = cond.value as { type?: string; value?: unknown } | undefined
+  if (wrapper?.type === 'metadata_variant' && wrapper.value && typeof wrapper.value === 'object') {
+    const key = (wrapper.value as { key?: string }).key
+    if (key && key !== cond.lhs) return `${toLabel(cond.lhs)}.${key}`
+  }
+  return toLabel(cond.lhs)
+}
+
+/** A single clause, e.g. `Authentication Type equals Three Ds`. */
+export function describeCondition(cond: EuclidCondition): string {
+  const wrapper = cond.value as { value?: unknown } | undefined
+  const isArray = Array.isArray(wrapper?.value)
+  const value = valueWords(cond)
+  return `${fieldWords(cond)} ${operatorWords(cond.comparison, isArray)} ${value || '…'}`.trim()
+}
+
+/** True when a statement needs its own brackets to stay unambiguous inside a larger expression. */
+function isCompound(stmt: EuclidStatement): boolean {
+  const conditions = stmt.condition?.length ?? 0
+  const nested = stmt.nested?.length ?? 0
+  return conditions + (nested > 0 ? 1 : 0) > 1
+}
+
+/**
+ * A statement as a fully bracketed boolean expression. Brackets are explicit rather than implied
+ * by operator precedence, so the text cannot be misread.
+ */
+export function describeStatement(stmt: EuclidStatement): string {
+  const clauses = (stmt.condition ?? []).map((c) => `(${describeCondition(c)})`)
+  let text = clauses.join(' and ')
+
+  const nested = stmt.nested ?? []
+  if (nested.length > 0) {
+    const branches = nested
+      .map((n) => (isCompound(n) ? `(${describeStatement(n)})` : describeStatement(n)))
+      .filter(Boolean)
+      .join(' or ')
+    if (branches) text = text ? `${text} and (${branches})` : `(${branches})`
+  }
+
+  return text
+}
+
+/** A rule's whole condition set. Statements are alternatives — any one matching is enough. */
+export function describeRuleConditions(rule: EuclidRule): string {
+  const statements = (rule.statements ?? []).map(describeStatement).filter(Boolean)
+  if (statements.length === 0) return 'Always matches'
+  if (statements.length === 1) return statements[0]
+  return statements.map((s) => (s.includes(' and ') ? `(${s})` : s)).join(' or ')
+}

--- a/website/src/features/routing/euclid/state.ts
+++ b/website/src/features/routing/euclid/state.ts
@@ -1,0 +1,238 @@
+import { RoutingAlgorithm, EuclidAlgorithmData } from '../../../types/api'
+import { RoutingKeyConfig } from '../../../hooks/useDynamicRoutingConfig'
+import type {
+  RuleBlock, StatementGroup, ConditionRow, GatewayEntry,
+} from '../../../components/ui/RuleCodeEditor'
+
+export type DefaultOutput = {
+  priorityGateways: GatewayEntry[]
+}
+
+export const OPERATOR_TO_API: Record<string, string> = {
+  '==': 'equal',
+  '!=': 'not_equal',
+  '>': 'greater_than',
+  '<': 'less_than',
+  '>=': 'greater_than_equal',
+  '<=': 'less_than_equal',
+  'in': 'equal',
+  'not_in': 'not_equal',
+}
+
+export const OPERATOR_LABELS: Record<string, string> = {
+  '==': 'equals',
+  '!=': 'not equals',
+  '>': 'greater than',
+  '<': 'less than',
+  '>=': 'greater than or equal',
+  '<=': 'less than or equal',
+  'in': 'is one of',
+  'not_in': 'is not one of',
+}
+
+
+export function toLabel(key: string): string {
+  return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+
+
+export function createCondition(routingKeys: Record<string, RoutingKeyConfig>): ConditionRow {
+  const firstKey = Object.keys(routingKeys)[0] || 'payment_method'
+  const firstKeyValues = routingKeys[firstKey]?.values || []
+  return {
+    id: crypto.randomUUID(),
+    lhs: firstKey,
+    operator: '==',
+    value: firstKeyValues[0] || '',
+    metadataKey: '',
+  }
+}
+
+export function createStatementGroup(routingKeys: Record<string, RoutingKeyConfig>): StatementGroup {
+  return {
+    id: crypto.randomUUID(),
+    conditions: [createCondition(routingKeys)],
+    nested: [],
+  }
+}
+
+export function formatOp(comparison: string): string {
+  const map: Record<string, string> = {
+    equal: '=', not_equal: '≠',
+    greater_than: '>', less_than: '<',
+    greater_than_equal: '≥', less_than_equal: '≤',
+  }
+  return map[comparison] ?? comparison.replace(/_/g, ' ')
+}
+
+
+// ---- Build Euclid payload ----
+export function buildAlgorithmData(rules: RuleBlock[], defaultOutput: DefaultOutput, routingKeys: Record<string, RoutingKeyConfig>) {
+  function buildPriorityOutput(gateways: GatewayEntry[]): Record<string, unknown> {
+    return {
+      priority: gateways.map((g) => ({ gateway_name: g.gatewayName, gateway_id: g.gatewayId || null })),
+    }
+  }
+
+  function buildOutput(block: RuleBlock): Record<string, unknown> {
+    if (block.outputType === 'volume_split') {
+      return {
+        volume_split: block.volumeSplitEntries.map((e) => ({
+          split: e.split,
+          output: { gateway_name: e.gatewayName, gateway_id: e.gatewayId || null },
+        })),
+      }
+    }
+    if (block.outputType === 'volume_split_priority') {
+      return {
+        volume_split_priority: block.volumeSplitPriorityEntries.map((e) => ({
+          split: e.split,
+          output: e.gateways.map((g) => ({ gateway_name: g.gatewayName, gateway_id: g.gatewayId || null })),
+        })),
+      }
+    }
+    return buildPriorityOutput(block.priorityGateways)
+  }
+
+  function buildCondition(c: ConditionRow) {
+    const keyType = routingKeys[c.lhs]?.type
+    const isMulti = c.operator === 'in' || c.operator === 'not_in'
+
+    if (isMulti && Array.isArray(c.value)) {
+      return {
+        lhs: c.lhs,
+        comparison: OPERATOR_TO_API[c.operator],
+        value: { type: 'enum_variant_array', value: c.value },
+        metadata: {},
+      }
+    }
+
+    if (keyType === 'udf' || keyType === 'global_ref') {
+      return {
+        lhs: c.lhs,
+        comparison: OPERATOR_TO_API[c.operator] || c.operator,
+        value: {
+          type: 'metadata_variant',
+          value: { key: c.metadataKey || c.lhs, value: c.value },
+        },
+        metadata: {},
+      }
+    }
+
+    const apiValueType =
+      keyType === 'integer' ? 'number' :
+      keyType === 'str_value' ? 'str_value' :
+      'enum_variant'
+    return {
+      lhs: c.lhs,
+      comparison: OPERATOR_TO_API[c.operator] || c.operator,
+      value: {
+        type: apiValueType,
+        value: keyType === 'integer' ? Number(c.value) : c.value,
+      },
+      metadata: {},
+    }
+  }
+
+  function buildStatement(group: StatementGroup): Record<string, unknown> {
+    const statement: Record<string, unknown> = {
+      condition: group.conditions.map(buildCondition),
+      nested: group.nested.length > 0 ? group.nested.map(buildStatement) : null,
+    }
+    return statement
+  }
+
+  return {
+    globals: {},
+    default_selection: buildPriorityOutput(defaultOutput.priorityGateways),
+    rules: rules.map((r) => ({
+      name: r.name,
+      routing_type: r.outputType,
+      output: buildOutput(r),
+      statements: r.statements.map(buildStatement),
+    })),
+  }
+}
+
+// ---- Reverse-parse API → RuleBlocks ----
+const API_OPERATOR_TO_UI: Record<string, string> = {
+  equal: '==', not_equal: '!=',
+  greater_than: '>', less_than: '<',
+  greater_than_equal: '>=', less_than_equal: '<=',
+}
+
+export function parseAlgorithmToRuleBlocks(algo: RoutingAlgorithm): { ruleBlocks: RuleBlock[]; defaultOutput: DefaultOutput } {
+  const algorithm = algo.algorithm_data || algo.algorithm
+  const data = algorithm?.data as EuclidAlgorithmData | undefined
+  if (!data) return { ruleBlocks: [], defaultOutput: { priorityGateways: [] } }
+
+  function parseGateways(arr: { gateway_name: string; gateway_id?: string | null }[]): GatewayEntry[] {
+    return arr.map((g) => ({ id: crypto.randomUUID(), gatewayName: g.gateway_name, gatewayId: g.gateway_id ?? '' }))
+  }
+
+  function parseCondition(cond: { lhs: string; comparison: string; value: { type: string; value: unknown } }): ConditionRow {
+    const isArray = cond.value?.type === 'enum_variant_array'
+    const isMetadataVariant = cond.value?.type === 'metadata_variant'
+    let operator = API_OPERATOR_TO_UI[cond.comparison] ?? cond.comparison
+    if (isArray && cond.comparison === 'equal') operator = 'in'
+    if (isArray && cond.comparison === 'not_equal') operator = 'not_in'
+
+    if (isMetadataVariant) {
+      const metaVal = cond.value?.value as { key?: string; value?: unknown } | undefined
+      return {
+        id: crypto.randomUUID(),
+        lhs: String(cond.lhs),
+        operator,
+        value: String(metaVal?.value ?? ''),
+        metadataKey: String(metaVal?.key ?? cond.lhs),
+      }
+    }
+
+    const value = isArray
+      ? (Array.isArray(cond.value?.value) ? (cond.value.value as string[]) : [String(cond.value?.value)])
+      : String(cond.value?.value ?? '')
+    return { id: crypto.randomUUID(), lhs: String(cond.lhs), operator, value, metadataKey: '' }
+  }
+
+  function parseStatement(stmt: { condition: Parameters<typeof parseCondition>[0][]; nested?: typeof stmt[] }): StatementGroup {
+    return {
+      id: crypto.randomUUID(),
+      conditions: (stmt.condition ?? []).map(parseCondition),
+      nested: (stmt.nested ?? []).map(parseStatement),
+    }
+  }
+
+  const ruleBlocks: RuleBlock[] = (data.rules ?? []).map((rule) => {
+    const output = rule.output as Record<string, unknown> | undefined
+    const outputType: RuleBlock['outputType'] = rule.routing_type ?? 'priority'
+    const rawPriority = output?.priority ?? output?.data
+    const rawVolume = output?.volume_split ?? (output?.type === 'volume_split' ? output?.data : undefined)
+    const rawVolumeSplitPriority = output?.volume_split_priority
+
+    return {
+      id: crypto.randomUUID(),
+      name: rule.name || 'Cloned Rule',
+      statements: (rule.statements ?? []).map(parseStatement),
+      outputType,
+      priorityGateways: outputType === 'priority'
+        ? parseGateways((Array.isArray(rawPriority) ? rawPriority : []) as { gateway_name: string; gateway_id?: string | null }[])
+        : [],
+      volumeSplitEntries: outputType === 'volume_split'
+        ? (Array.isArray(rawVolume) ? rawVolume : []).map((e: { split: number; output: { gateway_name: string; gateway_id?: string | null } }) => ({
+            id: crypto.randomUUID(), split: e.split, gatewayName: e.output.gateway_name, gatewayId: e.output.gateway_id ?? '',
+          }))
+        : [],
+      volumeSplitPriorityEntries: outputType === 'volume_split_priority'
+        ? (Array.isArray(rawVolumeSplitPriority) ? rawVolumeSplitPriority : []).map((e: { split: number; output: { gateway_name: string; gateway_id?: string | null }[] }) => ({
+            id: crypto.randomUUID(), split: e.split, gateways: parseGateways(e.output),
+          }))
+        : [],
+    }
+  })
+
+  const defRaw = (data.default_selection || data.defaultSelection) as Record<string, unknown> | undefined
+  const defArr = (Array.isArray(defRaw?.priority) ? defRaw!.priority : Array.isArray(defRaw?.data) ? defRaw!.data : []) as { gateway_name: string; gateway_id?: string | null }[]
+
+  return { ruleBlocks, defaultOutput: { priorityGateways: parseGateways(defArr) } }
+}

--- a/website/src/features/routing/euclid/summarize.ts
+++ b/website/src/features/routing/euclid/summarize.ts
@@ -1,0 +1,125 @@
+import { RoutingAlgorithm, EuclidAlgorithmData } from '../../../types/api'
+import { describeRuleConditions } from './describe'
+
+type PriorityGateway = { gateway_name: string; gateway_id: string | null }
+type VolumeSplit = { split: number; output: { gateway_name: string } }
+type VolumeSplitPriority = { split: number; output: PriorityGateway[] }
+
+export type NormalizedRuleOutput = {
+  priorityGateways: PriorityGateway[]
+  volumeSplits: VolumeSplit[]
+  volumeSplitPriorityEntries: VolumeSplitPriority[]
+  isVolumeSplit: boolean
+  isVolumeSplitPriority: boolean
+}
+
+/**
+ * The backend returns a rule's output in one of four shapes — `{ priority: [...] }`,
+ * `{ type: 'volume_split', data: [...] }`, `{ volume_split: [...] }`, or
+ * `{ volume_split_priority: [...] }`. Every consumer needs the same flattening, so it lives here
+ * once and both the breakdown panel and the list summaries read from it.
+ */
+export function normalizeRuleOutput(rule: {
+  output?: unknown
+  routing_type?: string
+}): NormalizedRuleOutput {
+  const output = rule.output as Record<string, unknown> | undefined
+  const rawPriority = output?.priority ?? output?.data
+  const rawVolume = output?.volume_split ?? (output?.type === 'volume_split' ? output?.data : undefined)
+  const rawVolumeSplitPriority = output?.volume_split_priority
+
+  const priorityGateways = (Array.isArray(rawPriority) ? rawPriority : []) as PriorityGateway[]
+  const volumeSplits = (Array.isArray(rawVolume) ? rawVolume : []) as VolumeSplit[]
+  const volumeSplitPriorityEntries = (
+    Array.isArray(rawVolumeSplitPriority) ? rawVolumeSplitPriority : []
+  ) as VolumeSplitPriority[]
+
+  return {
+    priorityGateways,
+    volumeSplits,
+    volumeSplitPriorityEntries,
+    isVolumeSplit: rule.routing_type === 'volume_split' || volumeSplits.length > 0,
+    isVolumeSplitPriority:
+      rule.routing_type === 'volume_split_priority' || volumeSplitPriorityEntries.length > 0,
+  }
+}
+
+function algorithmData(algo: RoutingAlgorithm): EuclidAlgorithmData | undefined {
+  const algorithm = algo.algorithm_data || algo.algorithm
+  return algorithm?.data as EuclidAlgorithmData | undefined
+}
+
+/**
+ * One-line summary of a rule's conditions for the list table. Delegates to the shared formatter so
+ * the row, the expanded breakdown and the builder all describe a rule the same way.
+ */
+export function summarizeConditions(algo: RoutingAlgorithm): string {
+  const rules = algorithmData(algo)?.rules ?? []
+  if (rules.length === 0) return 'No conditions — always matches'
+
+  const text = describeRuleConditions(rules[0])
+  return rules.length > 1 ? `${text} (+${rules.length - 1} more)` : text
+}
+
+/**
+ * Where a rule sends traffic — "zift (Priority 100%)" or "Stripe (50%) / Adyen (50%)" — plus the
+ * default fallback when one is configured.
+ */
+export function summarizeDestination(algo: RoutingAlgorithm): string {
+  const data = algorithmData(algo)
+  const first = data?.rules?.[0]
+
+  let primary = ''
+  if (first) {
+    const out = normalizeRuleOutput(first)
+    if (out.isVolumeSplitPriority) {
+      primary = out.volumeSplitPriorityEntries
+        .map((e) => `${e.output?.[0]?.gateway_name ?? '?'} (${e.split}%)`)
+        .join(' / ')
+    } else if (out.isVolumeSplit) {
+      primary = out.volumeSplits
+        .map((e) => `${e.output?.gateway_name ?? '?'} (${e.split}%)`)
+        .join(' / ')
+    } else if (out.priorityGateways.length > 0) {
+      primary = `${out.priorityGateways[0].gateway_name} (Priority 100%)`
+    }
+  }
+
+  const defaultSel = data?.default_selection || data?.defaultSelection
+  const fallbackRaw = (defaultSel as { priority?: unknown; data?: unknown } | undefined)
+  const fallbackArr = (Array.isArray(fallbackRaw?.priority)
+    ? fallbackRaw!.priority
+    : Array.isArray(fallbackRaw?.data)
+    ? fallbackRaw!.data
+    : []) as PriorityGateway[]
+  const fallback = fallbackArr[0]?.gateway_name
+
+  if (!primary) return fallback ? `${fallback} (fallback only)` : 'No destination configured'
+  return fallback ? `${primary} — fallback ${fallback}` : primary
+}
+
+/** Every distinct destination gateway a rule mentions — powers the list's Gateway filter. */
+export function destinationGateways(algo: RoutingAlgorithm): string[] {
+  const data = algorithmData(algo)
+  const names = new Set<string>()
+
+  ;(data?.rules ?? []).forEach((rule) => {
+    const out = normalizeRuleOutput(rule)
+    out.priorityGateways.forEach((g) => g.gateway_name && names.add(g.gateway_name))
+    out.volumeSplits.forEach((e) => e.output?.gateway_name && names.add(e.output.gateway_name))
+    out.volumeSplitPriorityEntries.forEach((e) =>
+      (e.output ?? []).forEach((g) => g.gateway_name && names.add(g.gateway_name))
+    )
+  })
+
+  const defaultSel = data?.default_selection || data?.defaultSelection
+  const fallbackRaw = defaultSel as { priority?: unknown; data?: unknown } | undefined
+  const fallbackArr = (Array.isArray(fallbackRaw?.priority)
+    ? fallbackRaw!.priority
+    : Array.isArray(fallbackRaw?.data)
+    ? fallbackRaw!.data
+    : []) as PriorityGateway[]
+  fallbackArr.forEach((g) => g.gateway_name && names.add(g.gateway_name))
+
+  return Array.from(names)
+}

--- a/website/src/features/routing/volumeSplit/payload.ts
+++ b/website/src/features/routing/volumeSplit/payload.ts
@@ -1,4 +1,23 @@
-import { VolumeSplitRuleCreatePayload, VolumeSplitRuleFormValues } from './types'
+import { VolumeSplitAlgorithmData, VolumeSplitGatewayFormEntry, VolumeSplitRuleCreatePayload, VolumeSplitRuleFormValues } from './types'
+
+/**
+ * The `algorithm` body a volume-split rule is stored as. Shared by create and update so the two
+ * paths cannot diverge in how they encode splits.
+ */
+export function toVolumeSplitAlgorithm(
+  gateways: VolumeSplitGatewayFormEntry[]
+): VolumeSplitAlgorithmData {
+  return {
+    type: 'volume_split',
+    data: gateways.map((gateway) => ({
+      split: gateway.split,
+      output: {
+        gateway_name: gateway.gatewayName.trim(),
+        gateway_id: gateway.gatewayId.trim() || null,
+      },
+    })),
+  }
+}
 
 export function toVolumeSplitCreatePayload(
   formValues: VolumeSplitRuleFormValues,
@@ -6,19 +25,10 @@ export function toVolumeSplitCreatePayload(
 ): VolumeSplitRuleCreatePayload {
   return {
     name: formValues.ruleName.trim(),
-    description: '',
+    description: formValues.description?.trim() ?? '',
     created_by: merchantId,
     algorithm_for: 'payment',
     metadata: {},
-    algorithm: {
-      type: 'volume_split',
-      data: formValues.gateways.map((gateway) => ({
-        split: gateway.split,
-        output: {
-          gateway_name: gateway.gatewayName.trim(),
-          gateway_id: gateway.gatewayId.trim() || null,
-        },
-      })),
-    },
+    algorithm: toVolumeSplitAlgorithm(formValues.gateways),
   }
 }

--- a/website/src/features/routing/volumeSplit/types.ts
+++ b/website/src/features/routing/volumeSplit/types.ts
@@ -6,6 +6,7 @@ export interface VolumeSplitGatewayFormEntry {
 }
 
 export interface VolumeSplitRuleFormValues {
+  description?: string
   ruleName: string
   gateways: VolumeSplitGatewayFormEntry[]
 }

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -118,12 +118,16 @@
     @apply bg-slate-300 dark:bg-[#222222] rounded-full hover:bg-slate-400 dark:hover:bg-[#333333] transition-colors;
   }
 
-  /* Form elements — Dynamic override */
+  /* Form elements — Dynamic override.
+     Every declaration here has to stay overridable by a component's own utility classes, so the
+     radius is a conservative default rather than a pill, only colours transition (animating
+     `all` made focus decoration fade in and out), and nothing is `!important` — an `!important`
+     box-shadow here silently suppressed every `focus:ring-*` in the app, because Tailwind
+     implements rings as box-shadows. */
   :where(input:not([type='checkbox']):not([type='radio']):not([type='range'])),
   :where(select),
   :where(textarea) {
-    @apply bg-white dark:bg-[#0f0f11] border-slate-200 dark:border-transparent text-slate-800 dark:text-white rounded-full px-4 placeholder-slate-400 dark:placeholder-[#66666e] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-500/20 dark:focus:bg-[#151518] dark:focus:border-[#333338];
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05) !important;
+    @apply bg-white dark:bg-[#0f0f11] border-slate-200 dark:border-transparent text-slate-800 dark:text-white rounded-lg px-4 placeholder-slate-400 dark:placeholder-[#66666e] transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/20 dark:focus:bg-[#151518] dark:focus:border-[#333338];
     font-family: 'Outfit', sans-serif;
   }
 
@@ -136,12 +140,6 @@
     background-repeat: no-repeat;
     background-position: right 1rem center;
     background-size: 16px 16px;
-  }
-
-  .dark input:not([type='checkbox']):not([type='radio']):not([type='range']),
-  .dark select,
-  .dark textarea {
-    box-shadow: none !important;
   }
 
   .dark select {
@@ -184,12 +182,12 @@
   appearance: none;
   display: inline-block;
   border-radius: 0.5rem;
-  padding: 0.25rem 1.75rem 0.25rem 0.5rem;
-  font-size: 0.75rem;
-  line-height: 1rem;
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 16 16' fill='none'%3E%3Cpath d='M4 6.5L8 10.5L12 6.5' stroke='%236b7280' stroke-width='1.75' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 0.4rem center;
+  background-position: right 0.6rem center;
   background-color: transparent;
   background-size: 14px 14px;
   border: 1px solid #e2e8f0;
@@ -246,5 +244,18 @@
 
   100% {
     transform: scaleX(0.96);
+  }
+}
+
+@layer components {
+  /* An input used as an inline title rather than a form field — an editable heading. Opts out of
+     the form-element defaults above (padding, border, radius, focus ring) so it sits flush with
+     the text around it, and marks focus with a soft tint instead of an outline. */
+  .input-bare {
+    @apply border-0 bg-transparent px-0 focus:ring-0;
+  }
+
+  .input-bare:focus {
+    @apply rounded-md bg-slate-100/80 dark:bg-white/[0.06];
   }
 }


### PR DESCRIPTION
## What

Both `/routing/rules` and `/routing/volume` were a create form and a saved-rules panel crammed onto one route. Each is now a full-width **list table** plus a dedicated **builder page**, with the shared pieces extracted so the two can't drift apart.

### Rule-based routing

- List table with per-column filters (name/ID search, status, gateway), click-to-expand rule detail, and a per-row `⋮` action menu.
- Builder moves to `/routing/rules/new` and `/routing/rules/:id/edit`, adding **in-place editing** (`/routing/update`) and **deletion** (`/routing/delete`). Both endpoints reject an active algorithm, so the menu disables Edit and Delete while a rule is active rather than letting the request fail.
- The 1600-line page is broken up: editors and the breakdown panel move to `components/routing/euclid/`, payload/parse helpers to `features/routing/euclid/`.

### Volume split

- Same list/builder split at `/routing/volume/new` and `/:id/edit`, gaining **edit, duplicate and delete** — none of which the page supported before, so fixing a typo previously meant creating a replacement.
- Adds a description field and a live distribution rail to the builder.

## Bugs found along the way

- **A rule was described three different ways**, and two were wrong. Nested OR branches were flattened, so `A and B and ((C and D) or E)` rendered as `A and B and C and D or E` — a materially different rule. All surfaces now derive from one formatter written against the interpreter's semantics (`eval_if_statement`), and the DSL serialiser brackets nested groups explicitly instead of relying on operator precedence. The DSL round-trips (serialise → parse returns the same structure).
- **Stale cross-page cache.** The volume page used array-form SWR keys while the rules pages used the URL strings — separate cache entries for the same endpoints. Since activating a volume rule deactivates the active rule-based rule server-side, the rules page showed a stale `Active` badge. Keys are now shared.
- **Global input styling** in `index.css` carried an `!important` box-shadow that silently suppressed *every* `focus:ring-*` in the app (Tailwind implements rings as box-shadows), plus a `rounded-full` default and a `transition-all` that made focus decoration flash. Removing it re-enables focus rings app-wide. Adds an `.input-bare` opt-out for the three inputs used as inline titles.
- **Typed gateway names were silently dropped** unless explicitly added. Rows now commit on focus leaving the row, so Enter and the Add button are shortcuts rather than requirements.
- **The volume page's pie chart** overflowed its card with long gateway IDs; replaced with a horizontal 100% bar plus legend (palette validated for CVD separation and contrast).

## Testing

- `tsc --noEmit` clean on both the website and tests projects; `vite build` succeeds.
- Page objects share row and action-menu handling via a new `RoutingListPage`; volume split coverage grows from one journey to fourteen cases (create, auto-computed last split, activate/deactivate, active-rule lock, edit round-trip asserting the `/routing/update` payload, duplicate, delete, filters).
- The Playwright suite needs a live backend and has **not** been run here.

## Reviewer notes

- **No visual verification** was possible in this session (no browser tooling), so the light/dark pass on both pages is worth doing before merge.
- `RoutingHubPage` and `ABTestingPage` still use the old array-form SWR keys, so they retain the same staleness against these two pages. Left out of scope deliberately — worth a follow-up.
- Empty `default_selection` is still accepted by the API and evaluates to a blank gateway name; the UI now warns but does not block. Flagged, not fixed.
