### PR TITLE
fix(routing): coerce numeric literals to strings for str_value keys on rule create

### DIFF
--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -14,7 +14,10 @@ use crate::{
             RoutingDictionaryRecord, RoutingEvaluateResponse, RoutingRequest, RoutingRule,
             SrDimensionConfig, StaticRoutingAlgorithm, ELIGIBLE_DIMENSIONS,
         },
-        utils::{generate_random_id, is_valid_enum_value, validate_routing_rule},
+        utils::{
+            generate_random_id, is_valid_enum_value, normalize_rule_value_types,
+            validate_routing_rule,
+        },
     },
     types::service_configuration::{find_config_by_name, insert_config, update_config},
 };
@@ -300,7 +303,7 @@ pub async fn routing_create(
 
     // The serde message names the field that did not parse. Dropping it leaves the caller with a
     // bare 400 and nothing to act on.
-    let config: RoutingRule = serde_json::from_value(payload.clone()).map_err(|error| {
+    let mut config: RoutingRule = serde_json::from_value(payload.clone()).map_err(|error| {
         error_stack::report!(EuclidErrors::InvalidRequest(format!(
             "could not parse routing rule: {error}"
         )))
@@ -310,6 +313,10 @@ pub async fn routing_create(
     let analytics_config_name = config.name.clone();
 
     logger::debug!("Received routing config: {:?}", config);
+
+    if let Some(routing_config) = state.config.routing_config.as_ref() {
+        normalize_rule_value_types(&mut config.algorithm, routing_config);
+    }
 
     match validate_routing_rule(&config, &state.config.routing_config) {
         Ok(validation_result) => {
@@ -1152,7 +1159,7 @@ async fn ensure_routing_algorithm_inactive(
 /// Edit an existing inactive routing algorithm in place (name/description/definition). Used by the
 /// A/B Testing dashboard's Edit action. Keeps the same id so history/links remain valid.
 pub async fn update_routing_rule(
-    Json(payload): Json<crate::euclid::types::UpdateRoutingConfigRequest>,
+    Json(mut payload): Json<crate::euclid::types::UpdateRoutingConfigRequest>,
 ) -> Result<Json<RoutingDictionaryRecord>, ContainerError<EuclidErrors>> {
     let timer = API_LATENCY_HISTOGRAM
         .with_label_values(&["update_routing_rule"])
@@ -1197,6 +1204,10 @@ pub async fn update_routing_rule(
             return Err(ContainerError::from(EuclidErrors::InvalidRequest(
                 "Routing algorithm does not belong to this merchant".to_string(),
             )));
+        }
+
+        if let Some(routing_config) = state.config.routing_config.as_ref() {
+            normalize_rule_value_types(&mut payload.algorithm, routing_config);
         }
 
         let utc_date_time = time::OffsetDateTime::now_utc();

--- a/src/euclid/utils.rs
+++ b/src/euclid/utils.rs
@@ -106,6 +106,50 @@ pub fn get_keys_by_type(config: &TomlConfig) -> HashMap<String, Vec<String>> {
     result
 }
 
+/// Coerces condition values to the representation their key's configured data type expects.
+///
+/// Hyperswitch's rule migration serializes numeric-looking literals as `number` values even for
+/// keys this service declares as `str_value` (`card_bin`, `extended_card_bin`), so those rules
+/// would be rejected by [`validate_routing_rule`] and — if stored as-is — could never match at
+/// evaluation time, since the interpreter only compares `str_value` against `str_value`. Any
+/// length/regex constraints on the key still apply to the coerced string during validation.
+pub fn normalize_rule_value_types(algorithm: &mut StaticRoutingAlgorithm, config: &TomlConfig) {
+    let StaticRoutingAlgorithm::Advanced(program) = algorithm else {
+        return;
+    };
+    for rule in &mut program.rules {
+        for statement in &mut rule.statements {
+            normalize_statement_value_types(statement, config);
+        }
+    }
+}
+
+fn normalize_statement_value_types(statement: &mut IfStatement, config: &TomlConfig) {
+    for condition in &mut statement.condition {
+        normalize_condition_value_type(condition, config);
+    }
+    if let Some(nested) = &mut statement.nested {
+        for nested_statement in nested {
+            normalize_statement_value_types(nested_statement, config);
+        }
+    }
+}
+
+fn normalize_condition_value_type(condition: &mut Comparison, config: &TomlConfig) {
+    let is_str_value_key = config
+        .keys
+        .keys
+        .get(&condition.lhs)
+        .is_some_and(|key_config| key_config.data_type == KeyDataType::StrValue);
+    if !is_str_value_key {
+        return;
+    }
+
+    if let ValueType::Number(number) = &condition.value {
+        condition.value = ValueType::StrValue(number.to_string());
+    }
+}
+
 pub fn validate_routing_rule(
     rule: &RoutingRule,
     config: &Option<TomlConfig>,
@@ -511,5 +555,169 @@ pub fn validate_string_value(
         Ok(())
     } else {
         Err(errors.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::euclid::types::KeysConfig;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn key_config(data_type: KeyDataType) -> KeyConfig {
+        KeyConfig {
+            data_type,
+            values: None,
+            min_value: None,
+            max_value: None,
+            min_length: None,
+            max_length: None,
+            exact_length: None,
+            regex: None,
+        }
+    }
+
+    fn routing_config() -> TomlConfig {
+        let mut keys = BTreeMap::new();
+        keys.insert(
+            "card_bin".to_string(),
+            KeyConfig {
+                exact_length: Some(6),
+                regex: Some("^[0-9]{6}$".to_string()),
+                ..key_config(KeyDataType::StrValue)
+            },
+        );
+        keys.insert(
+            "extended_card_bin".to_string(),
+            KeyConfig {
+                exact_length: Some(8),
+                regex: Some("^[0-9]{8}$".to_string()),
+                ..key_config(KeyDataType::StrValue)
+            },
+        );
+        keys.insert("amount".to_string(), key_config(KeyDataType::Integer));
+        TomlConfig {
+            keys: KeysConfig { keys },
+        }
+    }
+
+    /// A rule in the shape Hyperswitch's migration sends: BIN conditions carrying `number`
+    /// literals for keys this service declares as `str_value`.
+    fn migrated_rule(card_bin_value: serde_json::Value) -> RoutingRule {
+        serde_json::from_value(json!({
+            "name": "migrated rule",
+            "created_by": "merchant_1",
+            "algorithm": {
+                "type": "advanced",
+                "data": {
+                    "globals": {},
+                    "default_selection": {
+                        "priority": [{"gateway_name": "stripe", "gateway_id": null}]
+                    },
+                    "metadata": null,
+                    "rules": [{
+                        "name": "rule_1",
+                        "routing_type": "priority",
+                        "output": {"priority": [{"gateway_name": "adyen", "gateway_id": null}]},
+                        "statements": [{
+                            "condition": [
+                                {
+                                    "lhs": "card_bin",
+                                    "comparison": "equal",
+                                    "value": card_bin_value,
+                                    "metadata": {}
+                                },
+                                {
+                                    "lhs": "amount",
+                                    "comparison": "greater_than",
+                                    "value": {"type": "number", "value": 100},
+                                    "metadata": {}
+                                }
+                            ],
+                            "nested": [{
+                                "condition": [{
+                                    "lhs": "extended_card_bin",
+                                    "comparison": "equal",
+                                    "value": {"type": "number", "value": 41111111u64},
+                                    "metadata": {}
+                                }],
+                                "nested": null
+                            }]
+                        }]
+                    }]
+                }
+            }
+        }))
+        .expect("migrated rule payload should deserialize")
+    }
+
+    #[test]
+    fn normalize_coerces_numbers_to_strings_for_str_value_keys() {
+        let mut rule = migrated_rule(json!({"type": "number", "value": 411111}));
+
+        normalize_rule_value_types(&mut rule.algorithm, &routing_config());
+
+        let StaticRoutingAlgorithm::Advanced(program) = &rule.algorithm else {
+            panic!("expected advanced algorithm");
+        };
+        let statement = &program.rules[0].statements[0];
+        assert_eq!(
+            statement.condition[0].value,
+            ValueType::StrValue("411111".to_string())
+        );
+        // Integer-typed keys keep their numeric values.
+        assert_eq!(statement.condition[1].value, ValueType::Number(100));
+        // Nested statements are normalized too.
+        let nested = statement.nested.as_ref().expect("nested statements");
+        assert_eq!(
+            nested[0].condition[0].value,
+            ValueType::StrValue("41111111".to_string())
+        );
+    }
+
+    #[test]
+    fn migrated_rule_with_numeric_bins_passes_validation_after_normalization() {
+        let mut rule = migrated_rule(json!({"type": "number", "value": 411111}));
+        let config = Some(routing_config());
+
+        let before = validate_routing_rule(&rule, &config).expect("validation should run");
+        assert!(!before.is_valid);
+        assert!(before
+            .to_error_message()
+            .contains("expected str_value, got number"));
+
+        normalize_rule_value_types(&mut rule.algorithm, config.as_ref().expect("config"));
+
+        let after = validate_routing_rule(&rule, &config).expect("validation should run");
+        assert!(after.is_valid, "unexpected errors: {:?}", after.errors);
+    }
+
+    #[test]
+    fn coerced_values_are_still_checked_against_key_constraints() {
+        // A 5-digit BIN is invalid regardless of representation; coercion must not mask that.
+        let mut rule = migrated_rule(json!({"type": "number", "value": 41111}));
+        let config = Some(routing_config());
+
+        normalize_rule_value_types(&mut rule.algorithm, config.as_ref().expect("config"));
+
+        let result = validate_routing_rule(&rule, &config).expect("validation should run");
+        assert!(!result.is_valid);
+        assert!(result.to_error_message().contains("expected 6 characters"));
+    }
+
+    #[test]
+    fn normalize_leaves_str_value_conditions_untouched() {
+        let mut rule = migrated_rule(json!({"type": "str_value", "value": "411111"}));
+
+        normalize_rule_value_types(&mut rule.algorithm, &routing_config());
+
+        let StaticRoutingAlgorithm::Advanced(program) = &rule.algorithm else {
+            panic!("expected advanced algorithm");
+        };
+        assert_eq!(
+            program.rules[0].statements[0].condition[0].value,
+            ValueType::StrValue("411111".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Problem

Hyperswitch's migrate API fails against this service with:

```
Insertion error: Routing events error: Field validation failed: Invalid key 'card_bin': expected str_value, got number, status code: 400
Insertion error: Routing events error: Field validation failed: Invalid key 'extended_card_bin': expected str_value, got number, status code: 400
```

The rules being migrated are legacy euclid programs stored in HS whose BIN conditions carry **number** literals (`card_bin = 411111`), while this service's routing config declares `card_bin` / `extended_card_bin` as `str_value` keys. `validate_condition` therefore rejects the rule and `routing_create` returns 400, failing the whole migration for the merchant.

Even if validation were merely relaxed, storing the rule as-is would be worse: the interpreter only compares `StrValue` against `StrValue`, so a `Number`-valued `card_bin` condition would error (or never match) on every `/routing/evaluate` call.

## Fix

Add `normalize_rule_value_types` (src/euclid/utils.rs): walks an `Advanced` program's statements (including nested ones) and coerces `ValueType::Number` → `ValueType::StrValue` for any condition whose key is configured as `str_value`. Values for other key types are untouched.

Wired in before validation in `routing_create` and before persisting in `update_routing_rule`, so migrated rules are both accepted and stored in the representation the interpreter evaluates.

Key constraints still apply to the coerced string — a 5-digit `card_bin` (as `41111`) is still rejected by the `exact_length = 6` / regex checks with a clear message.

## Tests

4 new unit tests in `src/euclid/utils.rs` exercising the exact migrated-payload wire shape:
- numbers coerced for `str_value` keys, including nested statements; integer keys untouched
- migrated rule fails validation before normalization, passes after
- coerced values still checked against length/regex constraints
- already-string values pass through unchanged

`cargo test --no-default-features --features postgres euclid` — 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #399
