### PR TITLE
fix(routing): answer evaluate with the fallback when no rule is active

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -86,6 +86,15 @@ jobs:
         with:
           toolchain: "${{ env.rust_version }}"
 
+      - name: Install native deps for rdkafka
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libcurl4-openssl-dev \
+            libsasl2-dev \
+            zlib1g-dev
+
       - uses: Swatinem/rust-cache@v2.7.7
         with:
           save-if: ${{ github.event_name == 'push' }}

--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -550,6 +550,94 @@ async fn fetch_algorithm_from_db_and_cache(
     Ok(algorithm)
 }
 
+/// Response for a profile whose rules are all deactivated: the fallback the caller supplied,
+/// echoed back under a status that says the engine answered and has no rule to apply. The
+/// caller can then route by its fallback instead of guessing from a failed evaluation.
+fn no_active_algorithm_response(
+    payload: &RoutingRequest,
+    request_id: Option<String>,
+    global_request_id: Option<String>,
+    trace_id: Option<String>,
+) -> RoutingEvaluateResponse {
+    let fallback = payload.fallback_output.clone().unwrap_or_default();
+    let output = Output::Priority(fallback.clone());
+
+    let response = RoutingEvaluateResponse {
+        payment_id: payload.payment_id.clone(),
+        status: "no_active_algorithm".to_string(),
+        output: format_output(&output),
+        evaluated_output: fallback.clone(),
+        eligible_connectors: fallback,
+    };
+
+    crate::analytics::DomainAnalyticsEvent::record_rule_evaluation_preview(
+        crate::analytics::AnalyticsFlowContext::new(
+            crate::analytics::ApiFlow::RuleBasedRouting,
+            crate::analytics::FlowType::RoutingEvaluatePreview,
+        ),
+        Some(payload.created_by.clone()),
+        payload.payment_id.clone(),
+        preview_gateway(&response),
+        None,
+        Some(response.status.clone()),
+        serialize_routing_evaluate_analytics_details(payload, &response, None),
+        request_id,
+        global_request_id,
+        trace_id,
+    );
+
+    response
+}
+
+/// Whether the profile has any routing rule at all, scoped the same way the active-mapper
+/// lookup is. Separates a profile that deactivated its rules from one the engine has never
+/// been given any -- the two are indistinguishable from the mapper miss alone, but callers
+/// must treat them oppositely: the first is an authoritative "no rule", the second means the
+/// engine simply has nothing to say about this profile.
+async fn profile_has_any_routing_rule(
+    state: &crate::app::TenantAppState,
+    created_by: &str,
+    algorithm_for: Option<&str>,
+) -> bool {
+    let existing = match algorithm_for {
+        Some(algorithm_for) => {
+            crate::generics::generic_find_one_optional::<
+                <RoutingAlgorithm as HasTable>::Table,
+                _,
+                RoutingAlgorithm,
+            >(
+                &state.db,
+                dsl::created_by
+                    .eq(created_by.to_string())
+                    .and(dsl::algorithm_for.eq(algorithm_for.to_string())),
+            )
+            .await
+        }
+        None => {
+            crate::generics::generic_find_one_optional::<
+                <RoutingAlgorithm as HasTable>::Table,
+                _,
+                RoutingAlgorithm,
+            >(&state.db, dsl::created_by.eq(created_by.to_string()))
+            .await
+        }
+    };
+
+    match existing {
+        Ok(found) => found.is_some(),
+        Err(error) => {
+            // Reported as "no rules", which routes the caller down the error path it already
+            // took before this check existed.
+            logger::error!(
+                ?error,
+                created_by = %created_by,
+                "routing_evaluate: failed to check for existing routing rules"
+            );
+            false
+        }
+    }
+}
+
 pub async fn routing_evaluate(
     headers: axum::http::HeaderMap,
     Json(payload): Json<RoutingRequest>,
@@ -703,6 +791,36 @@ pub async fn routing_evaluate(
                 .await
             {
                 Ok(algo) => algo,
+                // A profile that has rules but none active has deliberately deactivated them,
+                // and that is an answer rather than a failure: the caller should route by its
+                // fallback. Reporting it as an error instead lets a caller that treats an
+                // errored evaluation as "engine unavailable" keep serving the rule the
+                // merchant just switched off. A profile with no rules at all stays an error,
+                // so a caller can still tell that the engine has nothing for it.
+                Err(e)
+                    if matches!(
+                        e.get_inner(),
+                        EuclidErrors::ActiveRoutingAlgorithmNotFound(_)
+                    ) && profile_has_any_routing_rule(
+                        &state,
+                        &payload.created_by,
+                        algorithm_for,
+                    )
+                    .await =>
+                {
+                    API_REQUEST_COUNTER
+                        .with_label_values(&["routing_evaluate", "success"])
+                        .inc();
+                    if let Some(timer) = timer.take() {
+                        timer.observe_duration();
+                    }
+                    return Ok(Json(no_active_algorithm_response(
+                        &payload,
+                        request_id,
+                        global_request_id,
+                        trace_id,
+                    )));
+                }
                 Err(e) => return fail_preview(e, "active_routing_lookup_failed"),
             }
         }

--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -27,9 +27,11 @@ use crate::euclid::{
     errors::ValidationErrorDetails,
     types::{RoutingAlgorithmMapper, RoutingAlgorithmMapperUpdate},
 };
+use crate::generics::MeshError;
 use crate::{euclid::types::RoutingAlgorithm, logger, metrics};
+use async_bb8_diesel::AsyncRunQueryDsl;
 use axum::{extract::Path, response::IntoResponse, Json};
-use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods};
+use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods, QueryDsl};
 use error_stack::ResultExt;
 
 use crate::app::get_tenant_app_state;
@@ -517,12 +519,26 @@ async fn fetch_algorithm_from_db_and_cache(
         }
     };
 
-    let active_routing_algorithm_id = mapper_result
-        .change_context(EuclidErrors::ActiveRoutingAlgorithmNotFound(
-            merchant_id.to_string(),
-        ))
-        .map_err(ContainerError::from)?
-        .routing_algorithm_id;
+    // Only a missing mapper row means no rule is active. Any other storage error is the engine
+    // failing to answer, and reporting it as ActiveRoutingAlgorithmNotFound would let the
+    // deactivated-rules path in `routing_evaluate` serve a 200 fallback while the database is
+    // unreachable -- exactly the "engine unavailable" case a caller must be able to tell apart.
+    let active_routing_algorithm_id = match mapper_result {
+        Ok(mapper) => mapper.routing_algorithm_id,
+        Err(MeshError::NotFound) => {
+            return Err(
+                EuclidErrors::ActiveRoutingAlgorithmNotFound(merchant_id.to_string()).into(),
+            )
+        }
+        Err(error) => {
+            logger::error!(
+                ?error,
+                merchant_id = %merchant_id,
+                "Failed to look up the active routing algorithm mapper"
+            );
+            return Err(EuclidErrors::StorageError.into());
+        }
+    };
 
     let algorithm = crate::generics::generic_find_one::<
         <RoutingAlgorithm as HasTable>::Table,
@@ -553,7 +569,8 @@ async fn fetch_algorithm_from_db_and_cache(
 /// Response for a profile whose rules are all deactivated: the fallback the caller supplied,
 /// echoed back under a status that says the engine answered and has no rule to apply. The
 /// caller can then route by its fallback instead of guessing from a failed evaluation.
-fn no_active_algorithm_response(
+async fn no_active_algorithm_response(
+    state: &crate::app::TenantAppState,
     payload: &RoutingRequest,
     request_id: Option<String>,
     global_request_id: Option<String>,
@@ -562,12 +579,27 @@ fn no_active_algorithm_response(
     let fallback = payload.fallback_output.clone().unwrap_or_default();
     let output = Output::Priority(fallback.clone());
 
+    // The evaluated path narrows both fields by the pm-filter graph, so this one does too:
+    // `evaluated_output` and `eligible_connectors` mean the same thing whichever path answered,
+    // and a caller reading them never has to know which it was.
+    let pm_filter_bundle = if pm_filter_graph::has_payment_method_type(&payload.parameters) {
+        state.get_pm_filter_graph_bundle().await
+    } else {
+        None
+    };
+    let eligible_connectors = eligibility_for_output(
+        pm_filter_bundle.as_deref(),
+        &payload.parameters,
+        &extract_connectors_for_eligibility(&output),
+    );
+    let evaluated_output = narrow_evaluated_output_to_eligible(fallback, &eligible_connectors);
+
     let response = RoutingEvaluateResponse {
         payment_id: payload.payment_id.clone(),
         status: "no_active_algorithm".to_string(),
         output: format_output(&output),
-        evaluated_output: fallback.clone(),
-        eligible_connectors: fallback,
+        evaluated_output,
+        eligible_connectors,
     };
 
     crate::analytics::DomainAnalyticsEvent::record_rule_evaluation_preview(
@@ -599,32 +631,46 @@ async fn profile_has_any_routing_rule(
     created_by: &str,
     algorithm_for: Option<&str>,
 ) -> bool {
-    let existing = match algorithm_for {
+    let conn = match state.db.get_conn().await {
+        Ok(conn) => conn,
+        Err(error) => {
+            logger::error!(
+                ?error,
+                created_by = %created_by,
+                "routing_evaluate: no connection to check for existing routing rules"
+            );
+            return false;
+        }
+    };
+
+    // A deactivated profile has no cache entry and no active mapper row, so this runs on every
+    // evaluate it makes. Selecting one id keeps it off the row itself, whose `algorithm_data`
+    // holds the whole rule program.
+    let existing: Result<Vec<String>, _> = match algorithm_for {
         Some(algorithm_for) => {
-            crate::generics::generic_find_one_optional::<
-                <RoutingAlgorithm as HasTable>::Table,
-                _,
-                RoutingAlgorithm,
-            >(
-                &state.db,
-                dsl::created_by
-                    .eq(created_by.to_string())
-                    .and(dsl::algorithm_for.eq(algorithm_for.to_string())),
-            )
-            .await
+            dsl::routing_algorithm
+                .filter(
+                    dsl::created_by
+                        .eq(created_by.to_string())
+                        .and(dsl::algorithm_for.eq(algorithm_for.to_string())),
+                )
+                .select(dsl::id)
+                .limit(1)
+                .get_results_async(&*conn)
+                .await
         }
         None => {
-            crate::generics::generic_find_one_optional::<
-                <RoutingAlgorithm as HasTable>::Table,
-                _,
-                RoutingAlgorithm,
-            >(&state.db, dsl::created_by.eq(created_by.to_string()))
-            .await
+            dsl::routing_algorithm
+                .filter(dsl::created_by.eq(created_by.to_string()))
+                .select(dsl::id)
+                .limit(1)
+                .get_results_async(&*conn)
+                .await
         }
     };
 
     match existing {
-        Ok(found) => found.is_some(),
+        Ok(found) => !found.is_empty(),
         Err(error) => {
             // Reported as "no rules", which routes the caller down the error path it already
             // took before this check existed.
@@ -814,12 +860,16 @@ pub async fn routing_evaluate(
                     if let Some(timer) = timer.take() {
                         timer.observe_duration();
                     }
-                    return Ok(Json(no_active_algorithm_response(
-                        &payload,
-                        request_id,
-                        global_request_id,
-                        trace_id,
-                    )));
+                    return Ok(Json(
+                        no_active_algorithm_response(
+                            &state,
+                            &payload,
+                            request_id,
+                            global_request_id,
+                            trace_id,
+                        )
+                        .await,
+                    ));
                 }
                 Err(e) => return fail_preview(e, "active_routing_lookup_failed"),
             }

--- a/tests/api/routing/routing-rule-mutations.spec.ts
+++ b/tests/api/routing/routing-rule-mutations.spec.ts
@@ -86,6 +86,48 @@ test.describe('Routing rule mutations (API)', () => {
     expect(all.body.some((r: any) => r.id === ruleId)).toBe(true)
   })
 
+  test('evaluating after deactivation answers with the caller\'s fallback', async ({ api, merchant }) => {
+    const m = merchant.id
+    const created = await api.createRoutingAlgorithm(
+      factory.singleRoutingPayload(m, { name: factory.ruleName('mutate_eval_off'), gateway: 'stripe' }),
+    )
+    const ruleId = created.body.rule_id
+    await api.activateRoutingAlgorithm(m, ruleId)
+
+    await api.raw('POST', '/routing/deactivate', {
+      body: { created_by: m, routing_algorithm_id: ruleId },
+    })
+
+    const evaluated = await api.evaluateRoutingAlgorithm(
+      factory.ruleEvaluatePayload(m, {}, { fallback_output: [factory.gatewayConnector('adyen')] }),
+      { failOnStatusCode: false },
+    )
+
+    // A merchant who switched their rules off has an answer coming — route by the fallback —
+    // rather than an error a caller would read as "engine unavailable" and paper over with its
+    // own stale copy of the rule.
+    expect(evaluated.status).toBe(200)
+    expect(evaluated.body.status).toBe('no_active_algorithm')
+    expect(evaluated.body.output.type).toBe('priority')
+    expect(evaluated.body.evaluated_output.map((c: any) => c.gateway_name)).toEqual(['adyen'])
+    expect(evaluated.body.eligible_connectors.map((c: any) => c.gateway_name)).toEqual(['adyen'])
+    // The rule the merchant deactivated is gone from the answer entirely.
+    expect(evaluated.body.evaluated_output.map((c: any) => c.gateway_name)).not.toContain('stripe')
+  })
+
+  test('evaluating for a merchant with no rules at all still errors', async ({ api, merchant }) => {
+    // The opposite state: the engine was never given a rule for this profile, so it has nothing to
+    // say and the caller should fall back to its own configuration. That stays a 400.
+    const evaluated = await api.evaluateRoutingAlgorithm(
+      factory.ruleEvaluatePayload(merchant.id, {}, {
+        fallback_output: [factory.gatewayConnector('adyen')],
+      }),
+      { failOnStatusCode: false },
+    )
+
+    expect(evaluated.status).toBe(400)
+  })
+
   test('deleting an inactive rule removes it from the list', async ({ api, merchant }) => {
     const m = merchant.id
     const created = await api.createRoutingAlgorithm(


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

`/routing/evaluate` returns `400 ActiveRoutingAlgorithmNotFound` whenever a profile has no active routing algorithm. That conflates two opposite situations:

- the merchant **deactivated** their rules — the engine has an authoritative answer: route by the fallback
- the engine has **never been given** any rules for this profile — the engine has nothing to say

A caller cannot separate those from the error, and cannot separate either from the engine being unreachable. Hyperswitch treats a failed evaluation as "engine unavailable" and degrades to its own copy of the rule, so **deactivating a rule on the Decision Engine dashboard leaves it still routing payments** through Hyperswitch's frozen pre-cutover copy. The merchant switches the rule off and nothing changes.

This is reachable on any cut-over profile whose rules were migrated (so Hyperswitch still holds a row) and whose deactivation happens on the DE side rather than through Hyperswitch.

### The distinction already exists in our data

Rules live in `routing_algorithm`; the active one in `routing_algorithm_mapper`. Rows in the former with no row in the latter means the rules were deactivated — an answer, not a failure.

| Engine state | Before | After |
| --- | --- | --- |
| Rules exist, none active (deactivated) | `400` | **`200`, fallback echoed, status `no_active_algorithm`** |
| No rules for the profile | `400` | `400` (unchanged) |
| Rule active and matches | `200` | unchanged |

The existence check is scoped by `algorithm_for` the same way the mapper lookup is, so an absent payout rule does not read as a deactivated one on a profile that has payment rules.

### Response shape

`evaluated_output` carries the caller's own `fallback_output` back, and `output` is formatted as an ordinary priority list, so no caller needs a new parser:

```json
{
  "payment_id": "pay_demo",
  "status": "no_active_algorithm",
  "output": { "type": "priority", "connectors": [ ... ] },
  "evaluated_output": [ { "gateway_name": "adyen", "gateway_id": "mca_fallback_adyen" } ],
  "eligible_connectors": [ { "gateway_name": "adyen", "gateway_id": "mca_fallback_adyen" } ]
}
```

### No Hyperswitch change required

The deactivated case now returns a non-empty result, so Hyperswitch's existing preference for a non-empty engine result picks it up and the merchant routes by their fallback. The unmigrated and unreachable cases are untouched, so its degradation to its own rule still works where that is the right answer.

The cache path is unaffected — `deactivate_routing_rule` already calls `invalidate_routing_algorithm_cache`, so the next evaluate reaches this lookup rather than serving a cached algorithm.

## How did you test it?

- `cargo check` clean on the default `mysql` build and on `--no-default-features --features "middleware,postgres"` — the `dsl` imports are feature-gated, so both matter.
- `cargo clippy` clean; `cargo fmt` applied.

## Known limitation

If a merchant has no default connectors configured, the caller's `fallback_output` is empty, so `evaluated_output` comes back empty and a caller keying off emptiness rather than `status` will still degrade to its own rule. Callers reading `status` are unaffected.

## Checklist

- [x] I formatted the code `cargo fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
