### PR TITLE
fix(auth): verify the email when a password reset completes

### DIFF
--- a/src/routes/user_auth.rs
+++ b/src/routes/user_auth.rs
@@ -1471,15 +1471,23 @@ pub async fn reset_password(
         .await
         .change_error(UserAuthError::StorageError)?;
 
+    // The reset link only ever goes to the address on the account, and the token above is
+    // single-use, so reaching this point proves the caller reads that mailbox — the same proof
+    // the verification link asks for. Settling both here is what lets someone whose verification
+    // token lapsed get back in: they reset, and the account is verified by the act of resetting.
     let rows_updated = crate::generics::generic_update_if_present::<
         <User as HasTable>::Table,
-        crate::storage::types::UserPasswordUpdate,
+        crate::storage::types::UserPasswordResetUpdate,
         _,
     >(
         &conn,
         dsl::user_id.eq(user_id.clone()),
-        crate::storage::types::UserPasswordUpdate {
+        crate::storage::types::UserPasswordResetUpdate {
             password_hash: new_hash,
+            #[cfg(feature = "mysql")]
+            email_verified: 1,
+            #[cfg(feature = "postgres")]
+            email_verified: true,
         },
     )
     .await

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -925,3 +925,16 @@ pub struct UserEmailVerifiedUpdate {
 pub struct UserPasswordUpdate {
     pub password_hash: String,
 }
+
+/// Written when a password reset completes: consuming a reset token proves control of the
+/// mailbox, which is the same thing a verification link proves, so the reset settles both.
+#[derive(AsChangeset, Debug)]
+#[cfg_attr(feature = "mysql", diesel(table_name = schema::users))]
+#[cfg_attr(feature = "postgres", diesel(table_name = schema_pg::users))]
+pub struct UserPasswordResetUpdate {
+    pub password_hash: String,
+    #[cfg(feature = "mysql")]
+    pub email_verified: i8,
+    #[cfg(feature = "postgres")]
+    pub email_verified: bool,
+}


### PR DESCRIPTION
## Problem

A user who lets their 24h email-verification token lapse is locked out with no way back in:

| what they try | what happens |
|---|---|
| sign up again with the same email | `409 Email already registered` |
| forgot-password | `200`, reset link delivered |
| reset-password with that link | `200 "Password reset successfully. You can now sign in with your new password."` |
| log in with the new password | `403 Email not verified` |

The reset path is the trap — it runs clean end to end and tells the user they can sign in, then login refuses them, because `login` checks `email_verified` before it ever checks the password (`src/routes/user_auth.rs:418`). Nothing in the API lets them recover, and nothing tells them verification is the blocker.

## Change

`reset_password` now marks the account verified along with the new password hash, through a new `UserPasswordResetUpdate` changeset.

The reset link only ever goes to the address stored on the account (`forgot_password` mails `user.email` from the DB, never a caller-supplied address), and the token is a v4 UUID held in Redis for an hour and consumed with GETDEL. So holding it proves the caller reads that mailbox — the same proof the verification link asks for, and strictly more of it, since the holder also sets the password. No new endpoint, no admin involvement, and the recovery route is a link the login page already shows.

## Verification

By hand against a server with `email_verification_enabled = true` and SMTP delivery into Mailpit, deleting the Redis token to simulate the 24h lapse:

1. sign up, leave unverified → `login` returns `403 Email not verified`
2. forgot-password → reset with the emailed token → `200`, and `email_verified` flips `f` → `t` in the DB
3. log in with the new password → JWT issued
4. `/auth/me` → `email_verified: true`

Both feature builds type-check (`--features postgres`, `--features mysql`). Full API suite: 116 passed, 3 skipped.

## Not covered by the suite

Every API spec signs up and logs in immediately, so enabling `email_verification_enabled` for the Playwright server would break all of them, and with `no_email_client` no reset mail exists for a test to read. Covering this in CI needs a second Playwright project with its own server env plus a Mailpit fixture — Mailpit is already started in `ci-pr.yml:214`. Worth a follow-up.