### PR TITLE
feat(scripts): add migration dashboard for HS → DE routing migration

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -18,6 +18,47 @@ env:
   RUST_BACKTRACE: short
 
 jobs:
+  # Which of this PR's files decide whether the expensive jobs below have anything to say. The
+  # Rust and spell checks run on everything and are not gated; the end-to-end suite boots the API,
+  # the dashboard and four datastores, so it is asked for by path rather than run by default.
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            # Everything the E2E job builds, boots or runs. Listed wide on purpose: an extra run
+            # costs a runner, a missed one costs a regression that reaches main.
+            e2e:
+              # The API binary under test, and what it is built and configured from
+              - 'src/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'config/**'
+              # The schema it is migrated onto
+              - 'migrations_pg/**'
+              - 'diesel_pg.toml'
+              - 'justfile'
+              # The dashboard the UI project drives
+              - 'website/**'
+              # The suite itself, and the toolchain that type-checks and runs it
+              - 'tests/**'
+              - 'playwright.config.ts'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              # The datastores it starts, and this workflow
+              - 'docker-compose*.y*ml'
+              - '.github/workflows/ci-pr.yml'
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -157,6 +198,8 @@ jobs:
 
   e2e-playwright:
     name: E2E (Playwright)
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/scripts/migration-dashboard/README.md
+++ b/scripts/migration-dashboard/README.md
@@ -56,6 +56,10 @@ named environment or preset its fields:
 scripts/migration-dashboard/server.py --env production-eu
 ```
 
+It listens on loopback only. This server authenticates nobody and holds the admin credentials,
+so whoever reaches the port is the operator — a non-loopback `--host` is refused unless
+`--allow-remote` is given with it. Forward the port over SSH rather than binding wide.
+
 **Production.** An environment of kind *production* is marked wherever it is named, and the
 first migration, cutover or scope run of a session asks for its name to be typed back — once per
 session, checked by the server too, so a page left open cannot write on a click alone. Nothing

--- a/scripts/migration-dashboard/README.md
+++ b/scripts/migration-dashboard/README.md
@@ -1,0 +1,193 @@
+# Migration front
+
+A local console over Hyperswitch's routing-rule migration endpoints: where every profile stands
+in the move to the decision engine, and a way to move the ones that have not crossed yet.
+
+Rule translation happens in Hyperswitch, not here — it holds the rules, the credentials and the
+connector context (see [`docs/hs-hierarchy-migration.md`](../../docs/hs-hierarchy-migration.md)).
+This tool only drives the endpoints:
+
+| Endpoint | Used for |
+|---|---|
+| `GET /routing/migration/status` (HS) | Every profile holding rules, with its HS and DE rule ids set-diffed |
+| `POST /routing/rule/migrate` (HS) | Writing a batch of profiles' rules into the DE, and provisioning the scope they land in |
+| `POST /admin/hierarchy/reconcile` (DE) | Which scanned profiles the DE has no scope for. Read-only |
+| `PUT /context` (Superposition) | Cutting a profile's routing over, and back |
+
+The Hyperswitch endpoints are admin-authenticated and idempotent: rules already in the decision
+engine are skipped, so a partial run repairs itself on the next one.
+
+## Running it
+
+```bash
+scripts/migration-dashboard/server.py
+```
+
+Then open <http://127.0.0.1:8090>. Python 3.9+, standard library only.
+
+## Environments
+
+The console holds as many environments as you configure and works one at a time; the header
+picker switches between them. Sandbox and Production EU are seeded, without credentials — the
+keys are pasted in when needed. **Environment** in the header sets, per environment:
+
+| Field | What it is |
+|---|---|
+| Environment, Kind | Its name, and what a write here reaches — *sandbox*, *production*, *local*, *other*. Kind is guessed from the URL and yours to correct |
+| Hyperswitch URL + Admin API key | Sent as `api-key`. Base URL, so a path on it is kept |
+| Extra headers | Sent on every HS call; hosted environments route by `x-feature` |
+| Superposition URL + secret + headers | Where cutovers are written (`x-superposition-secret`, `x-tenant`, `x-org-id`). Leave empty and the dashboard stays read-only about routing |
+| Override key | The config a cutover writes, `routing.routing_result_source` by default |
+| Decision engine URL + admin secret + headers | Where scopes are read (`x-admin-secret`). Leave empty and the scope column reads as unchecked |
+
+Credentials stay in the local server process — the page only ever sees their last four
+characters. Nothing touches disk unless **Remember on this machine** is ticked, which writes
+`~/.config/hs-migration-dashboard/config.json` at mode 0600 (credentials only if *including the
+credentials* is ticked too). **Forget saved** removes it.
+
+Changing an environment's URL clears its key and the scan; switching environments clears the
+scan but keeps each one's credentials. Profile ids are not comparable across environments.
+
+`--env`, `--hs-url`, `--admin-api-key`, `--de-url`, `--de-admin-secret`, `--port`, `--host` (or
+`HS_ENV`, `HS_URL`, `HS_ADMIN_API_KEY`, `DE_URL`, `DE_ADMIN_SECRET`, `PORT`, `HOST`) open on a
+named environment or preset its fields:
+
+```bash
+scripts/migration-dashboard/server.py --env production-eu
+```
+
+**Production.** An environment of kind *production* is marked wherever it is named, and the
+first migration, cutover or scope run of a session asks for its name to be typed back — once per
+session, checked by the server too, so a page left open cannot write on a click alone. Nothing
+else differs: same endpoints, same idempotency.
+
+## Reading the table
+
+**Scan estate** walks the status endpoint to the end of the feed, 500 profiles at a time, and
+resolves each merchant through `GET /accounts/{merchant_id}`. Every profile costs Hyperswitch a
+call to the decision engine, so it runs as a background job with progress. **Rescan** reads it
+again.
+
+The crossing bar on each row — and once across the estate — splits that scope's rules into
+landed in the DE, still only in HS, and out of scope. States come from Hyperswitch:
+
+| State | Meaning |
+|---|---|
+| `pending` | Rules in Hyperswitch, none in the decision engine |
+| `partial` | Some crossed, some did not |
+| `diverged` | Same number of rules on both sides, but not the same ones |
+| `migrated` | Every rule is across; Hyperswitch is still routing |
+| `enabled` | Cut over — the decision engine decides this profile's routing |
+| `enabled_without_rules` | Cut over with rules missing, so traffic falls through to the default connector list |
+| `unknown` | The decision engine could not be read |
+
+Click a state chip to filter; chips combine with the org, merchant and routing-source selectors
+and the search box, which covers rule ids as well as scope ids.
+
+The **Note** column says why a profile is held back:
+
+- `merchant account missing` — the rules outlived the merchant account. Held back by default;
+  see *Allow profiles with no merchant account* below. Fixing it means dispositioning the
+  account in Hyperswitch.
+- `only out-of-scope rules` — the profile holds nothing but `dynamic` or `three_ds_decision_rule`
+  rules, which reach the decision engine another way. Already finished despite reading `pending`.
+- `no scope in DE` / `no ancestry in DE` — see [Scopes](#scopes).
+
+## Migrating
+
+Click a row to open its panel — *Migrate this profile*, *Add to batch*, and the rule ids it is
+missing. For many profiles, tick the checkboxes (the header one takes every movable profile on
+the page; a selection survives paging) and choose **Migrate selected**. Runs go 25 profiles at a
+time; a failed batch does not stop the ones after it, and re-running is safe. A disabled
+checkbox says why on hover. The scan refreshes when the run finishes.
+
+**Allow profiles with no merchant account** sends the profiles Hyperswitch cannot read an
+account for; they come back `not attempted` otherwise. Profiles holding only out-of-scope rules
+stay unavailable either way.
+
+`/routing/rule/migrate` reads at most 1000 rules per profile per call, so a larger profile is
+walked with successive offsets rather than reported as done on its first page.
+
+**Tracing a failure.** Every report line ends with the `x-request-id` of the Hyperswitch request
+that produced it, and Hyperswitch logs under that id — click it to select it whole. That is what
+makes `HE_00 · Something went wrong` actionable. Upstream errors name the service and endpoint
+too, so a `401` is attributable to one of the three credentials.
+
+Migration writes rules; it does not switch traffic. A profile reads `migrated` until it is cut
+over.
+
+## Scopes
+
+Whether the decision engine holds a **scope** for a profile — a `merchant_account` row keyed by
+the profile id — is a separate question from rules, and Hyperswitch cannot answer it: its
+per-profile read lists rules only, so a profile with no scope looks exactly like a scope with no
+rules yet. It reads `pending`, a migration **succeeds** on it and turns it `migrated`, and the
+failure only shows on live traffic after cutover — `decide-gateway` loads the scope first and
+answers `MERCHANT_NOT_FOUND` without one.
+
+So the dashboard asks the decision engine directly: each scan posts the scanned profiles as an
+org → merchant → profile tree to the read-only `POST /admin/hierarchy/reconcile`, which answers
+with `missing_in_de` and `has_ancestry`. Missing scopes carry a `no scope in DE` note, count
+under **Missing in DE**, and are **held back from cutover** (enforced by the server against the
+last scan). Missing ancestry is milder — routing is unaffected, but the dashboard cannot name
+the account above the profile and org or merchant grants cannot expand to it — so it is
+reported, not held back. Migration is never held back; nor is rolling back.
+
+**Provision scopes** — from a row panel, a selection, or the notice — creates them by
+**re-running the migration**, because `/routing/rule/migrate` provisions the scope and its
+ancestry before it reads a rule. Every rule is skipped, so a pure provisioning run reports
+skipping all of them. It works this way rather than calling the DE's `/admin/hierarchy/sync`
+because a scope is only as good as its ancestry, and the status feed carries neither profile
+name nor org name, and its `merchant_id` is the *provider* for platform-written rules. Only
+Hyperswitch has it right. Re-running is safe: `sync` writes only what differs.
+
+**Stranded** scopes — a DE scope whose id is an HS *merchant* id rather than a profile id — are
+reported in the notice and never written to. They hold rules and scores no profile inherits.
+Only a person can say which profile was meant.
+
+Leave the decision engine unset and none of this runs; the notice says the check did not happen,
+because an unchecked scope and a present one are not the same claim.
+
+## Cutting over
+
+A `migrated` profile is fully across and still routed by Hyperswitch. What decides that is
+`routing.routing_result_source`, read per profile from Superposition, so cutting over means
+writing an override for it:
+
+```bash
+curl --request PUT 'https://superposition.example.net/context' \
+  --header 'x-superposition-secret: <secret>' \
+  --header 'x-tenant: hyperswitch' --header 'x-org-id: hyperswitch' \
+  --data '{"context": {"profile_id": "pro_…"},
+           "override": {"routing.routing_result_source": "decision_engine"},
+           "description": "Cut over profile pro_… to Decision Engine",
+           "change_reason": "DE cutover"}'
+```
+
+which is what **Cut over to decision engine** does, from a row panel or from the selection bar.
+The direction is offered by state, and the server enforces it against the last scan so a stale
+tab cannot cut over a profile that has since fallen behind:
+
+| Profile state | Offered |
+|---|---|
+| `migrated`, with a scope | *Cut over to decision engine* |
+| `migrated`, no scope | Neither — the decision engine would refuse the profile outright |
+| `enabled`, `enabled_without_rules` | *Roll back to Hyperswitch* — routing only, no rule is touched |
+| anything else | Neither — live traffic would route against a DE missing rules |
+
+Failures raise a banner as well as appearing in the report, and a failed profile can just be
+sent again. The estate is not re-read afterwards; **Rescan** when you want it.
+
+**The override key.** Hyperswitch renamed this config into a folder — `routing_result_source`
+became `routing.routing_result_source` — so which name works depends on when the workspace was
+seeded. A workspace refuses an override whose key it has no schema for, so a wrong name fails
+loudly (`failed to get schema for config key …`); the run retries once under the other spelling,
+adopts it for the rest of the run, and leaves the Override key field holding it. When both are
+refused, nothing changes.
+
+The one failure nothing here can detect: if a workspace defines *both* names, an override under
+the one the router does not read is accepted and does nothing. A cutover that reports every
+profile written while a rescan still shows them `migrated` is that.
+
+Cutovers move live traffic the moment Superposition accepts the override. Rules are untouched in
+both directions, so it is reversible by rolling back.

--- a/scripts/migration-dashboard/index.html
+++ b/scripts/migration-dashboard/index.html
@@ -1,0 +1,1734 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Migration front</title>
+<style>
+  :root {
+    --ground: #f4f6f8;
+    --panel: #ffffff;
+    --panel-sunk: #eef1f5;
+    --ink: #0f1620;
+    --ink-soft: #56616f;
+    --ink-faint: #8a94a2;
+    --line: #dde3ea;
+    --line-strong: #c3ccd7;
+    --hs: #9c5f14;
+    --hs-fill: #e6a340;
+    --de: #0c6f68;
+    --de-fill: #2aa79a;
+    --alarm: #a52a1f;
+    --alarm-fill: #d9503f;
+    --focus: #1f6feb;
+    --radius: 6px;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", "JetBrains Mono", Menlo, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ground: #0e1116;
+      --panel: #161a21;
+      --panel-sunk: #1d222b;
+      --ink: #e8ecf1;
+      --ink-soft: #a4b0be;
+      --ink-faint: #6f7b8a;
+      --line: #262c36;
+      --line-strong: #39414d;
+      --hs: #e6a340;
+      --hs-fill: #c98a2e;
+      --de: #45c4b6;
+      --de-fill: #2a9083;
+      --alarm: #ef6d5c;
+      --alarm-fill: #b8392b;
+      --focus: #6ea8ff;
+    }
+  }
+
+  * { box-sizing: border-box; }
+  /* `hidden` has to win over the layout rules below, which set display on the same elements. */
+  [hidden] { display: none !important; }
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.45;
+  }
+  button, input, select { font: inherit; color: inherit; }
+  :focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+
+  .wrap { max-width: 1500px; margin: 0 auto; padding: 22px 20px 120px; }
+
+  /* ---------------------------------------------------------------- header */
+  header { display: flex; flex-wrap: wrap; gap: 18px; align-items: flex-end; justify-content: space-between; }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-bottom: 4px;
+  }
+  h1 { margin: 0; font-size: 27px; font-weight: 640; letter-spacing: -0.02em; }
+  .endpoints { font-family: var(--mono); font-size: 11.5px; color: var(--ink-soft); margin-top: 6px; }
+  .endpoints b { font-weight: 600; color: var(--ink); }
+  .header-actions { display: flex; align-items: center; gap: 10px; }
+  .env-pick {
+    background: var(--panel); border: 1px solid var(--line-strong); border-radius: var(--radius);
+    padding: 5px 8px; font-family: var(--sans); font-size: 12.5px; margin-right: 8px;
+  }
+  /* Production is said in the one colour this page keeps for things that cannot be undone,
+     wherever the environment is named — the header, the panel and every confirm. */
+  .live-tag {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--panel); background: var(--alarm); border-radius: 3px; padding: 2px 6px; margin-right: 8px;
+  }
+  /* Full width, above everything, for as long as the console is pointed at production. */
+  body.live { border-top: 3px solid var(--alarm); }
+  body.live .env-pick { border-color: var(--alarm); color: var(--alarm); }
+
+  button.action {
+    background: var(--ink);
+    color: var(--panel);
+    border: 1px solid var(--ink);
+    border-radius: var(--radius);
+    padding: 8px 15px;
+    font-weight: 560;
+    cursor: pointer;
+  }
+  button.action:hover:not(:disabled) { opacity: 0.86; }
+  button.action:disabled { opacity: 0.4; cursor: not-allowed; }
+  button.ghost {
+    background: transparent;
+    color: var(--ink);
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius);
+    padding: 6px 12px;
+    cursor: pointer;
+  }
+  button.ghost:hover { background: var(--panel-sunk); }
+
+  /* ------------------------------------------------------- the crossing bar */
+  /* One bar per estate and one per profile: rules landed in the decision engine,
+     rules still held only by Hyperswitch, rules this migration never carries. */
+  .crossing { display: flex; height: 100%; width: 100%; border-radius: 2px; overflow: hidden; background: var(--panel-sunk); }
+  .crossing span { display: block; height: 100%; }
+  .seg-de { background: var(--de-fill); }
+  .seg-hs { background: var(--hs-fill); }
+  .seg-oos { background: repeating-linear-gradient(135deg, var(--line-strong) 0 3px, transparent 3px 6px); }
+
+  .estate {
+    margin-top: 18px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 16px 18px;
+  }
+  .estate-bar { height: 12px; margin: 12px 0 10px; }
+  .estate-legend { display: flex; flex-wrap: wrap; gap: 18px; font-size: 12.5px; color: var(--ink-soft); }
+  .estate-legend b { font-family: var(--mono); font-weight: 600; color: var(--ink); }
+  .swatch { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 6px; vertical-align: baseline; }
+  .counts { display: flex; flex-wrap: wrap; gap: 26px; }
+  .count-label { font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-faint); }
+  .count-value { font-family: var(--mono); font-size: 21px; font-weight: 600; }
+
+  /* --------------------------------------------------------------- filters */
+  .states { display: flex; flex-wrap: wrap; gap: 8px; margin: 18px 0 12px; }
+  .state-chip {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--tone, var(--line-strong));
+    border-radius: var(--radius);
+    padding: 7px 13px;
+    cursor: pointer;
+  }
+  .state-chip[aria-pressed="true"] { background: var(--ink); color: var(--panel); border-color: var(--ink); }
+  .state-chip .n { font-family: var(--mono); font-weight: 600; font-size: 15px; }
+  .state-chip .k { font-size: 12px; }
+  .state-chip:disabled { opacity: 0.35; cursor: default; }
+
+  .filters {
+    display: flex; flex-wrap: wrap; gap: 10px; align-items: center;
+    background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 11px 13px;
+  }
+  .filters label { font-size: 11px; letter-spacing: 0.07em; text-transform: uppercase; color: var(--ink-faint); margin-right: 6px; }
+  .filters select, .filters input[type="search"] {
+    background: var(--panel-sunk);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 6px 9px;
+    max-width: 230px;
+  }
+  .filters .spacer { flex: 1; }
+  .toggle { display: flex; align-items: center; gap: 7px; font-size: 13px; color: var(--ink-soft); cursor: pointer; }
+
+  /* ----------------------------------------------------------------- table */
+  .table-wrap { margin-top: 12px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; }
+  thead th {
+    position: sticky; top: 0; z-index: 2;
+    background: var(--panel);
+    border-bottom: 1px solid var(--line-strong);
+    text-align: left;
+    font-size: 11px; letter-spacing: 0.07em; text-transform: uppercase; color: var(--ink-faint);
+    font-weight: 600;
+    padding: 10px 12px;
+    white-space: nowrap;
+  }
+  thead th.sortable { cursor: pointer; }
+  thead th.sortable:hover { color: var(--ink); }
+  tbody td { border-bottom: 1px solid var(--line); padding: 8px 12px; vertical-align: middle; }
+  tbody tr:hover { background: var(--panel-sunk); }
+  tbody tr.selected { background: color-mix(in srgb, var(--focus) 8%, var(--panel)); }
+  .num { font-family: var(--mono); text-align: right; font-variant-numeric: tabular-nums; }
+  .id { font-family: var(--mono); font-size: 12px; }
+  .sub { display: block; font-size: 11.5px; color: var(--ink-faint); }
+  .bar-cell { width: 130px; }
+  .bar-cell .crossing { height: 8px; }
+
+  .badge {
+    display: inline-block; font-size: 11.5px; font-weight: 560;
+    padding: 2px 8px; border-radius: 999px;
+    border: 1px solid currentColor;
+  }
+  .badge.pending, .badge.partial { color: var(--hs); }
+  .badge.partial { background: color-mix(in srgb, var(--hs-fill) 16%, transparent); }
+  .badge.migrated { color: var(--de); }
+  .badge.enabled { color: var(--panel); background: var(--de); border-color: var(--de); }
+  .badge.diverged, .badge.enabled_without_rules { color: var(--panel); background: var(--alarm); border-color: var(--alarm); }
+  .badge.unknown { color: var(--ink-faint); }
+  .tag { font-family: var(--mono); font-size: 11px; color: var(--ink-faint); white-space: nowrap; }
+  /* A profile the decision engine has no scope for is not a slower migration but a broken one,
+     so it is toned like the states that mean the same thing. */
+  .tag.warn, .count-value.warn { color: var(--alarm); }
+  .notice.warn { border-left-color: var(--alarm); }
+
+  .group-row td { background: var(--panel-sunk); font-weight: 600; padding: 7px 12px; }
+  .group-row .id { font-weight: 600; }
+  tbody tr.row { cursor: pointer; }
+  .detail td { background: var(--panel-sunk); font-family: var(--mono); font-size: 11.5px; color: var(--ink-soft); }
+  .panel-actions {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
+    padding-bottom: 10px; margin-bottom: 10px; border-bottom: 1px solid var(--line);
+  }
+  .panel-actions button { font-family: var(--sans); }
+  .panel-note { font-family: var(--sans); font-size: 12.5px; color: var(--ink-soft); flex: 1 1 320px; }
+  .panel-note code { font-family: var(--mono); color: var(--ink); }
+  .panel-note em { font-style: normal; color: var(--hs); font-weight: 560; }
+  .detail .ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+  .detail .ids span { background: var(--panel); border: 1px solid var(--line); border-radius: 4px; padding: 1px 6px; }
+  .expand { background: none; border: none; cursor: pointer; color: var(--ink-faint); padding: 0 4px; }
+
+  .notice {
+    margin-top: 10px; padding: 9px 13px; border-radius: var(--radius);
+    background: var(--panel); border: 1px solid var(--line); border-left: 3px solid var(--hs-fill);
+    color: var(--ink-soft); font-size: 13px;
+  }
+  .notice b { font-family: var(--mono); color: var(--ink); }
+  .notice em { font-style: normal; color: var(--ink); }
+  .empty { padding: 46px 20px; text-align: center; color: var(--ink-soft); }
+  .empty b { display: block; font-size: 16px; color: var(--ink); margin-bottom: 6px; }
+
+  /* ------------------------------------------------------------ action bar */
+  .actionbar {
+    position: fixed; left: 0; right: 0; bottom: 0;
+    background: var(--panel); border-top: 1px solid var(--line-strong);
+    padding: 12px 20px;
+    display: flex; align-items: center; gap: 16px;
+    box-shadow: 0 -6px 22px rgba(0,0,0,0.07);
+  }
+  .actionbar .summary { font-size: 13.5px; }
+  .actionbar .summary b { font-family: var(--mono); }
+  .actionbar .spacer { flex: 1; }
+  .progress { height: 4px; background: var(--panel-sunk); border-radius: 2px; overflow: hidden; width: 260px; }
+  .progress span { display: block; height: 100%; background: var(--de-fill); transition: width 0.3s ease; }
+  @media (prefers-reduced-motion: reduce) { .progress span { transition: none; } }
+
+  .report { margin-top: 14px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 14px 16px; }
+  .report h2 { margin: 0 0 8px; font-size: 15px; }
+  .report .rows { max-height: 260px; overflow: auto; margin-top: 10px; font-family: var(--mono); font-size: 12px; }
+  .report .rows div { padding: 3px 0; border-bottom: 1px solid var(--line); }
+  /* Hyperswitch's own log is searched by this, so it is one click to select rather than a
+     careful drag through an id that looks like the profile id beside it. */
+  .rid { color: var(--ink-faint); user-select: all; }
+  /* ----------------------------------------------------------- environment */
+  .env {
+    margin-top: 14px; background: var(--panel); border: 1px solid var(--line);
+    border-radius: 10px; padding: 15px 17px;
+  }
+  .env h2 { margin: 0 0 3px; font-size: 15px; }
+  .env .env-section {
+    margin: 22px 0 3px; font-size: 13px; letter-spacing: 0.07em;
+    text-transform: uppercase; color: var(--ink-faint);
+    border-top: 1px solid var(--line); padding-top: 16px;
+  }
+  .env .env-note code { font-family: var(--mono); color: var(--ink); }
+  .env .env-note em { font-style: normal; color: var(--ink); font-weight: 560; }
+  .env .env-note { margin: 0 0 13px; font-size: 12.5px; color: var(--ink-soft); max-width: 70ch; }
+  .env-grid { display: flex; flex-wrap: wrap; gap: 14px; }
+  .env-field { display: flex; flex-direction: column; gap: 4px; flex: 1 1 320px; }
+  .env-field span { font-size: 11px; letter-spacing: 0.07em; text-transform: uppercase; color: var(--ink-faint); }
+  .env input {
+    background: var(--panel-sunk); border: 1px solid var(--line);
+    border-radius: var(--radius); padding: 7px 9px; width: 100%;
+  }
+  .env-headers { margin-top: 14px; display: flex; flex-direction: column; gap: 8px; }
+  .env-header-row { display: flex; gap: 8px; align-items: center; }
+  .env-header-row input:first-child { flex: 0 1 220px; font-family: var(--mono); font-size: 12.5px; }
+  .env-header-row input:nth-child(2) { flex: 1 1 260px; font-family: var(--mono); font-size: 12.5px; }
+  .env-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-top: 15px; }
+  .env-actions .toggle { white-space: nowrap; flex: 0 0 auto; }
+  .env-actions .spacer { flex: 1; }
+  .env-error { color: var(--alarm); font-size: 13px; }
+
+  /* --------------------------------------------------------------- paging */
+  .pager {
+    display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+    margin-top: 10px; font-size: 13px; color: var(--ink-soft);
+  }
+  .pager .spacer { flex: 1; }
+  .pager b { font-family: var(--mono); color: var(--ink); }
+  .pager select { background: var(--panel-sunk); border: 1px solid var(--line); border-radius: var(--radius); padding: 5px 8px; }
+  .pager button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .banner a { color: inherit; }
+  .banner b { font-family: var(--mono); }
+  #report:target .report, #cutover-report:target .report { border-color: var(--alarm); }
+  .banner { margin-top: 14px; border-left: 3px solid var(--alarm); background: var(--panel); padding: 10px 14px; border-radius: var(--radius); color: var(--alarm); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div>
+      <div class="eyebrow">hyperswitch &rarr; decision engine</div>
+      <h1>Migration front</h1>
+      <div class="endpoints">
+        <span class="live-tag" id="live-tag" hidden>production</span>
+        <b id="hs-url">&mdash;</b> &nbsp;<span id="key-state" class="tag"></span>
+      </div>
+    </div>
+    <div class="header-actions">
+      <span class="tag" id="scanned-at"></span>
+      <select class="env-pick" id="env-pick" title="The environment this console reads and writes"></select>
+      <button class="ghost" id="env-btn">Environment</button>
+      <button class="action" id="scan-btn">Scan estate</button>
+    </div>
+  </header>
+
+  <section class="env" id="env-panel" hidden>
+    <h2 id="env-title">Environment</h2>
+    <p class="env-note">The environment this console reads and writes. The API key is held by
+      the local server process and is never sent to this page; extra headers travel with every
+      call, which is how a hosted environment picks the release train to answer from.</p>
+    <p class="env-note">Each environment is kept under its own name with its own three
+      addresses and credentials, so sandbox and production are switched between from the header
+      rather than typed over each other. <em>Kind</em> is what a write here reaches: a
+      <em>production</em> environment is marked in the header and in every confirm, and a
+      migration, cutover or scope run against it asks for the environment's name once per
+      session before the first one.</p>
+    <div class="env-grid">
+      <label class="env-field"><span>Environment</span>
+        <input id="env-label" spellcheck="false" placeholder="Production EU" /></label>
+      <label class="env-field"><span>Kind</span>
+        <select id="env-kind">
+          <option value="sandbox">Sandbox &mdash; safe to write to</option>
+          <option value="production">Production &mdash; live merchants</option>
+          <option value="local">Local</option>
+          <option value="other">Other</option>
+        </select></label>
+    </div>
+    <div class="env-grid">
+      <label class="env-field"><span>Hyperswitch URL</span>
+        <input id="env-url" type="url" spellcheck="false" placeholder="https://sandbox.hyperswitch.io" /></label>
+      <label class="env-field"><span>Admin API key</span>
+        <input id="env-key" type="password" autocomplete="off" spellcheck="false" placeholder="paste the admin api-key" /></label>
+    </div>
+    <div class="env-headers" id="env-headers"></div>
+
+    <h3 class="env-section">Superposition</h3>
+    <p class="env-note">Where a cutover is written. Hyperswitch reads
+      <code id="env-key-name">routing.routing_result_source</code> per profile and asks whoever
+      it names for the routing result, so this is what moves a migrated profile from
+      <em>migrated</em> to <em>enabled</em>. Leave it empty to keep the dashboard read-only about
+      routing.</p>
+    <div class="env-grid">
+      <label class="env-field"><span>Superposition URL</span>
+        <input id="sp-url" type="url" spellcheck="false" placeholder="https://superposition.example.net" /></label>
+      <label class="env-field"><span>Superposition secret</span>
+        <input id="sp-secret" type="password" autocomplete="off" spellcheck="false" placeholder="x-superposition-secret" /></label>
+      <label class="env-field"><span>Override key</span>
+        <input id="sp-key" spellcheck="false" /></label>
+    </div>
+    <div class="env-headers" id="sp-headers"></div>
+
+    <h3 class="env-section">Decision engine</h3>
+    <p class="env-note">Optional, and the only part of this console that talks to the decision
+      engine directly. Hyperswitch reports which <em>rules</em> have crossed; whether it holds a
+      <em>scope</em> for a profile at all is a question only the decision engine can answer, and
+      a profile with rules but no scope is refused at
+      <code>decide-gateway</code> with <code>MERCHANT_NOT_FOUND</code>. Give an address and the
+      admin secret and every scan checks it; leave it empty and the scope column says it was not
+      read.</p>
+    <div class="env-grid">
+      <label class="env-field"><span>Decision engine URL</span>
+        <input id="de-url" type="url" spellcheck="false" placeholder="https://decision-engine.example.net" /></label>
+      <label class="env-field"><span>Admin secret</span>
+        <input id="de-secret" type="password" autocomplete="off" spellcheck="false" placeholder="x-admin-secret" /></label>
+    </div>
+    <div class="env-headers" id="de-headers"></div>
+
+    <div class="env-actions">
+      <button class="ghost" id="env-add-header">Add Hyperswitch header</button>
+      <button class="ghost" id="sp-add-header">Add Superposition header</button>
+      <button class="ghost" id="de-add-header">Add decision engine header</button>
+      <label class="toggle" title="Writes every environment configured here to ~/.config/hs-migration-dashboard/config.json, readable only by you"><input type="checkbox" id="env-remember" /> Remember on this machine</label>
+      <label class="toggle" title="Credentials are remembered together or not at all — every environment's key and secrets, or none of them"><input type="checkbox" id="env-remember-key" /> including the credentials</label>
+      <span class="spacer"></span>
+      <span class="env-error" id="env-error"></span>
+      <button class="ghost" id="env-forget" hidden>Forget saved</button>
+      <button class="action" id="env-save">Use this environment</button>
+    </div>
+  </section>
+
+  <div id="alert"></div>
+
+  <section class="estate" id="estate" hidden>
+    <div class="counts">
+      <div>
+        <div class="count-label">Organizations</div>
+        <div class="count-value" id="c-orgs">0</div>
+      </div>
+      <div>
+        <div class="count-label">Merchants</div>
+        <div class="count-value" id="c-merchants">0</div>
+      </div>
+      <div>
+        <div class="count-label">Profiles with rules</div>
+        <div class="count-value" id="c-profiles">0</div>
+      </div>
+      <div>
+        <div class="count-label">Rules pending</div>
+        <div class="count-value" id="c-pending">0</div>
+      </div>
+      <div>
+        <div class="count-label">Ready to cut over</div>
+        <div class="count-value" id="c-cutover">0</div>
+      </div>
+      <div>
+        <div class="count-label">Scopes to provision</div>
+        <div class="count-value" id="c-scopes">&mdash;</div>
+      </div>
+    </div>
+    <div class="estate-bar"><div class="crossing" id="estate-bar"></div></div>
+    <div class="estate-legend">
+      <span><i class="swatch" style="background:var(--de-fill)"></i>In the decision engine <b id="l-de">0</b></span>
+      <span><i class="swatch" style="background:var(--hs-fill)"></i>Only in Hyperswitch <b id="l-hs">0</b></span>
+      <span><i class="swatch seg-oos"></i>Out of scope &mdash; dynamic and 3DS <b id="l-oos">0</b></span>
+    </div>
+  </section>
+
+  <div id="scopes"></div>
+
+  <div class="states" id="states"></div>
+
+  <div class="filters">
+    <span><label for="f-org">Org</label><select id="f-org"></select></span>
+    <span><label for="f-merchant">Merchant</label><select id="f-merchant"></select></span>
+    <span><label for="f-source">Routing source</label><select id="f-source"></select></span>
+    <span><label for="f-scope">DE scope</label><select id="f-scope">
+      <option value="">Any scope</option>
+      <option value="missing">Missing in DE</option>
+      <option value="no_ancestry">No ancestry</option>
+      <option value="present">Complete</option>
+    </select></span>
+    <span><label for="f-search">Find</label><input type="search" id="f-search" placeholder="profile, merchant or rule id" /></span>
+    <span class="spacer"></span>
+    <label class="toggle"><input type="checkbox" id="f-actionable" /> Only profiles with rules to move</label>
+    <label class="toggle"><input type="checkbox" id="f-group" /> Group by org</label>
+    <label class="toggle" title="Migration can only answer &quot;not attempted&quot; for these until the merchant account exists in Hyperswitch"><input type="checkbox" id="f-blocked" /> Allow profiles with no merchant account</label>
+  </div>
+  <div id="more"></div>
+  <div id="nothing-selectable"></div>
+
+  <div class="pager" id="pager" hidden>
+    <span id="pager-info"></span>
+    <button class="ghost" id="select-view" hidden></button>
+    <span class="spacer"></span>
+    <label class="toggle" for="page-size">Rows per page</label>
+    <select id="page-size">
+      <option value="50">50</option>
+      <option value="100" selected>100</option>
+      <option value="250">250</option>
+      <option value="500">500</option>
+      <option value="0">All</option>
+    </select>
+    <button class="ghost" id="page-prev">&larr; Previous</button>
+    <span id="page-label"></span>
+    <button class="ghost" id="page-next">Next &rarr;</button>
+  </div>
+
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th style="width:34px"><input type="checkbox" id="select-all" title="Select every profile on this page that has rules to move" /></th>
+          <th style="width:26px"></th>
+          <th class="sortable" data-sort="organization_id">Organization</th>
+          <th class="sortable" data-sort="merchant_id">Merchant</th>
+          <th class="sortable" data-sort="profile_id">Profile</th>
+          <th class="sortable num" data-sort="rules_hyperswitch">HS</th>
+          <th class="sortable num" data-sort="rules_decision_engine">DE</th>
+          <th class="bar-cell">Crossing</th>
+          <th class="sortable num" data-sort="rules_pending">Pending</th>
+          <th class="sortable num" data-sort="rules_out_of_scope">Out of scope</th>
+          <th class="sortable" data-sort="state">State</th>
+          <th>Note</th>
+        </tr>
+      </thead>
+      <tbody id="rows"></tbody>
+    </table>
+    <div class="empty" id="empty">
+      <b>Nothing scanned yet</b>
+      Scan the estate to read where every profile holding routing rules stands.
+    </div>
+  </div>
+
+  <div id="report" tabindex="-1"></div>
+  <div id="cutover-report" tabindex="-1"></div>
+  <div id="scope-report" tabindex="-1"></div>
+</div>
+
+<div class="actionbar" id="actionbar" hidden>
+  <div class="summary" id="action-summary"></div>
+  <div class="progress" id="job-progress" hidden><span></span></div>
+  <span class="tag" id="job-message"></span>
+  <div class="spacer"></div>
+  <button class="ghost" id="clear-btn">Clear selection</button>
+  <button class="ghost" id="scope-btn" hidden>Provision scopes</button>
+  <button class="ghost" id="rollback-btn" hidden>Roll back to Hyperswitch</button>
+  <button class="action" id="cutover-btn" hidden>Cut over to decision engine</button>
+  <button class="action" id="migrate-btn">Migrate selected</button>
+</div>
+
+<script>
+"use strict";
+
+// The lifecycle order Hyperswitch reports, with the tone each state is read in: amber while
+// rules are still only on the Hyperswitch side, teal once they have crossed, red where a
+// profile is cut over or counted right but is missing rules.
+const STATES = [
+  ["pending",               "Pending",              "var(--hs-fill)"],
+  ["partial",               "Partial",              "var(--hs)"],
+  ["diverged",              "Diverged",             "var(--alarm)"],
+  ["migrated",              "Migrated",             "var(--de-fill)"],
+  ["enabled",               "Enabled",              "var(--de)"],
+  ["enabled_without_rules", "Enabled, no rules",    "var(--alarm-fill)"],
+  ["unknown",               "Unknown",              "var(--ink-faint)"],
+];
+const BLOCKERS = {
+  no_merchant_account: "merchant account missing",
+  out_of_scope_only: "only out-of-scope rules",
+};
+// Why a row's checkbox is disabled, shown on hover. A control that is present and explained
+// beats one that silently is not there.
+// The two directions a cutover can take a profile, as Hyperswitch names them.
+const TO_DE = "decision_engine";
+const TO_HS = "hyperswitch_routing";
+const BLOCKED_WHY = {
+  no_merchant_account: "This profile's merchant account cannot be read in Hyperswitch, so a " +
+    "migration would answer \"merchant account could not be read\". Tick " +
+    "\u201cAllow profiles with no merchant account\u201d to try it anyway.",
+  out_of_scope_only: "Nothing to move: this profile holds only dynamic or 3DS rules, which " +
+    "reach the decision engine another way.",
+};
+// Why a scope that is not in the decision engine matters, said wherever the fact is shown.
+const NO_SCOPE_WHY = "The decision engine holds no scope for this profile. Rules can still be " +
+  "written under it, but decide-gateway loads the scope first and answers MERCHANT_NOT_FOUND " +
+  "without one, so it cannot be cut over until the scope exists.";
+// A scope with nothing recorded above it. Routing is unaffected — only naming and grants are.
+const NO_ANCESTRY_WHY = "The decision engine holds a scope for this profile but nothing above " +
+  "it: no organization, merchant or profile name. Routing is unaffected, but the dashboard " +
+  "cannot name the account and an org or merchant grant cannot expand to reach it.";
+
+// The picker's escape hatch: an environment that is not one of the ones already held. A name
+// is a slug of letters, digits and dashes, so a value with a space in it cannot collide.
+const NEW_ENV = "new environment";
+
+const el = (id) => document.getElementById(id);
+let data = null;              // last scan from the server
+let config = {};              // the environment the server is pointed at
+let selected = new Set();     // profile ids picked for migration
+let expanded = new Set();
+let stateFilter = new Set();
+let sort = { key: "state", dir: 1 };
+let polling = null;
+let page = 0;                 // page of the filtered table, not of the status feed
+let pageSize = 100;
+let liveAck = "";             // the production environment whose name has been typed back
+let ackedFor = "";            // which environment that answer was given for
+let envHeaders = [];          // extra Hyperswitch headers, edited in the environment panel
+let spHeaders = [];           // extra Superposition headers
+let deHeaders = [];           // extra decision engine headers
+
+// ------------------------------------------------------------------ loading
+
+async function loadState() {
+  // The scan is nearly the whole payload and only changes when one finishes, so the poll says
+  // which one it holds and is sent the jobs alone for as long as nothing has replaced it.
+  const held = data ? `?scan_at=${encodeURIComponent(data.scanned_at)}` : "";
+  const res = await fetch("/api/state" + held);
+  const state = await res.json();
+  if (state.scan_unchanged) state.scan = data;
+  render(state);
+  const running = state.scan_job.running || state.migrate_job.running ||
+                  state.cutover_job.running || state.scope_job.running;
+  if (running && !polling) polling = setInterval(loadState, 900);
+  if (!running && polling) { clearInterval(polling); polling = null; }
+  return state;
+}
+
+async function post(path, body) {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body || {}),
+  });
+  const payload = await res.json();
+  if (!res.ok) throw new Error(payload.error || "request failed");
+  return payload;
+}
+
+// ----------------------------------------------------------------- rendering
+
+function render(state) {
+  config = state.config;
+  el("hs-url").textContent = config.hyperswitch_url;
+  el("key-state").textContent = config.api_key_set
+    ? `api-key ${config.api_key_hint}` : "no api-key set";
+  el("env-forget").hidden = !config.saved;
+  // The panel is a view of the environment in use, so a switch from the picker refills it. Left
+  // as it was, it would show the last environment's addresses and credentials under the new
+  // one's name — and "Use this environment" would then write them onto it.
+  if (!el("env-panel").hidden && !envCreating && envPanelFor !== config.name) openEnv(false);
+  renderEnvPick();
+  el("live-tag").hidden = !config.live;
+  document.body.classList.toggle("live", Boolean(config.live));
+  // The answer given for one production environment says nothing about another, so it is asked
+  // for again as soon as the console is pointed somewhere else.
+  if (ackedFor !== config.name) { liveAck = ""; ackedFor = config.name; }
+
+  const scanning = state.scan_job.running;
+  const migrating = state.migrate_job.running;
+  el("scan-btn").disabled = scanning || migrating || !config.api_key_set;
+  el("scan-btn").textContent = scanning ? "Scanning…" : (state.scan ? "Rescan" : "Scan estate");
+  // Nothing can be read without a key, so the panel opens itself rather than leaving the
+  // scan button inert with no explanation.
+  if (!config.api_key_set && !envTouched) openEnv();
+
+  const failure = state.scan_job.error || state.migrate_job.error || state.cutover_job.error ||
+                  state.scope_job.error;
+  el("alert").innerHTML = failure
+    ? `<div class="banner">${escape(failure)}</div>`
+    : runFailureBanner(state);
+
+  if (state.scan) {
+    data = state.scan;
+    el("scanned-at").textContent = "scanned " + timeAgo(data.scanned_at);
+    renderEstate(data.totals);
+    renderStates(data.totals.states);
+    renderFilters();
+    renderRows();
+  }
+  renderScopes(state);
+  renderMore(state);
+  renderActionBar(state);
+  renderReport(state.migrate_job);
+  renderCutoverReport(state.cutover_job);
+  renderScopeReport(state.scope_job);
+}
+
+// The batch this profile's outcome came back in. `HE_00 / Something went wrong` is the router
+// declining to say what happened; what happened is in its log, under this id.
+function requestIds(profile) {
+  const ids = profile.request_ids || [];
+  if (!ids.length) return "";
+  return ` · <span class="rid" title="Hyperswitch x-request-id — search its logs for this">` +
+         `${escape(ids.join(" "))}</span>`;
+}
+
+// What a finished run failed at, said at the top of the page. It stays until the next run, which
+// is when the result it describes is replaced.
+function runFailureBanner(state) {
+  const cut = state.cutover_job.result;
+  if (cut && cut.totals.failed) {
+    const first = cut.profiles.find((p) => !p.ok);
+    return `<div class="banner"><b>${cut.totals.failed}</b> of ${cut.totals.profiles}
+      ${plural(cut.totals.profiles, "profile")} did not switch routing &mdash;
+      ${escape(first.error)}. <a href="#cutover-report">See the run</a>.</div>`;
+  }
+  const run = state.migrate_job.result;
+  if (run && run.failures && run.failures.length) {
+    return `<div class="banner"><b>${run.failures.length}</b>
+      ${plural(run.failures.length, "batch")} did not run &mdash;
+      ${escape(run.failures[0].error)}. <a href="#report">See the run</a>.</div>`;
+  }
+  return "";
+}
+
+// How much of the estate the last scan read. A scan walks the status feed to its end, so this
+// says what the table is made of rather than offering to read the rest.
+function renderMore(state) {
+  const target = el("more");
+  if (!state.scan) { target.innerHTML = ""; return; }
+  const read = state.scan.rows.length;
+  target.innerHTML = `<div class="notice">Whole estate read &mdash; <b>${read}</b>
+    ${plural(read, "profile")} across <b>${state.pages_read}</b> ${plural(state.pages_read, "page")}
+    of the status feed.</div>`;
+}
+
+function renderEstate(totals) {
+  el("estate").hidden = false;
+  el("c-orgs").textContent = totals.organizations;
+  el("c-merchants").textContent = totals.merchants;
+  el("c-profiles").textContent = totals.profiles;
+  el("c-pending").textContent = totals.rules_pending;
+  el("c-cutover").textContent = totals.cutover_ready;
+  // Nothing checked is not the same as nothing missing, so an unread column says so rather
+  // than reading as a clean zero.
+  const checked = totals.scopes_checked > 0;
+  const incomplete = totals.scopes_missing + totals.scopes_no_ancestry;
+  el("c-scopes").textContent = checked ? incomplete : "\u2014";
+  el("c-scopes").classList.toggle("warn", checked && totals.scopes_missing > 0);
+  el("l-de").textContent = totals.rules_decision_engine;
+  el("l-hs").textContent = totals.rules_pending;
+  el("l-oos").textContent = totals.rules_out_of_scope;
+  el("estate-bar").innerHTML = crossing(
+    totals.rules_decision_engine, totals.rules_pending, totals.rules_out_of_scope);
+}
+
+// Whether the decision engine holds a scope for each profile — the one thing the migration
+// status cannot say, since Hyperswitch reads that engine for rules alone. Without a scope a
+// profile still migrates its rules and still reads `migrated`, and only fails when traffic
+// arrives, which is why this is stated at the top rather than left in a column.
+function renderScopes(state) {
+  const target = el("scopes");
+  if (!state.scan) { target.innerHTML = ""; return; }
+  const scopes = state.scan.scopes;
+  const de = config.decision_engine || {};
+  const busy = state.scan_job.running || state.migrate_job.running ||
+               state.cutover_job.running || state.scope_job.running;
+  if (!de.ready) {
+    target.innerHTML = `<div class="notice">Scopes not checked. Hyperswitch compares rule ids
+      only &mdash; a profile the decision engine has no scope for reads exactly like one whose
+      rules have not crossed yet, migrates clean, and is refused at
+      <code>decide-gateway</code> once it is cut over. Set the decision engine URL and admin
+      secret under <em>Environment</em> to have every scan check.</div>`;
+    return;
+  }
+  if (!scopes) { target.innerHTML = ""; return; }
+  if (scopes.error) {
+    target.innerHTML = `<div class="notice warn">The decision engine could not be read, so no
+      profile below claims a scope either way &mdash; ${escape(scopes.error)}</div>`;
+    return;
+  }
+  const missing = scopes.missing || [];
+  const noAncestry = scopes.no_ancestry || [];
+  const stranded = scopes.stranded || [];
+  const strandedNote = stranded.length
+    ? `<div style="margin-top:6px"><b>${stranded.length}</b>
+       ${plural(stranded.length, "scope")} in the decision engine ${stranded.length === 1 ? "is" : "are"}
+       registered under a merchant id rather than a profile id
+       (${stranded.slice(0, 3).map(escape).join(", ")}${stranded.length > 3 ? "…" : ""}).
+       They hold rules and scores no profile inherits, and nothing here can decide which profile
+       they meant &mdash; disposition them in the decision engine.</div>` : "";
+  // A scope with no ancestry against it is a second, milder gap: routing works, naming and
+  // grants do not. It is offered to the same run, and never holds a cutover.
+  const ancestryNote = noAncestry.length
+    ? `<div style="margin-top:6px"><b>${noAncestry.length}</b>
+       ${plural(noAncestry.length, "profile")} ${noAncestry.length === 1 ? "has" : "have"} a scope
+       with nothing recorded above it &mdash; no organization, merchant or profile name. Routing
+       is unaffected; the dashboard cannot name the account and an org or merchant grant cannot
+       expand to reach it. Provisioning fills it in.</div>` : "";
+  if (!missing.length && !noAncestry.length) {
+    target.innerHTML = `<div class="notice">Every profile read has a scope in the decision
+      engine, with its ancestry &mdash; <b>${scopes.linked}</b> linked.${strandedNote}</div>`;
+    return;
+  }
+  if (!missing.length) {
+    target.innerHTML = `<div class="notice"><b>${scopes.linked}</b> profiles have a scope in the
+      decision engine.${ancestryNote}
+      <span class="env-actions" style="margin-top:8px">
+        <button class="ghost" id="scopes-fix" ${busy ? "disabled" : ""}>Provision ${noAncestry.length}
+          ${plural(noAncestry.length, "scope")}</button>
+        <button class="ghost" id="scopes-filter">Show them</button>
+      </span>${strandedNote}</div>`;
+    wireScopeButtons(noAncestry, "no_ancestry");
+    return;
+  }
+  target.innerHTML = `<div class="notice warn"><b>${missing.length}</b>
+    ${plural(missing.length, "profile")} ${missing.length === 1 ? "has" : "have"} no scope in the
+    decision engine. Their rules can be migrated and will read as <em>migrated</em>, but
+    <code>decide-gateway</code> loads the scope before anything else and answers
+    <code>MERCHANT_NOT_FOUND</code> without one, so cutting them over is held back until it
+    exists.
+    <span class="env-actions" style="margin-top:8px">
+      <button class="ghost" id="scopes-fix" ${busy ? "disabled" : ""}>Provision
+        ${missing.length + noAncestry.length} ${plural(missing.length + noAncestry.length, "scope")}</button>
+      <button class="ghost" id="scopes-filter">Show them</button>
+    </span>${ancestryNote}${strandedNote}</div>`;
+  wireScopeButtons(missing.concat(noAncestry), "missing");
+}
+
+function wireScopeButtons(ids, filterValue) {
+  el("scopes-fix").onclick = () => createScopes(ids);
+  el("scopes-filter").onclick = () => {
+    el("f-scope").value = filterValue;
+    page = 0;
+    renderRows(); renderActionBarFromData();
+  };
+}
+
+function crossing(de, hs, oos) {
+  const total = Math.max(de + hs + oos, 1);
+  const pct = (n) => (n / total * 100).toFixed(2) + "%";
+  const parts = [];
+  if (de > 0) parts.push(`<span class="seg-de" style="width:${pct(de)}" title="${de} in the decision engine"></span>`);
+  if (hs > 0) parts.push(`<span class="seg-hs" style="width:${pct(hs)}" title="${hs} only in Hyperswitch"></span>`);
+  if (oos > 0) parts.push(`<span class="seg-oos" style="width:${pct(oos)}" title="${oos} out of scope"></span>`);
+  return parts.join("");
+}
+
+function renderStates(counts) {
+  el("states").innerHTML = STATES.map(([key, label, tone]) => {
+    const n = counts[key] || 0;
+    const on = stateFilter.has(key);
+    return `<button class="state-chip" data-state="${key}" style="--tone:${tone}"
+              aria-pressed="${on}" ${n === 0 && !on ? "disabled" : ""}>
+              <span class="n">${n}</span><span class="k">${label}</span></button>`;
+  }).join("");
+  el("states").querySelectorAll(".state-chip").forEach((btn) => {
+    btn.onclick = () => {
+      const key = btn.dataset.state;
+      stateFilter.has(key) ? stateFilter.delete(key) : stateFilter.add(key);
+      page = 0;
+      renderStates(counts); renderRows(); renderActionBarFromData();
+    };
+  });
+}
+
+function renderFilters() {
+  fillSelect("f-org", "All organizations",
+    unique(data.rows.map((r) => r.organization_id).filter(Boolean)));
+  fillSelect("f-merchant", "All merchants", unique(data.rows.map((r) => r.merchant_id)));
+  fillSelect("f-source", "Any routing source",
+    unique(data.rows.map((r) => r.routing_source).filter(Boolean)));
+}
+
+function fillSelect(id, allLabel, values) {
+  const select = el(id);
+  const current = select.value;
+  select.innerHTML = `<option value="">${allLabel}</option>` +
+    values.map((v) => `<option value="${escape(v)}">${escape(v)}</option>`).join("");
+  if (values.includes(current)) select.value = current;
+}
+
+// A profile can be picked when some run could act on it: rules to move, or a routing source to
+// switch. Profiles whose merchant account is gone are held back from migration by default, since
+// the endpoint can only answer "not attempted" for them.
+function isSelectable(row) {
+  if (row.migratable || row.cutover || row.needs_provision) return true;
+  return el("f-blocked").checked && row.blocker === "no_merchant_account" && row.rules_pending > 0;
+}
+
+function cutoverReady() { return Boolean(config.superposition && config.superposition.ready); }
+function scopesReady() { return Boolean(config.decision_engine && config.decision_engine.ready); }
+function selectedRows() { return data ? data.rows.filter((r) => selected.has(r.profile_id)) : []; }
+
+function visibleRows() {
+  if (!data) return [];
+  const org = el("f-org").value, merchant = el("f-merchant").value, source = el("f-source").value;
+  const scope = el("f-scope").value;
+  const needle = el("f-search").value.trim().toLowerCase();
+  const actionable = el("f-actionable").checked;
+  let rows = data.rows.filter((r) => {
+    if (stateFilter.size && !stateFilter.has(r.state)) return false;
+    if (org && r.organization_id !== org) return false;
+    if (merchant && r.merchant_id !== merchant) return false;
+    if (source && r.routing_source !== source) return false;
+    if (scope === "missing" && !r.scope_missing) return false;
+    if (scope === "no_ancestry" && !r.ancestry_missing) return false;
+    if (scope === "present" && (r.scope_in_de !== true || r.ancestry_missing)) return false;
+    if (actionable && !r.migratable) return false;
+    if (needle) {
+      const hay = [r.profile_id, r.merchant_id, r.merchant_name, r.organization_id,
+                   ...(r.rules_missing_in_decision_engine || [])].join(" ").toLowerCase();
+      if (!hay.includes(needle)) return false;
+    }
+    return true;
+  });
+  const key = sort.key;
+  const rank = (r) => key === "state" ? STATES.findIndex(([k]) => k === r.state) : r[key];
+  rows.sort((a, b) => {
+    const x = rank(a) ?? -1, y = rank(b) ?? -1;
+    if (x === y) return a.profile_id.localeCompare(b.profile_id);
+    return (x > y ? 1 : -1) * sort.dir;
+  });
+  if (el("f-group").checked) {
+    rows.sort((a, b) => {
+      const ax = a.organization_id || "￿", bx = b.organization_id || "￿";
+      if (ax !== bx) return ax.localeCompare(bx);
+      return a.merchant_id.localeCompare(b.merchant_id);
+    });
+  }
+  return rows;
+}
+
+function renderRows() {
+  const all = visibleRows();
+  renderSelectableNotice(all);
+  el("empty").hidden = all.length > 0;
+  if (!all.length && data) {
+    el("empty").innerHTML = "<b>No profiles match these filters</b>Widen the filters to see the rest of the estate.";
+  }
+  const rows = renderPager(all);
+  const grouped = el("f-group").checked;
+  const out = [];
+  let group = null;
+  for (const r of rows) {
+    if (grouped) {
+      const key = (r.organization_id || "(no organization)") + " / " + r.merchant_id;
+      if (key !== group) {
+        group = key;
+        out.push(`<tr class="group-row"><td colspan="12"><span class="id">${escape(key)}</span>
+          ${r.merchant_name ? `<span class="sub">${escape(r.merchant_name)}</span>` : ""}</td></tr>`);
+      }
+    }
+    out.push(rowHtml(r, grouped));
+    if (expanded.has(r.profile_id)) out.push(detailHtml(r));
+  }
+  el("rows").innerHTML = out.join("");
+  // The header box reflects the view: ticked only when everything movable in it is picked.
+  const movable = rows.filter(isSelectable);
+  el("select-all").checked = movable.length > 0 && movable.every((r) => selected.has(r.profile_id));
+
+  el("rows").querySelectorAll("input[data-pick]").forEach((box) => {
+    box.onchange = () => {
+      box.checked ? selected.add(box.dataset.pick) : selected.delete(box.dataset.pick);
+      box.closest("tr").classList.toggle("selected", box.checked);
+      renderActionBarFromData();
+    };
+  });
+  const toggle = (id) => {
+    expanded.has(id) ? expanded.delete(id) : expanded.add(id);
+    renderRows();
+  };
+  el("rows").querySelectorAll("button[data-expand]").forEach((btn) => {
+    btn.onclick = (event) => { event.stopPropagation(); toggle(btn.dataset.expand); };
+  });
+  // Clicking the row itself opens it. The checkbox and the panel's own buttons keep their
+  // meaning, so clicks that land on a control are left alone.
+  el("rows").querySelectorAll("tr[data-row]").forEach((tr) => {
+    tr.onclick = (event) => {
+      if (event.target.closest("input, button, a")) return;
+      toggle(tr.dataset.row);
+    };
+  });
+  el("rows").querySelectorAll("button[data-migrate-one]").forEach((btn) => {
+    btn.onclick = (event) => { event.stopPropagation(); migrateProfiles([btn.dataset.migrateOne]); };
+  });
+  el("rows").querySelectorAll("button[data-cutover-one]").forEach((btn) => {
+    btn.onclick = (event) => { event.stopPropagation(); cutoverProfiles([btn.dataset.cutoverOne], TO_DE); };
+  });
+  el("rows").querySelectorAll("button[data-rollback-one]").forEach((btn) => {
+    btn.onclick = (event) => { event.stopPropagation(); cutoverProfiles([btn.dataset.rollbackOne], TO_HS); };
+  });
+  el("rows").querySelectorAll("button[data-scope-one]").forEach((btn) => {
+    btn.onclick = (event) => { event.stopPropagation(); createScopes([btn.dataset.scopeOne]); };
+  });
+  el("rows").querySelectorAll("button[data-pick-btn]").forEach((btn) => {
+    btn.onclick = (event) => {
+      event.stopPropagation();
+      const id = btn.dataset.pickBtn;
+      selected.has(id) ? selected.delete(id) : selected.add(id);
+      renderRows();
+      renderActionBarFromData();
+    };
+  });
+}
+
+// The table shows one page of the filtered rows; the estate is larger than a browser wants to
+// lay out at once, and paging keeps a row's position stable while it is being worked on.
+function renderPager(all) {
+  const pages = pageSize === 0 ? 1 : Math.max(1, Math.ceil(all.length / pageSize));
+  if (page >= pages) page = pages - 1;
+  const start = pageSize === 0 ? 0 : page * pageSize;
+  const shown = pageSize === 0 ? all : all.slice(start, start + pageSize);
+  const pager = el("pager");
+  pager.hidden = all.length === 0;
+  el("pager-info").innerHTML = all.length
+    ? `Showing <b>${shown.length ? start + 1 : 0}\u2013${start + shown.length}</b> of
+       <b>${all.length}</b> ${plural(all.length, "profile")} in view`
+    : "";
+  // The header checkbox reaches one page; a cutover of everything `migrated` is a run over
+  // hundreds, so the filtered set gets its own control rather than 6 pages of ticking.
+  const selectable = all.filter(isSelectable);
+  const beyond = selectable.length > shown.filter(isSelectable).length;
+  const viewBtn = el("select-view");
+  viewBtn.hidden = !beyond;
+  if (beyond) {
+    const allPicked = selectable.every((r) => selected.has(r.profile_id));
+    viewBtn.textContent = allPicked
+      ? `Clear all ${selectable.length}`
+      : `Select all ${selectable.length} in view`;
+    viewBtn.onclick = () => {
+      selectable.forEach((r) => allPicked ? selected.delete(r.profile_id) : selected.add(r.profile_id));
+      renderRows(); renderActionBarFromData();
+    };
+  }
+  el("page-label").innerHTML = `Page <b>${page + 1}</b> of <b>${pages}</b>`;
+  el("page-prev").disabled = page === 0;
+  el("page-next").disabled = page >= pages - 1;
+  return shown;
+}
+
+// An operator looking for the migrate action needs to know why no row offers one.
+function renderSelectableNotice(rows) {
+  const target = el("nothing-selectable");
+  if (!rows.length || rows.some(isSelectable)) { target.innerHTML = ""; return; }
+  const counts = rows.reduce((acc, r) => {
+    const key = r.blocker || (r.rules_pending === 0 ? "nothing_pending" : "other");
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+  const reasons = [];
+  if (counts.no_merchant_account)
+    reasons.push(`<b>${counts.no_merchant_account}</b> have no merchant account in Hyperswitch`);
+  if (counts.out_of_scope_only)
+    reasons.push(`<b>${counts.out_of_scope_only}</b> hold only dynamic or 3DS rules`);
+  if (counts.nothing_pending)
+    reasons.push(`<b>${counts.nothing_pending}</b> are already across`);
+  if (counts.other) reasons.push(`<b>${counts.other}</b> report an unreadable decision engine`);
+  target.innerHTML = `<div class="notice">No profile in view can be migrated &mdash;
+    ${reasons.join(", ")}. ${counts.no_merchant_account
+      ? "Tick <em>Allow profiles with no merchant account</em> to send them anyway and see what Hyperswitch reports."
+      : ""}</div>`;
+}
+
+function rowHtml(r, grouped) {
+  const de = r.rules_decision_engine;
+  const landed = Math.max((de === null ? 0 : de) - r.rules_extra, 0);
+  const selectable = isSelectable(r);
+  const pick = `<input type="checkbox" data-pick="${escape(r.profile_id)}"
+      ${selected.has(r.profile_id) ? "checked" : ""} ${selectable ? "" : "disabled"}
+      title="${escape(selectable
+        ? (r.needs_provision && !r.migratable ? "Pick to have its scope provisioned" : "Pick for migration")
+        : (BLOCKED_WHY[r.blocker] || "Nothing to move"))}" />`;
+  // A missing scope is shown alongside whatever else holds the row back rather than replacing
+  // it: the two are independent, and the merchant-account note is what the escape hatch keys on.
+  const notes = [
+    r.scope_missing ? `<span class="tag warn" title="${escape(NO_SCOPE_WHY)}">no scope in DE</span>` : "",
+    !r.scope_missing && r.ancestry_missing
+      ? `<span class="tag" title="${escape(NO_ANCESTRY_WHY)}">no ancestry in DE</span>` : "",
+    r.blocker ? `<span class="tag">${BLOCKERS[r.blocker]}</span>` : "",
+    !r.blocker && r.rules_extra ? `<span class="tag">${r.rules_extra} only in DE</span>` : "",
+  ].filter(Boolean);
+  const note = notes.join(" ");
+  return `<tr class="row ${selected.has(r.profile_id) ? "selected" : ""}"
+      data-row="${escape(r.profile_id)}" title="Open this profile">
+    <td>${pick}</td>
+    <td><button class="expand" data-expand="${escape(r.profile_id)}"
+          aria-expanded="${expanded.has(r.profile_id)}"
+          title="Open this profile">${expanded.has(r.profile_id) ? "&minus;" : "+"}</button></td>
+    <td class="id">${grouped ? "" : escape(r.organization_id || "—")}</td>
+    <td class="id">${grouped ? "" : escape(r.merchant_id)}
+      ${!grouped && r.merchant_name ? `<span class="sub">${escape(r.merchant_name)}</span>` : ""}</td>
+    <td class="id">${escape(r.profile_id)}</td>
+    <td class="num">${r.rules_hyperswitch}</td>
+    <td class="num">${de === null ? "—" : de}</td>
+    <td class="bar-cell"><div class="crossing">${crossing(landed, r.rules_pending, r.rules_out_of_scope)}</div></td>
+    <td class="num">${r.rules_pending || ""}</td>
+    <td class="num">${r.rules_out_of_scope || ""}</td>
+    <td><span class="badge ${r.state}">${labelOf(r.state)}</span></td>
+    <td>${note}</td>
+  </tr>`;
+}
+
+function detailHtml(r) {
+  const list = (title, ids) => ids && ids.length
+    ? `<div>${title}<div class="ids">${ids.map((i) => `<span>${escape(i)}</span>`).join("")}</div></div>` : "";
+  const facts = [
+    list(`Missing in the decision engine (${r.rules_pending})`, r.rules_missing_in_decision_engine),
+    list(`Only in the decision engine (${r.rules_extra})`, r.rules_only_in_decision_engine),
+    r.routing_source ? `<div>Routing source: ${escape(r.routing_source)}</div>` : "",
+    r.rules_out_of_scope ? `<div>${r.rules_out_of_scope} ${plural(r.rules_out_of_scope, "rule")} out of scope — dynamic and 3DS rules reach the decision engine another way.</div>` : "",
+  ].filter(Boolean).join("");
+  return `<tr class="detail"><td colspan="2"></td><td colspan="10">
+    ${panelActions(r)}
+    ${facts || "Nothing outstanding."}
+  </td></tr>`;
+}
+
+// What can be done to this one profile, stated where the operator is looking. The batch
+// checkbox is for planning a run; this is for acting on the row in front of you.
+function panelActions(r) {
+  const inRun = migrateRunning();
+  const picked0 = selected.has(r.profile_id);
+  const pick0 = `<button class="ghost" data-pick-btn="${escape(r.profile_id)}">
+    ${picked0 ? "Remove from batch" : "Add to batch"}</button>`;
+  // A missing scope is a second thing wrong with the profile, independent of anything the rule
+  // counts say, so it is stated above whatever else the row offers rather than in place of it:
+  // a profile can be missing both a scope and its merchant account, and each has its own action.
+  if (!r.scope_missing && r.ancestry_missing) {
+    return `<div class="panel-actions">
+      <button class="action" data-scope-one="${escape(r.profile_id)}" ${inRun ? "disabled" : ""}>
+        Provision the ancestry</button>
+      ${pick0}
+      <span class="panel-note">The decision engine holds a scope for this profile but nothing
+        above it &mdash; no organization, merchant or profile name. <em>Routing is
+        unaffected</em>: <code>decide-gateway</code> needs only the scope, so this profile can be
+        cut over as it stands. What is missing is the account name the dashboard shows, and the
+        reach of any org or merchant grant. Provisioning re-runs the migration so Hyperswitch
+        records it; no rule is touched.</span></div>` + profileActions(r, inRun, "");
+  }
+  if (!r.scope_missing) return profileActions(r, inRun, pick0);
+  return `<div class="panel-actions">
+      <button class="action" data-scope-one="${escape(r.profile_id)}" ${inRun ? "disabled" : ""}>
+        Provision the scope</button>
+      ${pick0}
+      <span class="panel-note">The decision engine holds no scope for this profile.
+        ${r.rules_pending
+          ? `Its ${r.rules_pending} pending ${plural(r.rules_pending, "rule")} can still be migrated — rules key off the profile id and are written either way — `
+          : `Its rules are all across — they key off the profile id and were written either way — `}
+        but <code>decide-gateway</code> loads the scope first and answers
+        <code>MERCHANT_NOT_FOUND</code> without one, so <em>this profile cannot be cut over
+        until the scope exists</em>. Provisioning re-runs the migration for it: Hyperswitch
+        creates the scope, named with the organization, merchant and profile only it can read,
+        before it looks at a rule &mdash; and every rule already across is skipped.</span></div>` +
+    // The batch button is already above, so the panel below is drawn without one.
+    profileActions(r, inRun, "");
+}
+
+// What the rule counts alone say can be done to this profile.
+function profileActions(r, inRun, pick0) {
+  // A profile with every rule across is where a cutover belongs: the decision engine can answer
+  // for it, and until this is written Hyperswitch keeps deciding.
+  if (r.cutover === "to_de") {
+    return `<div class="panel-actions">
+      <button class="action" data-cutover-one="${escape(r.profile_id)}"
+        ${inRun || !cutoverReady() ? "disabled" : ""}>Cut over to decision engine</button>
+      ${pick0}
+      <span class="panel-note">${cutoverReady()
+        ? `Writes <code>${escape(config.superposition.config_key)}: decision_engine</code> for this
+           profile in Superposition. <em>This moves live traffic</em> — the decision engine starts
+           deciding routing for it.`
+        : `Set the Superposition URL and secret under <em>Environment</em> to cut profiles over
+           from here.`}</span></div>`;
+  }
+  if (r.cutover === "to_hs") {
+    return `<div class="panel-actions">
+      <button class="ghost" data-rollback-one="${escape(r.profile_id)}"
+        ${inRun || !cutoverReady() ? "disabled" : ""}>Roll back to Hyperswitch</button>
+      ${pick0}
+      <span class="panel-note">The decision engine decides routing for this profile
+        ${r.state === "enabled_without_rules" ? "and its rules are missing, so traffic falls through to the default connector list. " : ""}
+        Rolling back writes <code>hyperswitch_routing</code> for it, which hands routing back to
+        Hyperswitch without touching any rule.</span></div>`;
+  }
+  if (r.rules_pending === 0) {
+    return `<div class="panel-actions"><span class="panel-note">Every rule this endpoint
+      carries is already in the decision engine. Nothing to migrate.</span></div>`;
+  }
+  if (r.blocker === "out_of_scope_only") {
+    return `<div class="panel-actions"><span class="panel-note">${r.rules_out_of_scope} rules,
+      all of them dynamic or 3DS. This endpoint never carries those, so there is nothing to
+      migrate.</span></div>`;
+  }
+  const pickButton = pick0;
+  if (r.blocker === "no_merchant_account") {
+    return `<div class="panel-actions">
+      <button class="action" data-migrate-one="${escape(r.profile_id)}" ${inRun ? "disabled" : ""}>
+        Migrate anyway</button>
+      ${pickButton}
+      <span class="panel-note">Merchant <code>${escape(r.merchant_id)}</code> cannot be read in
+        Hyperswitch, so this will come back as <em>not attempted</em> until that account exists.
+        Running it is safe — it writes nothing.</span></div>`;
+  }
+  return `<div class="panel-actions">
+    <button class="action" data-migrate-one="${escape(r.profile_id)}" ${inRun ? "disabled" : ""}>
+      Migrate this profile</button>
+    ${pickButton}
+    <span class="panel-note">Writes ${r.rules_pending}
+      ${plural(r.rules_pending, "rule")} into the decision engine. Rules already there are left
+      alone, and Hyperswitch keeps serving this profile until routing is cut over
+      separately.</span></div>`;
+}
+
+// --------------------------------------------------------------- action bar
+
+function renderActionBarFromData() { renderActionBar(lastState); }
+function migrateRunning() {
+  return Boolean((lastState.migrate_job && lastState.migrate_job.running) ||
+                 (lastState.cutover_job && lastState.cutover_job.running) ||
+                 (lastState.scope_job && lastState.scope_job.running));
+}
+let lastState = { scan_job: {}, migrate_job: {}, cutover_job: {}, scope_job: {} };
+
+const JOB_VERB = { scan: "Scanning", migrate: "Migrating", cutover: "Switching routing",
+                   scopes: "Creating scopes" };
+
+function renderActionBar(state) {
+  lastState = state;
+  const migrating = state.migrate_job.running, scanning = state.scan_job.running;
+  const cutting = state.cutover_job.running, scoping = state.scope_job.running;
+  const job = migrating ? state.migrate_job
+            : cutting ? state.cutover_job
+            : scoping ? state.scope_job
+            : (scanning ? state.scan_job : null);
+  const bar = el("actionbar");
+  bar.hidden = !selected.size && !job;
+
+  const rows = selectedRows();
+  const rules = rows.reduce((n, r) => n + r.rules_pending, 0);
+  const movable = rows.filter((r) => r.rules_pending > 0).length;
+  const toDe = rows.filter((r) => r.cutover === "to_de").length;
+  const toHs = rows.filter((r) => r.cutover === "to_hs").length;
+  const noScope = rows.filter((r) => r.needs_provision).length;
+  const parts = [];
+  if (movable) parts.push(`<b>${rules}</b> ${plural(rules, "rule")} to move`);
+  if (noScope) parts.push(`<b>${noScope}</b> to provision in the decision engine`);
+  if (toDe) parts.push(`<b>${toDe}</b> ready to cut over`);
+  if (toHs) parts.push(`<b>${toHs}</b> already on the decision engine`);
+  el("action-summary").innerHTML = selected.size
+    ? `<b>${selected.size}</b> ${plural(selected.size, "profile")} selected` +
+      (parts.length ? ` &middot; ${parts.join(" &middot; ")}` : "")
+    : (job ? `${JOB_VERB[job.kind]}…` : "");
+
+  const progress = el("job-progress");
+  progress.hidden = !job;
+  if (job) {
+    const pct = job.total ? Math.min(100, job.done / job.total * 100) : 8;
+    progress.firstElementChild.style.width = pct + "%";
+    el("job-message").textContent = job.message + (job.total ? ` (${job.done}/${job.total})` : "");
+  } else {
+    el("job-message").textContent = "";
+  }
+  const busy = migrating || scanning || cutting || scoping;
+  el("migrate-btn").hidden = selected.size > 0 && movable === 0;
+  el("migrate-btn").disabled = !movable || busy;
+  el("migrate-btn").textContent = migrating ? "Migrating…" : `Migrate ${movable || ""}`.trim();
+
+  // The cutover buttons appear only for a selection that has something to switch, so the bar
+  // offers the direction the selection is actually in rather than both at all times.
+  const cutBtn = el("cutover-btn");
+  cutBtn.hidden = !toDe;
+  cutBtn.disabled = busy || !cutoverReady();
+  cutBtn.title = cutoverReady() ? "" : "Set the Superposition URL and secret under Environment";
+  cutBtn.textContent = cutting ? "Switching…" : `Cut over ${toDe} to decision engine`;
+  const backBtn = el("rollback-btn");
+  backBtn.hidden = !toHs || toDe > 0;
+  backBtn.disabled = busy || !cutoverReady();
+  backBtn.textContent = `Roll back ${toHs} to Hyperswitch`;
+
+  // Creating scopes comes before either cutover direction in the order work actually happens,
+  // and it is the only action a scope-missing selection has.
+  const scopeBtn = el("scope-btn");
+  scopeBtn.hidden = !noScope;
+  scopeBtn.disabled = busy || !scopesReady();
+  scopeBtn.textContent = scoping ? "Provisioning…" : `Provision ${noScope} ${plural(noScope, "scope")}`;
+}
+
+function renderReport(job) {
+  const result = job.result;
+  if (!result) { el("report").innerHTML = ""; return; }
+  const t = result.totals;
+  const notAttempted = result.profiles.filter((p) => p.not_attempted);
+  const withErrors = result.profiles.filter((p) => (p.errors || []).length);
+  el("report").innerHTML = `
+    <div class="report">
+      <h2>Last migration run</h2>
+      <div class="estate-legend">
+        <span><b>${t.profiles}</b> ${plural(t.profiles, "profile")}</span>
+        <span><b>${t.rules_migrated}</b> ${plural(t.rules_migrated, "rule")} moved</span>
+        <span><b>${t.rules_skipped}</b> already there</span>
+        <span><b>${t.rules_failed}</b> failed</span>
+        <span><b>${t.rules_not_applicable}</b> not applicable</span>
+        <span><b>${t.profiles_not_attempted}</b> not attempted</span>
+      </div>
+      ${result.failures.length ? `<div class="banner">${result.failures.length} batches did not run: ${escape(result.failures[0].error)}</div>` : ""}
+      ${(withErrors.length || notAttempted.length) ? `<div class="rows">
+        ${withErrors.map((p) => p.errors.map((e) =>
+          `<div>${escape(p.profile_id)} · ${escape(e.algorithm_id)} · ${escape(e.error)}${requestIds(p)}</div>`).join("")).join("")}
+        ${notAttempted.map((p) =>
+          `<div>${escape(p.profile_id)} · not attempted · ${escape(p.not_attempted)}${requestIds(p)}</div>`).join("")}
+      </div>` : ""}
+    </div>`;
+}
+
+// What Superposition answered, profile by profile. The table still reads as the last scan left
+// it — a switch does not re-read the estate — so the report says which profiles moved and leaves
+// the rescan to whoever wants the states refreshed.
+function renderCutoverReport(job) {
+  const result = job.result;
+  if (!result) { el("cutover-report").innerHTML = ""; return; }
+  queueMicrotask(() => {
+    const btn = el("use-other-key");
+    if (btn) btn.onclick = () => useOtherKey(otherKeyName(result.config_key));
+  });
+  const t = result.totals;
+  const target = result.source === TO_DE ? "the decision engine" : "Hyperswitch";
+  const failed = result.profiles.filter((p) => !p.ok);
+  el("cutover-report").innerHTML = `
+    <div class="report">
+      <h2>Last routing switch &mdash; to ${target}</h2>
+      <div class="estate-legend">
+        <span><b>${t.profiles}</b> ${plural(t.profiles, "profile")}</span>
+        <span><b>${t.written}</b> overrides written</span>
+        <span><b>${t.failed}</b> failed</span>
+        <span class="tag">${escape((result.key_used || []).join(", ") || result.config_key)}:
+          ${escape(result.source)}</span>
+      </div>
+      ${t.failed ? `<div class="banner">${t.failed} ${plural(t.failed, "profile")} did not
+        switch &mdash; they are listed below and can be sent again, since writing the same
+        override twice changes nothing.</div>` : ""}
+      ${unknownKeyNote(result)}
+      ${failed.length ? `<div class="rows">
+        ${failed.map((p) => `<div>${escape(p.profile_id)} · ${escape(p.error)}</div>`).join("")}
+      </div>` : `<div class="panel-note" style="margin-top:8px">The table still shows the states
+        the last scan read. <b>Rescan</b> to read them again with the new routing source.</div>`}
+    </div>`;
+}
+
+// What the sync wrote. The scan is re-read as the run's last step, so unlike a cutover the
+// table beneath this already reflects it — the report is here to say what happened to the
+// profiles that were left out.
+function renderScopeReport(job) {
+  const result = job.result;
+  if (!result) { el("scope-report").innerHTML = ""; return; }
+  const t = result.totals;
+  const notAttempted = result.profiles.filter((p) => p.not_attempted);
+  el("scope-report").innerHTML = `
+    <div class="report">
+      <h2>Last scope run</h2>
+      <div class="estate-legend">
+        <span><b>${result.requested}</b> ${plural(result.requested, "profile")} sent</span>
+        <span><b>${result.still_missing.length}</b> still without a scope</span>
+        <span><b>${result.still_without_ancestry.length}</b> still without ancestry</span>
+        <span><b>${t.rules_skipped}</b> ${plural(t.rules_skipped, "rule")} already across</span>
+        <span><b>${t.rules_migrated}</b> moved</span>
+      </div>
+      ${result.failures.length ? `<div class="banner">${result.failures.length}
+        ${plural(result.failures.length, "batch")} did not run &mdash;
+        ${escape(result.failures[0].error)}</div>` : ""}
+      ${notAttempted.length ? `<div class="rows">
+        ${notAttempted.map((p) =>
+          `<div>${escape(p.profile_id)} · not attempted · ${escape(p.not_attempted)}${requestIds(p)}</div>`).join("")}
+      </div>` : ""}
+      ${(() => {
+        // Sent, reported fine, and the rescan still finds the gap — which means Hyperswitch
+        // answered success without provisioning. Worth naming, since nothing else would say so.
+        const unfixed = result.still_missing.concat(result.still_without_ancestry)
+          .filter((id) => !notAttempted.some((p) => p.profile_id === id));
+        const sent = new Map(result.profiles.map((p) => [p.profile_id, p]));
+        return unfixed.length ? `<div class="notice warn">These profiles were sent and the
+          decision engine still holds no scope, or none of their ancestry, afterwards &mdash; so
+          Hyperswitch reported success without provisioning one. That is a Hyperswitch-side
+          failure, not a selection mistake, and the id beside each is the request that reported
+          it.<div class="rows" style="margin-top:6px">${unfixed
+            .map((id) => `<div>${escape(id)}${requestIds(sent.get(id) || {})}</div>`).join("")}</div></div>` : "";
+      })()}
+    </div>`;
+}
+
+// Superposition rejects an override whose key its workspace does not define. That key was moved
+// into a `routing.` folder at one point, so an environment seeded either side of that rename
+// wants the other spelling — which is offered here rather than left to be guessed.
+function unknownKeyNote(result) {
+  // The workspace had no schema for the configured name and took the other one; the run says so
+  // and the field now holds what worked, so nothing has to be guessed twice.
+  if (result.key_switched) {
+    return `<div class="notice">This workspace has no config called
+      <b>${escape(result.key_switched)}</b>. The overrides went under
+      <b>${escape((result.key_used || []).join(", "))}</b> instead, which is now the override key
+      &mdash; save it under <em>Environment</em> with <em>Remember on this machine</em> to keep
+      it past a restart.</div>`;
+  }
+  const missing = result.profiles.some((p) =>
+    !p.ok && /failed to get schema for config key/i.test(p.error || ""));
+  if (!missing) return "";
+  const other = otherKeyName(result.config_key);
+  return `<div class="notice">This workspace has no config called
+    <b>${escape(result.config_key)}</b>, so every override under it is refused. Here it is likely
+    to be <b>${escape(other)}</b>: the routing configs were moved into a <code>routing.</code>
+    folder at one point, and an environment answers to the name it was seeded with.
+    <button class="ghost" id="use-other-key" style="margin-left:8px">Use ${escape(other)}</button>
+    </div>`;
+}
+
+function otherKeyName(key) {
+  return key.includes(".") ? key.slice(key.lastIndexOf(".") + 1) : "routing." + key;
+}
+
+// Switching the key is a config change, not a rerun: the profiles stay selected so the run can
+// be sent again once the name is right.
+async function useOtherKey(key) {
+  const sp = config.superposition || {};
+  try {
+    render(await post("/api/config", {
+      hyperswitch_url: config.hyperswitch_url,
+      headers: config.headers,
+      superposition: { url: sp.url, headers: sp.headers, config_key: key },
+    }));
+  } catch (err) { alert(err.message); }
+}
+
+// -------------------------------------------------------------------- events
+
+async function startScan(options) {
+  try { await post("/api/scan", { restart: options.restart !== false }); }
+  catch (err) { alert(err.message); }
+  loadState();
+  if (!polling) polling = setInterval(loadState, 900);
+}
+
+el("scan-btn").onclick = () => startScan({ restart: true });
+
+// ------------------------------------------------------------- environment
+
+let envTouched = false;       // set once the panel is opened, so it stops opening itself
+let envCreating = false;      // whether the panel is adding an environment or editing this one
+let envPanelFor = null;       // which environment the panel's fields were filled from
+
+// Every environment the server holds, plus the way to start another one. Rebuilt on each render
+// so a rename or a new environment shows up without a reload; the option in hand is not
+// replaced while it is open, or picking from it would fight the poll.
+function renderEnvPick() {
+  const pick = el("env-pick");
+  const wanted = (config.environments || []).map((env) =>
+    `<option value="${escape(env.name)}"${env.current ? " selected" : ""}>` +
+    `${escape(env.label)}${env.live ? " \u2022 production" : ""}</option>`).join("") +
+    `<option value="${NEW_ENV}">New environment\u2026</option>`;
+  if (pick.innerHTML !== wanted) pick.innerHTML = wanted;
+  pick.value = config.name;
+}
+
+// `blank` opens the panel on nothing at all, for an environment that does not exist yet: saving
+// it adds one rather than editing the one on screen.
+function openEnv(blank) {
+  envTouched = true;
+  envCreating = Boolean(blank);
+  el("env-panel").hidden = false;
+  el("env-label").value = blank ? "" : (config.label || "");
+  el("env-kind").value = blank ? "other" : (config.kind || "other");
+  el("env-url").value = blank ? "" : (config.hyperswitch_url || "");
+  el("env-key").value = "";
+  el("env-key").placeholder = !blank && config.api_key_set
+    ? `unchanged (${config.api_key_hint})` : "paste the admin api-key";
+  el("env-remember").checked = Boolean(config.saved);
+  envHeaders = blank ? [] : (config.headers || []).map((h) => ({ ...h }));
+  const sp = blank ? {} : (config.superposition || {});
+  el("sp-url").value = sp.url || "";
+  el("sp-secret").value = "";
+  el("sp-secret").placeholder = sp.secret_set ? "unchanged" : "x-superposition-secret";
+  el("sp-key").value = sp.config_key || config.cutover_key_default || "";
+  el("env-key-name").textContent = sp.config_key || config.cutover_key_default || "";
+  spHeaders = blank ? [] : (sp.headers || []).map((h) => ({ ...h }));
+  const de = blank ? {} : (config.decision_engine || {});
+  el("de-url").value = de.url || "";
+  el("de-secret").value = "";
+  el("de-secret").placeholder = de.secret_set ? "unchanged" : "x-admin-secret";
+  deHeaders = blank ? [] : (de.headers || []).map((h) => ({ ...h }));
+  envPanelFor = blank ? null : config.name;
+  el("env-title").textContent = blank ? "New environment" : "Environment";
+  el("env-save").textContent = blank ? "Add this environment" : "Use this environment";
+  el("env-error").textContent = "";
+  renderEnvHeaders();
+  el("env-label").focus();
+}
+
+// The environment's kind follows the address while it is being typed, so a production URL is
+// marked as one before it is saved. It stops following as soon as the kind is set by hand.
+let kindTouched = false;
+function guessKind(url) {
+  const host = (url.match(/^https?:\/\/([^/]*)/) || ["", ""])[1].toLowerCase();
+  if (!host || /^(localhost|127\.0\.0\.1|\[::1\])(:|$)/.test(host)) return "local";
+  if (host.includes("sandbox") || host.includes("integ")) return "sandbox";
+  if (host.endsWith("hyperswitch.io")) return "production";
+  return "other";
+}
+
+function renderEnvHeaders() {
+  drawHeaders("env-headers", envHeaders,
+    `No extra headers. A hosted environment usually needs one &mdash; <code>x-feature</code>
+     names the release train that answers.`);
+  drawHeaders("sp-headers", spHeaders,
+    `No Superposition headers. <code>x-tenant</code> and <code>x-org-id</code> are what a
+     workspace is usually addressed by.`);
+  drawHeaders("de-headers", deHeaders,
+    `No decision engine headers. A multi-tenant deployment picks its tenant with
+     <code>x-tenant-id</code>; the default tenant answers without one.`);
+}
+
+function drawHeaders(id, list, emptyNote) {
+  const box = el(id);
+  box.innerHTML = list.map((h, i) => `
+    <div class="env-header-row">
+      <input value="${escape(h.name)}" data-header-name="${i}" placeholder="header" spellcheck="false" />
+      <input value="${escape(h.value)}" data-header-value="${i}" placeholder="value" spellcheck="false" />
+      <button class="ghost" data-header-drop="${i}" title="Remove this header">Remove</button>
+    </div>`).join("") || `<div class="env-note">${emptyNote}</div>`;
+  box.querySelectorAll("input[data-header-name]").forEach((input) => {
+    input.oninput = () => { list[input.dataset.headerName].name = input.value; };
+  });
+  box.querySelectorAll("input[data-header-value]").forEach((input) => {
+    input.oninput = () => { list[input.dataset.headerValue].value = input.value; };
+  });
+  box.querySelectorAll("button[data-header-drop]").forEach((btn) => {
+    btn.onclick = () => { list.splice(Number(btn.dataset.headerDrop), 1); renderEnvHeaders(); };
+  });
+}
+
+el("env-btn").onclick = () => {
+  if (el("env-panel").hidden) openEnv(false); else el("env-panel").hidden = true;
+};
+
+el("env-url").oninput = () => {
+  if (!kindTouched) el("env-kind").value = guessKind(el("env-url").value.trim());
+};
+el("env-kind").onchange = () => { kindTouched = true; };
+
+el("env-pick").onchange = async () => {
+  const name = el("env-pick").value;
+  if (name === NEW_ENV) { kindTouched = false; openEnv(true); el("env-pick").value = config.name; return; }
+  if (name === config.name) return;
+  try {
+    adoptState(await post("/api/environment", { name }));
+  } catch (err) { alert(err.message); el("env-pick").value = config.name; }
+};
+
+// The server drops the scan when the environment changes, so the table follows it down rather
+// than showing the last estate under the new environment's name.
+function adoptState(state) {
+  data = state.scan;
+  selected.clear();
+  expanded.clear();
+  page = 0;
+  if (!state.scan) { el("estate").hidden = true; el("rows").innerHTML = ""; el("pager").hidden = true; }
+  render(state);
+}
+
+el("env-add-header").onclick = () => { envHeaders.push({ name: "", value: "" }); renderEnvHeaders(); };
+el("sp-add-header").onclick = () => { spHeaders.push({ name: "", value: "" }); renderEnvHeaders(); };
+el("de-add-header").onclick = () => { deHeaders.push({ name: "", value: "" }); renderEnvHeaders(); };
+
+el("env-save").onclick = async () => {
+  el("env-error").textContent = "";
+  try {
+    const state = await post("/api/config", {
+      create: envCreating,
+      label: el("env-label").value.trim(),
+      kind: el("env-kind").value,
+      hyperswitch_url: el("env-url").value.trim(),
+      api_key: el("env-key").value,
+      headers: envHeaders.filter((h) => h.name.trim()),
+      superposition: {
+        url: el("sp-url").value.trim(),
+        secret: el("sp-secret").value,
+        config_key: el("sp-key").value.trim(),
+        headers: spHeaders.filter((h) => h.name.trim()),
+      },
+      decision_engine: {
+        url: el("de-url").value.trim(),
+        admin_secret: el("de-secret").value,
+        headers: deHeaders.filter((h) => h.name.trim()),
+      },
+      remember: el("env-remember").checked,
+      remember_key: el("env-remember").checked && el("env-remember-key").checked,
+    });
+    el("env-panel").hidden = true;
+    kindTouched = false;
+    envCreating = false;
+    adoptState(state);
+  } catch (err) { el("env-error").textContent = err.message; }
+};
+
+el("env-forget").onclick = async () => {
+  if (!confirm("Remove every saved environment from ~/.config/hs-migration-dashboard/config.json?\n\n" +
+               "They stay in this session; the credentials are gone when the server stops.")) return;
+  try {
+    render(await post("/api/config", {
+      hyperswitch_url: el("env-url").value.trim(),
+      headers: envHeaders.filter((h) => h.name.trim()),
+      forget: true,
+    }));
+  } catch (err) { el("env-error").textContent = err.message; }
+};
+
+// What a confirm opens with when the environment is production, so which estate is being
+// written to is read before the sentence that says what to.
+function liveHeading() {
+  return config.live ? `${config.label} \u2014 PRODUCTION. This writes to live merchants.\n\n` : "";
+}
+
+// A production environment is confirmed by name once per session, on top of the confirm each
+// action already asks for. The answer is held for the rest of the session because a migration
+// window is many runs, and sent with every write — the server asks for it too, so a page left
+// open on production cannot write by a click alone.
+function confirmLive(what) {
+  if (!config.live || liveAck === config.name) return true;
+  const typed = prompt(
+    `${config.label} is a production environment.\n\n` +
+    `${what} here changes live merchants' routing data. Type the environment's name to ` +
+    `confirm, once for this session:\n\n  ${config.name}`);
+  if (typed === null) return false;
+  if (typed.trim() !== config.name) {
+    alert(`That is not ${config.name} \u2014 nothing was sent.`);
+    return false;
+  }
+  liveAck = config.name;
+  return true;
+}
+
+async function migrateProfiles(ids) {
+  const rows = data.rows.filter((r) => ids.includes(r.profile_id));
+  const rules = rows.reduce((n, r) => n + r.rules_pending, 0);
+  const blocked = rows.filter((r) => r.blocker === "no_merchant_account").length;
+  const scope = ids.length === 1
+    ? `profile ${ids[0]}`
+    : `${ids.length} profiles`;
+  if (!confirmLive("Migrating rules")) return;
+  if (!confirm(liveHeading() +
+               `Write ${rules} ${plural(rules, "rule")} from ${scope} into the decision engine?\n\n` +
+               (blocked ? `${blocked === ids.length ? (ids.length === 1 ? "It has" : "All of them have")
+                                                    : `${blocked} of them have`} ` +
+                          `no merchant account in Hyperswitch, so the run will come back as ` +
+                          `"not attempted".\n\n` : "") +
+               `Rules already there are left alone. Hyperswitch keeps serving these profiles ` +
+               `until routing is switched over separately.`)) return;
+  try {
+    await post("/api/migrate", { profile_ids: ids, live_ack: liveAck });
+    ids.forEach((id) => selected.delete(id));
+  } catch (err) { alert(err.message); }
+  loadState();
+  if (!polling) polling = setInterval(loadState, 900);
+}
+
+el("migrate-btn").onclick = () =>
+  migrateProfiles(selectedRows().filter((r) => r.rules_pending > 0).map((r) => r.profile_id));
+
+// Switching routing is the one action here that moves live traffic, so it names what it will do
+// to whom before it does it, and the count it confirms is the count it sends.
+async function cutoverProfiles(ids, source) {
+  const toDe = source === TO_DE;
+  const scope = ids.length === 1 ? `profile ${ids[0]}` : `${ids.length} profiles`;
+  const key = (config.superposition || {}).config_key;
+  if (!confirmLive("Switching routing")) return;
+  if (!confirm(
+      liveHeading() +
+      (toDe ? `Hand routing for ${scope} to the decision engine?`
+            : `Hand routing for ${scope} back to Hyperswitch?`) + "\n\n" +
+      `This writes ${key}: ${source} in Superposition and takes effect on live traffic. ` +
+      (toDe ? "Every rule for these profiles is already across, and rules are not touched either way."
+            : "Rules are left where they are, so this can be reversed by cutting over again."))) return;
+  try {
+    await post("/api/cutover", { profile_ids: ids, source, live_ack: liveAck });
+    ids.forEach((id) => selected.delete(id));
+  } catch (err) { alert(err.message); }
+  loadState();
+  if (!polling) polling = setInterval(loadState, 900);
+}
+
+// Creating a scope writes an empty row and no rule, so unlike a migration or a cutover there is
+// nothing here to undo — the confirm says what it is rather than asking for a decision twice.
+async function createScopes(ids) {
+  const scope = ids.length === 1 ? `profile ${ids[0]}` : `${ids.length} profiles`;
+  if (!confirmLive("Provisioning scopes")) return;
+  if (!confirm(liveHeading() + `Provision a decision engine scope for ${scope}?\n\n` +
+               `This re-runs the migration for them. Hyperswitch creates the scope before it ` +
+               `reads a rule, and rules already across are skipped — so no routing moves and ` +
+               `nothing is rewritten. It is what lets these profiles be cut over later.`)) return;
+  try {
+    await post("/api/de-scopes", { profile_ids: ids, live_ack: liveAck });
+    ids.forEach((id) => selected.delete(id));
+  } catch (err) { alert(err.message); }
+  loadState();
+  if (!polling) polling = setInterval(loadState, 900);
+}
+
+el("scope-btn").onclick = () =>
+  createScopes(selectedRows().filter((r) => r.needs_provision).map((r) => r.profile_id));
+
+el("cutover-btn").onclick = () =>
+  cutoverProfiles(selectedRows().filter((r) => r.cutover === "to_de").map((r) => r.profile_id), TO_DE);
+el("rollback-btn").onclick = () =>
+  cutoverProfiles(selectedRows().filter((r) => r.cutover === "to_hs").map((r) => r.profile_id), TO_HS);
+
+el("clear-btn").onclick = () => { selected.clear(); renderRows(); renderActionBarFromData(); };
+
+el("select-all").onchange = (event) => {
+  const rows = visibleRows().filter(isSelectable);
+  rows.forEach((r) => event.target.checked ? selected.add(r.profile_id) : selected.delete(r.profile_id));
+  renderRows(); renderActionBarFromData();
+};
+
+["f-org", "f-merchant", "f-source", "f-scope", "f-actionable", "f-group"].forEach((id) => {
+  el(id).onchange = () => { page = 0; renderRows(); renderActionBarFromData(); };
+});
+
+el("page-prev").onclick = () => { page = Math.max(0, page - 1); renderRows(); window.scrollTo({ top: 0 }); };
+el("page-next").onclick = () => { page += 1; renderRows(); window.scrollTo({ top: 0 }); };
+el("page-size").onchange = () => { pageSize = Number(el("page-size").value); page = 0; renderRows(); };
+// Turning the escape hatch back off drops what it let through first, or a blocked profile
+// would ride along in a run whose checkbox no longer offers it.
+el("f-blocked").onchange = () => {
+  if (!el("f-blocked").checked && data) {
+    for (const row of data.rows) {
+      if (selected.has(row.profile_id) && !isSelectable(row)) selected.delete(row.profile_id);
+    }
+  }
+  renderRows();
+  renderActionBarFromData();
+};
+
+el("f-search").oninput = debounce(() => { page = 0; renderRows(); renderActionBarFromData(); }, 160);
+
+document.querySelectorAll("th.sortable").forEach((th) => {
+  th.onclick = () => {
+    const key = th.dataset.sort;
+    sort = { key, dir: sort.key === key ? -sort.dir : 1 };
+    renderRows();
+  };
+});
+
+// ------------------------------------------------------------------- helpers
+
+function labelOf(state) {
+  const found = STATES.find(([k]) => k === state);
+  return found ? found[1] : state;
+}
+function plural(n, word) { return n === 1 ? word : word + "s"; }
+function unique(values) { return [...new Set(values)].sort(); }
+function escape(value) {
+  return String(value ?? "").replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+function timeAgo(seconds) {
+  const delta = Math.max(0, Date.now() / 1000 - seconds);
+  if (delta < 60) return "just now";
+  if (delta < 3600) return `${Math.round(delta / 60)}m ago`;
+  return `${Math.round(delta / 3600)}h ago`;
+}
+function debounce(fn, ms) {
+  let timer;
+  return (...args) => { clearTimeout(timer); timer = setTimeout(() => fn(...args), ms); };
+}
+
+loadState();
+</script>
+</body>
+</html>

--- a/scripts/migration-dashboard/index.html
+++ b/scripts/migration-dashboard/index.html
@@ -1454,11 +1454,26 @@ function openEnv(blank) {
 // The environment's kind follows the address while it is being typed, so a production URL is
 // marked as one before it is saved. It stops following as soon as the kind is set by hand.
 let kindTouched = false;
+const PRODUCTION_DOMAIN = "hyperswitch.io";
+
+// The host on its own: userinfo, port and IPv6 brackets off, so an address is read by the name
+// it resolves to rather than by the text it was typed as.
+function hostnameOf(url) {
+  let text = String(url || "").trim().toLowerCase();
+  text = text.replace(/^[a-z][a-z0-9+.-]*:\/\//, "");
+  text = text.split("/")[0].split("?")[0].split("#")[0];
+  text = text.slice(text.lastIndexOf("@") + 1);
+  if (text.startsWith("[")) return text.slice(1).split("]")[0];
+  return text.split(":")[0];
+}
+
 function guessKind(url) {
-  const host = (url.match(/^https?:\/\/([^/]*)/) || ["", ""])[1].toLowerCase();
-  if (!host || /^(localhost|127\.0\.0\.1|\[::1\])(:|$)/.test(host)) return "local";
+  const host = hostnameOf(url);
+  if (!host || host === "localhost" || host === "127.0.0.1" || host === "::1") return "local";
   if (host.includes("sandbox") || host.includes("integ")) return "sandbox";
-  if (host.endsWith("hyperswitch.io")) return "production";
+  // The domain, or something under it — matched label by label, so `nothyperswitch.io` is not
+  // read as the hosted product. Mirrors `guess_kind` in server.py.
+  if (host === PRODUCTION_DOMAIN || host.endsWith("." + PRODUCTION_DOMAIN)) return "production";
   return "other";
 }
 

--- a/scripts/migration-dashboard/server.py
+++ b/scripts/migration-dashboard/server.py
@@ -41,8 +41,10 @@ from __future__ import annotations
 import argparse
 import copy
 import enum
+import ipaddress
 import json
 import os
+import socket
 import threading
 import time
 import urllib.error
@@ -63,6 +65,10 @@ CONFIG_FILE = (
 # by `x-feature`, so the header travels with every call rather than only the first.
 DEFAULT_HS_URL = "https://sandbox.hyperswitch.io"
 DEFAULT_HEADERS = {"x-feature": "sandbox-custom-c2"}
+
+# The domain the hosted product is served from, used to offer a kind for an address that was
+# just typed. Only this name and hosts under it; see `guess_kind`.
+PRODUCTION_DOMAIN = "hyperswitch.io"
 
 # The saved file holds every environment; older files held the one that was in use.
 CONFIG_VERSION = 2
@@ -368,12 +374,15 @@ def guess_kind(url: str) -> EnvKind:
     for a config saved before environments said what they were. It is a first answer and not a
     finding: an environment carries its own kind, and a production deployment on a domain this
     does not recognise has to be marked as one in the panel."""
-    host = host_of(url).lower()
-    if not host or host.split(":")[0] in ("localhost", "127.0.0.1", "[::1]"):
+    host = hostname_of(url)
+    if not host or host in ("localhost", "127.0.0.1", "::1"):
         return EnvKind.LOCAL
     if "sandbox" in host or "integ" in host:
         return EnvKind.SANDBOX
-    if host.endswith("hyperswitch.io"):
+    # The domain, or something under it — matched label by label rather than as a suffix of the
+    # text, so `nothyperswitch.io` is not read as the hosted product, and a port or a userinfo
+    # prefix does not stop a production address from being recognised as one.
+    if host == PRODUCTION_DOMAIN or host.endswith("." + PRODUCTION_DOMAIN):
         return EnvKind.PRODUCTION
     return EnvKind.OTHER
 
@@ -479,6 +488,41 @@ def alternate_key(key: str) -> str:
 
 def host_of(url: str) -> str:
     return urllib.parse.urlparse(url).netloc or url
+
+
+def hostname_of(url: str) -> str:
+    """The host on its own, lowercased, with any userinfo, port and IPv6 brackets taken off, so
+    an address is compared by the name it resolves to rather than by the text it was typed as."""
+    try:
+        host = urllib.parse.urlparse(url).hostname
+    except ValueError:  # a malformed netloc, e.g. an unclosed bracket or a non-numeric port
+        host = None
+    if host:
+        return host.lower()
+    # Not a URL: what was typed may still be a bare host, with or without the parts above.
+    text = (url or "").strip().lower().rsplit("@", 1)[-1]
+    if text.startswith("["):
+        return text[1:].split("]", 1)[0]
+    return text.split("/", 1)[0].split(":", 1)[0]
+
+
+def is_loopback(host: str) -> bool:
+    """Whether an address to listen on reaches this machine only. An empty host and `0.0.0.0`
+    are every interface, and a name that does not resolve is not taken on trust."""
+    name = (host or "").strip().strip("[]")
+    if not name:
+        return False
+    try:
+        return ipaddress.ip_address(name).is_loopback
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(name, None)
+    except OSError:
+        return False
+    return bool(infos) and all(
+        ipaddress.ip_address(info[4][0]).is_loopback for info in infos
+    )
 
 
 def load_saved():
@@ -1383,8 +1427,22 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         path = urllib.parse.urlparse(self.path).path
-        length = int(self.headers.get("Content-Length") or 0)
-        payload = json.loads(self.rfile.read(length) or b"{}") if length else {}
+        # A body that is not a JSON object is answered with a 400 rather than raised: the
+        # handler would otherwise die mid-request and the caller would see a dropped connection
+        # instead of a reason.
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            self.send_json({"error": "malformed Content-Length"}, status=400)
+            return
+        try:
+            payload = json.loads(self.rfile.read(length) or b"{}") if length else {}
+        except (ValueError, UnicodeDecodeError) as err:
+            self.send_json({"error": f"malformed JSON body: {err}"}, status=400)
+            return
+        if not isinstance(payload, dict):
+            self.send_json({"error": "body must be a JSON object"}, status=400)
+            return
         board = self.dashboard
 
         if path == "/api/config":
@@ -1397,8 +1455,11 @@ class Handler(BaseHTTPRequestHandler):
             if board.migrate_job.running or board.cutover_job.running or board.scope_job.running:
                 self.send_json({"error": "a run is in flight, it refreshes the scan when it finishes"}, status=409)
                 return
-            pages = payload.get("pages", SCAN_PAGES_DEFAULT)
-            pages = max(0, min(int(pages), 200))
+            try:
+                pages = max(0, min(int(payload.get("pages", SCAN_PAGES_DEFAULT)), 200))
+            except (TypeError, ValueError):
+                self.send_json({"error": "pages must be a number"}, status=400)
+                return
             restart = bool(payload.get("restart"))
             if not board.scan_job.start(board.run_scan, pages, restart):
                 self.send_json({"error": "a scan is already running"}, status=409)
@@ -1411,9 +1472,16 @@ class Handler(BaseHTTPRequestHandler):
                 return
             if self.stopped_by_live_guard(payload, "writing rules"):
                 return
-            batch_size = int(payload.get("batch_size") or MIGRATE_BATCH_SIZE)
-            if board.scan_job.running or board.scope_job.running:
-                self.send_json({"error": "a scan is running, try again once it finishes"}, status=409)
+            try:
+                batch_size = int(payload.get("batch_size") or MIGRATE_BATCH_SIZE)
+            except (TypeError, ValueError):
+                self.send_json({"error": "batch_size must be a number"}, status=400)
+                return
+            # One run at a time against an environment, the same way the other three answer: a
+            # migration alongside a cutover would move traffic to a profile whose rules are
+            # still being written.
+            if board.scan_job.running or board.scope_job.running or board.cutover_job.running:
+                self.send_json({"error": "a run is in flight, try again once it finishes"}, status=409)
                 return
             started = board.migrate_job.start(
                 board.run_migrate, profile_ids, max(1, min(batch_size, 1000))
@@ -1678,8 +1746,30 @@ def main():
         "whichever one was last in use",
     )
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8090")))
-    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("HOST", "127.0.0.1"),
+        help="interface to listen on. Loopback only unless --allow-remote is given as well",
+    )
+    parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        default=os.environ.get("ALLOW_REMOTE", "") not in ("", "0", "false", "no"),
+        help="permit a non-loopback --host. This server has no authentication of its own and "
+        "holds the admin credentials, so anyone who can reach it can migrate and cut over",
+    )
     args = parser.parse_args()
+
+    # The endpoints this serves write to live merchants and it authenticates nobody: whoever
+    # reaches the port is the operator. Loopback is the boundary that stands in for a login, so
+    # binding wider is refused unless it is asked for outright.
+    if not args.allow_remote and not is_loopback(args.host):
+        parser.error(
+            f"--host {args.host} is not loopback, and this server has no authentication: anyone "
+            "who can reach it could migrate rules or cut production traffic over. Pass "
+            "--allow-remote if that is intended, or leave --host at 127.0.0.1 and forward the "
+            "port over SSH."
+        )
 
     saved = load_saved() or {}
     environments = Environments(saved.get("environments") or [])

--- a/scripts/migration-dashboard/server.py
+++ b/scripts/migration-dashboard/server.py
@@ -1,0 +1,1734 @@
+#!/usr/bin/env python3
+"""Migration front — a console over Hyperswitch's routing-rule migration endpoints.
+
+Serves `index.html` and proxies to Hyperswitch, holding the admin API key in this process so
+it never reaches the browser:
+
+    GET  /api/state                 last scan, its totals, and any running job
+    POST /api/config                point at an environment: urls, credentials, extra headers
+    POST /api/environment           switch to another environment already configured here
+    POST /api/scan                  page through GET  /routing/migration/status
+    POST /api/migrate               batch  through POST /routing/rule/migrate
+    POST /api/cutover               switch routing over with PUT /context on Superposition
+    POST /api/de-scopes             provision missing scopes through POST /routing/rule/migrate
+
+The environment is set from the dashboard rather than the command line, because the key for a
+hosted environment is pasted in when it is needed and the extra headers differ per environment
+(sandbox needs `x-feature`). Sandbox and each production region are held side by side rather
+than one at a time, so moving between them is a pick from the header rather than three URLs and
+three credentials typed again. Nothing is written to disk unless "remember" is asked for.
+
+An environment says what it is, and a production one is marked as such wherever it is shown and
+takes its name typed back before a migration, a cutover or a scope run — every write against it
+lands on live merchants.
+
+`/routing/migration/status` reports one page at a time and each profile in a page costs the
+router one call to the decision engine, so a scan is a background job that pages with progress,
+and a scan of a large estate is resumed page by page rather than run to the end in one go.
+
+That status is about rules only. Whether the decision engine holds a *scope* for a profile is a
+question it alone can answer, so a scan also asks it — see `Dashboard.check_scopes`.
+
+Only the standard library is used: this is an operations tool that has to run from a checkout
+during a migration window, with no environment to prepare first.
+
+    ./server.py                     then set the environment in the browser
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import enum
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CONFIG_FILE = (
+    Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config")
+    / "hs-migration-dashboard"
+    / "config.json"
+)
+
+# What the dashboard opens on. Hyperswitch's hosted sandbox routes a request to a release train
+# by `x-feature`, so the header travels with every call rather than only the first.
+DEFAULT_HS_URL = "https://sandbox.hyperswitch.io"
+DEFAULT_HEADERS = {"x-feature": "sandbox-custom-c2"}
+
+# The saved file holds every environment; older files held the one that was in use.
+CONFIG_VERSION = 2
+
+
+class EnvKind(enum.Enum):
+    """What an environment is, which is what decides how much ceremony a write to it takes.
+
+    A name this version does not know reads as OTHER instead of failing, so a file written by a
+    later one — or edited by hand — still opens."""
+
+    SANDBOX = "sandbox"
+    PRODUCTION = "production"
+    LOCAL = "local"
+    OTHER = "other"
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.OTHER
+
+    @property
+    def live(self) -> bool:
+        """Whether a write here reaches real merchants."""
+        return self is EnvKind.PRODUCTION
+
+
+# The environments this is pointed at in practice, always offered in the picker even before one
+# has been configured. They carry addresses and nothing else: a credential belongs to whoever is
+# running the window, and is pasted in when it is needed.
+ENV_PRESETS = [
+    {
+        "name": "sandbox",
+        "label": "Sandbox",
+        "kind": EnvKind.SANDBOX.value,
+        "hyperswitch_url": DEFAULT_HS_URL,
+        "headers": dict(DEFAULT_HEADERS),
+    },
+    {
+        "name": "production-eu",
+        "label": "Production EU",
+        "kind": EnvKind.PRODUCTION.value,
+        # The production regions serve the API under `/api` on the region host, so the base URL
+        # carries that path and every endpoint below hangs off it.
+        "hyperswitch_url": "https://eu.hyperswitch.io/api",
+        "headers": {},
+    },
+]
+
+# Cutting a profile over is a Superposition override, not a Hyperswitch call: the router reads
+# `routing.routing_result_source` per profile and asks whoever it names for the routing result.
+# The key is editable because it is the one thing that fails quietly — an override written under
+# a key the router does not read is accepted and changes nothing, which is why every cutover run
+# re-reads the profiles afterwards and reports what the router now says.
+CUTOVER_KEY = "routing.routing_result_source"
+# Superposition refuses an override whose key its workspace has no schema for, and this config
+# was moved into a `routing.` folder at one point, so an environment answers to whichever name it
+# was seeded with. That refusal is proof the name is not defined there, which is what makes
+# retrying under the other one safe rather than a guess.
+SCHEMA_REFUSAL = "failed to get schema for config key"
+DEFAULT_SUPERPOSITION_HEADERS = {"x-tenant": "hyperswitch", "x-org-id": "hyperswitch"}
+SOURCE_DECISION_ENGINE = "decision_engine"
+SOURCE_HYPERSWITCH = "hyperswitch_routing"
+# Which states each direction may be applied to. Cutting over a profile whose rules have not all
+# crossed would route live traffic against a decision engine that is missing them.
+CUTOVER_FROM = {"migrated"}
+ROLLBACK_FROM = {"enabled", "enabled_without_rules"}
+
+# The decision engine's read-only reconcile, gated by the shared admin secret rather than an API
+# key. It reports which profiles it has no scope for, and is the only question Hyperswitch cannot
+# answer — which is why the decision engine needs its own address here.
+#
+# Its sibling `/admin/hierarchy/sync` is deliberately not called from here. Creating a scope means
+# writing the organization and merchant above the profile, and this tool would have to name them
+# from the status feed — which carries the provider rather than the owner for a platform-written
+# rule, and carries no profile or organization name at all. Hyperswitch has all of that in hand
+# and syncs the hierarchy itself; see `run_scope_provision`.
+DE_RECONCILE_PATH = "/admin/hierarchy/reconcile"
+
+# Hyperswitch stamps every response with this and writes its own logs under it. It is the only
+# handle on a failure whose body explains nothing — `HE_00 Something went wrong` is the router
+# declining to say what happened, and what happened is in its log under this id — so it is kept
+# with the outcome it belongs to rather than read once and dropped.
+REQUEST_ID_HEADER = "x-request-id"
+
+# Hyperswitch caps the status page at 500 and the migration batch at 1000 profiles; both
+# defaults here sit under the cap so a slow decision engine cannot stall a whole run.
+STATUS_PAGE_SIZE = 500
+MIGRATE_BATCH_SIZE = 25
+
+# Pages read per scan; 0 is every page there is. An estate is thousands of profiles, not
+# millions — a few pages of 500 — so a scan reads the whole feed and the table is complete the
+# first time it is looked at, rather than growing under whoever is working through it.
+SCAN_PAGES_DEFAULT = 0
+
+# `/routing/rule/migrate` reads this many rules *per profile in the batch* and defaults to 50,
+# so a profile with more rules than this would quietly migrate only its first page. The request
+# asks for the cap, and any profile holding more than a page is walked with offsets below.
+RULE_PAGE_LIMIT = 1000
+
+# States where Hyperswitch holds rules the decision engine does not, i.e. what a migration run
+# would write. `unknown` is excluded: the decision engine could not be read, so a migration
+# would be firing blind.
+UNFINISHED_STATES = {"pending", "partial", "diverged", "enabled_without_rules"}
+
+
+class Target:
+    """The environment being worked on, changeable while the server runs."""
+
+    def __init__(self, hs_url: str, api_key: str = "", headers=None, label: str = "",
+                 name: str = "", kind=EnvKind.OTHER):
+        self.lock = threading.Lock()
+        self.set(hs_url, api_key, headers or {}, label, name, kind)
+
+    def set(self, hs_url: str, api_key: str, headers: dict, label: str,
+            name: str = "", kind=EnvKind.OTHER):
+        with self.lock:
+            self.hs_url = (hs_url or "").rstrip("/")
+            self.api_key = api_key or ""
+            self.headers = clean_headers(headers)
+            self.label = label or host_of(self.hs_url)
+            # The label is what an environment is called on screen; the name is that label as a
+            # key — what the saved file files it under and what a production write is confirmed
+            # with, so it stays stable while the label is being typed.
+            self.name = (name or "").strip() or slug_of(self.label)
+            self.kind = EnvKind(kind)
+
+    def snapshot(self):
+        with self.lock:
+            return self.hs_url, self.api_key, dict(self.headers)
+
+    def identity(self):
+        with self.lock:
+            return self.name, self.label, self.kind
+
+    def public(self):
+        """What the browser is told: everything except the key itself."""
+        with self.lock:
+            return {
+                "hyperswitch_url": self.hs_url,
+                "label": self.label,
+                "name": self.name,
+                "kind": self.kind.value,
+                "live": self.kind.live,
+                "headers": [{"name": k, "value": v} for k, v in sorted(self.headers.items())],
+                "api_key_set": bool(self.api_key),
+                "api_key_hint": ("…" + self.api_key[-4:]) if len(self.api_key) > 4 else "",
+            }
+
+
+class Superposition:
+    """Where cutovers are written. Configured from the dashboard like the environment itself,
+    because the secret belongs to whoever is running the migration window."""
+
+    def __init__(self, url: str = "", secret: str = "", headers=None, config_key: str = CUTOVER_KEY):
+        self.lock = threading.Lock()
+        self.set(url, secret, headers or dict(DEFAULT_SUPERPOSITION_HEADERS), config_key)
+
+    def set(self, url: str, secret: str, headers: dict, config_key: str):
+        with self.lock:
+            self.url = (url or "").rstrip("/")
+            if self.url.endswith("/context"):
+                self.url = self.url[: -len("/context")]
+            self.secret = secret or ""
+            self.headers = clean_headers(headers)
+            self.config_key = (config_key or "").strip() or CUTOVER_KEY
+
+    def snapshot(self):
+        with self.lock:
+            return self.url, self.secret, dict(self.headers), self.config_key
+
+    def adopt_key(self, key: str):
+        """Keep the name this workspace actually answered to, so the rest of the run and every
+        run after it goes straight there."""
+        with self.lock:
+            self.config_key = key
+
+    def public(self):
+        with self.lock:
+            return {
+                "url": self.url,
+                "headers": [{"name": k, "value": v} for k, v in sorted(self.headers.items())],
+                "config_key": self.config_key,
+                "secret_set": bool(self.secret),
+                "ready": bool(self.url and self.secret),
+            }
+
+
+class DecisionEngine:
+    """The decision engine itself, which the rest of this tool only ever reaches through
+    Hyperswitch. It is addressed directly for one question Hyperswitch cannot answer: whether a
+    profile exists there as a scope at all. Optional — leave it unset and the scope column
+    simply says it was not read."""
+
+    def __init__(self, url: str = "", admin_secret: str = "", headers=None):
+        self.lock = threading.Lock()
+        self.set(url, admin_secret, headers or {})
+
+    def set(self, url: str, admin_secret: str, headers: dict):
+        with self.lock:
+            self.url = (url or "").rstrip("/")
+            # The address is usually copied from a curl of one of the hierarchy endpoints, so a
+            # path on the end of it is dropped rather than turned into `…/reconcile/admin/…`.
+            for path in (DE_RECONCILE_PATH, "/admin/hierarchy/sync"):
+                if self.url.endswith(path):
+                    self.url = self.url[: -len(path)]
+            self.admin_secret = admin_secret or ""
+            self.headers = clean_headers(headers)
+
+    def snapshot(self):
+        with self.lock:
+            return self.url, self.admin_secret, dict(self.headers)
+
+    def public(self):
+        with self.lock:
+            return {
+                "url": self.url,
+                "headers": [{"name": k, "value": v} for k, v in sorted(self.headers.items())],
+                "secret_set": bool(self.admin_secret),
+                "ready": bool(self.url and self.admin_secret),
+            }
+
+
+class Environments:
+    """Every environment this console knows about, of which exactly one is in use.
+
+    The one in use is the Target, Superposition and DecisionEngine above; the rest sit here as
+    plain records. Switching writes the three back into the record they came from and loads the
+    next one over them, so going from sandbox to production and back is a pick rather than six
+    addresses and three credentials typed again.
+
+    Credentials are held here for as long as the process runs whether or not they were
+    remembered on disk: a key pasted in for a production window should survive a look at sandbox
+    in the middle of it."""
+
+    def __init__(self, records=None):
+        self.lock = threading.Lock()
+        self.records: dict[str, dict] = {}
+        for record in records or []:
+            record = normalise_env(record)
+            self.records[record["name"]] = record
+
+    def seed(self, presets):
+        """Offer the known environments even before one has been configured. A preset is skipped
+        where the store already holds that name or that address — the saved record is the one
+        with the credentials, and a second row for the same host under another name would be a
+        second place to look for them."""
+        with self.lock:
+            held = {record["hyperswitch_url"] for record in self.records.values()}
+            for preset in presets:
+                record = normalise_env(preset)
+                if record["name"] in self.records or record["hyperswitch_url"] in held:
+                    continue
+                self.records[record["name"]] = record
+
+    def remember(self, record: dict):
+        with self.lock:
+            self.records[record["name"]] = normalise_env(record)
+
+    def rename(self, old: str, record: dict):
+        """An environment renamed in the panel moves rather than forks, or the picker would
+        offer both the old name and the new one with the credentials only under one of them."""
+        with self.lock:
+            record = normalise_env(record)
+            if old != record["name"]:
+                self.records.pop(old, None)
+            self.records[record["name"]] = record
+
+    def get(self, name: str):
+        with self.lock:
+            record = self.records.get(name)
+            return copy.deepcopy(record) if record else None
+
+    def records_list(self):
+        with self.lock:
+            return [copy.deepcopy(record) for record in self.records.values()]
+
+    def public(self, active: str):
+        """The picker: what each environment is called, where it points, and whether its
+        credentials are already in hand — never the credentials themselves."""
+        return [
+            {
+                "name": record["name"],
+                "label": record["label"],
+                "kind": record["kind"],
+                "live": EnvKind(record["kind"]).live,
+                "hyperswitch_url": record["hyperswitch_url"],
+                "api_key_set": bool(record.get("api_key")),
+                "current": record["name"] == active,
+            }
+            for record in self.records_list()
+        ]
+
+
+def slug_of(text: str) -> str:
+    """A label as a key: what the saved file files an environment under, and what a production
+    write is confirmed with."""
+    kept = "".join(c if c.isalnum() else "-" for c in (text or "").lower())
+    return "-".join(part for part in kept.split("-") if part) or "environment"
+
+
+def guess_kind(url: str) -> EnvKind:
+    """What an address looks like, used as the answer offered for a URL that was just typed and
+    for a config saved before environments said what they were. It is a first answer and not a
+    finding: an environment carries its own kind, and a production deployment on a domain this
+    does not recognise has to be marked as one in the panel."""
+    host = host_of(url).lower()
+    if not host or host.split(":")[0] in ("localhost", "127.0.0.1", "[::1]"):
+        return EnvKind.LOCAL
+    if "sandbox" in host or "integ" in host:
+        return EnvKind.SANDBOX
+    if host.endswith("hyperswitch.io"):
+        return EnvKind.PRODUCTION
+    return EnvKind.OTHER
+
+
+def normalise_env(record: dict) -> dict:
+    """One environment's record, with everything the rest of this file expects it to have."""
+    record = copy.deepcopy(dict(record or {}))
+    url = (record.get("hyperswitch_url") or "").rstrip("/")
+    sp = dict(record.get("superposition") or {})
+    de = dict(record.get("decision_engine") or {})
+    record.update(
+        {
+            "hyperswitch_url": url,
+            "label": (record.get("label") or "").strip() or host_of(url),
+            "headers": clean_headers(record.get("headers") or {}),
+            "superposition": {
+                "url": (sp.get("url") or "").strip(),
+                "secret": sp.get("secret") or "",
+                "headers": clean_headers(sp.get("headers") or dict(DEFAULT_SUPERPOSITION_HEADERS)),
+                "config_key": (sp.get("config_key") or "").strip() or CUTOVER_KEY,
+            },
+            "decision_engine": {
+                "url": (de.get("url") or "").strip(),
+                "admin_secret": de.get("admin_secret") or "",
+                "headers": clean_headers(de.get("headers") or {}),
+            },
+        }
+    )
+    record["name"] = (record.get("name") or "").strip() or slug_of(record["label"])
+    record["kind"] = EnvKind(record.get("kind") or guess_kind(url)).value
+    record["api_key"] = record.get("api_key") or ""
+    return record
+
+
+def env_record(target: Target, superposition, decision_engine) -> dict:
+    """The environment on screen, as a record the store can hold."""
+    hs_url, api_key, headers = target.snapshot()
+    name, label, kind = target.identity()
+    sp_url, sp_secret, sp_headers, config_key = superposition.snapshot()
+    de_url, de_secret, de_headers = decision_engine.snapshot()
+    return normalise_env(
+        {
+            "name": name,
+            "label": label,
+            "kind": kind.value,
+            "hyperswitch_url": hs_url,
+            "api_key": api_key,
+            "headers": headers,
+            "superposition": {
+                "url": sp_url,
+                "secret": sp_secret,
+                "headers": sp_headers,
+                "config_key": config_key,
+            },
+            "decision_engine": {
+                "url": de_url,
+                "admin_secret": de_secret,
+                "headers": de_headers,
+            },
+        }
+    )
+
+
+def apply_env(record: dict, target: Target, superposition, decision_engine):
+    """Point the three services at one environment's record."""
+    record = normalise_env(record)
+    target.set(
+        record["hyperswitch_url"],
+        record["api_key"],
+        record["headers"],
+        record["label"],
+        record["name"],
+        record["kind"],
+    )
+    sp = record["superposition"]
+    superposition.set(sp["url"], sp["secret"], sp["headers"], sp["config_key"])
+    de = record["decision_engine"]
+    decision_engine.set(de["url"], de["admin_secret"], de["headers"])
+
+
+def without_secrets(record: dict) -> dict:
+    record = copy.deepcopy(record)
+    record["api_key"] = ""
+    record["superposition"]["secret"] = ""
+    record["decision_engine"]["admin_secret"] = ""
+    return record
+
+
+def clean_headers(headers: dict) -> dict:
+    """Header values reach a request line, so anything that could open a second one is dropped
+    rather than escaped."""
+    return {
+        str(name).strip(): str(value).strip()
+        for name, value in (headers or {}).items()
+        if str(name).strip() and "\r" not in f"{name}{value}" and "\n" not in f"{name}{value}"
+    }
+
+
+def alternate_key(key: str) -> str:
+    """The same config under its other name: foldered if it is flat, flat if it is foldered."""
+    return key.rsplit(".", 1)[-1] if "." in key else "routing." + key
+
+
+def host_of(url: str) -> str:
+    return urllib.parse.urlparse(url).netloc or url
+
+
+def load_saved():
+    """The saved file as this version reads it: a list of environments and which one was last in
+    use. A file from before environments were named holds one environment at the top level, and
+    is read as that."""
+    try:
+        saved = json.loads(CONFIG_FILE.read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(saved, dict):
+        return None
+    if isinstance(saved.get("environments"), list):
+        return {
+            "active": saved.get("active") or "",
+            "environments": [normalise_env(record) for record in saved["environments"]],
+        }
+    if not saved.get("hyperswitch_url"):
+        return None
+    # That one environment was never named, so a known address names it: the file is from before
+    # the picker existed, and it should come back as the entry the picker offers.
+    record = normalise_env(saved)
+    preset = next(
+        (p for p in ENV_PRESETS if p["hyperswitch_url"] == record["hyperswitch_url"]), None
+    )
+    if preset:
+        record.update({"name": preset["name"], "label": preset["label"], "kind": preset["kind"]})
+    return {"active": record["name"], "environments": [record]}
+
+
+def save_config(environments: Environments, active: str, keep_secrets: bool):
+    """Every environment is written, not only the one on screen — the point of naming them is
+    that a switch does not mean typing an address in again.
+
+    `keep_secrets` is the "credentials are wanted on disk" answer, and it covers all of them at
+    once: they are remembered together or not at all, since none is useful without the others."""
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    records = environments.records_list()
+    payload = {
+        "version": CONFIG_VERSION,
+        "active": active,
+        "environments": records if keep_secrets else [without_secrets(r) for r in records],
+    }
+    # Written before the mode is set, so the file is never briefly world-readable with a key in
+    # it: opened by hand at 0600 rather than through write_text.
+    fd = os.open(CONFIG_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def forget_config():
+    try:
+        CONFIG_FILE.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def describe_failure(err, service: str, method: str, url: str) -> str:
+    """Which call failed, and then what it answered.
+
+    Three services answer into the same error line and any of them can say 401 — a body on its
+    own does not name whose credential was refused, or which environment's. The name and the
+    endpoint come first so they survive the truncation below."""
+    body = err.read().decode("utf-8", "replace").strip()
+    where = f"{service} {method} {url}"
+    request_id = request_id_of(err.headers)
+    if request_id:
+        where += f" [{REQUEST_ID_HEADER} {request_id}]"
+    return f"{where} — {body}" if body else f"{where} — no response body"
+
+
+def request_id_of(headers) -> str:
+    return (headers.get(REQUEST_ID_HEADER) or "").strip() if headers else ""
+
+
+class UpstreamError(Exception):
+    """A call to Hyperswitch, Superposition or the decision engine that came back non-2xx,
+    carrying its status and body."""
+
+    def __init__(self, status: int, body: str, request_id: str = ""):
+        super().__init__(f"HTTP {status}: {body[:400]}")
+        self.status = status
+        self.body = body
+        self.request_id = request_id
+
+
+def hs_call(target: Target, method: str, path: str, query=None, body=None, timeout: int = 300,
+            with_request_id: bool = False):
+    """`with_request_id` returns `(payload, x-request-id)` instead of the payload alone, for a
+    call whose *answer* can carry a failure — a batch that comes back 200 with a profile the
+    router could not migrate is only traceable through the id of the request that carried it."""
+    hs_url, api_key, headers = target.snapshot()
+    _, label, _ = target.identity()
+    # The environment is part of the name: with several configured, "Hyperswitch refused the
+    # key" is only half an answer.
+    service = f"Hyperswitch {label}"
+    if not hs_url:
+        raise UpstreamError(0, "no environment set — open Environment and give a URL")
+    if not api_key:
+        raise UpstreamError(
+            0, f"{label} has no API key set — open Environment and paste the admin API key"
+        )
+    url = hs_url + path
+    if query:
+        url += "?" + urllib.parse.urlencode(query)
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("api-key", api_key)
+    request.add_header("Accept", "application/json")
+    for name, value in headers.items():
+        request.add_header(name, value)
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+            request_id = request_id_of(response.headers)
+    except urllib.error.HTTPError as err:
+        raise UpstreamError(
+            err.code,
+            describe_failure(err, service, method, hs_url + path),
+            request_id_of(err.headers),
+        ) from None
+    except urllib.error.URLError as err:
+        raise UpstreamError(0, f"{service} at {hs_url} unreachable: {err.reason}") from None
+    payload = json.loads(raw) if raw else None
+    return (payload, request_id) if with_request_id else payload
+
+
+def superposition_call(sp: Superposition, method: str, path: str, body=None, timeout: int = 60):
+    url, secret, headers, _ = sp.snapshot()
+    if not url:
+        raise UpstreamError(0, "no Superposition URL set — open Environment and give one")
+    if not secret:
+        raise UpstreamError(0, "no Superposition secret set — open Environment and paste it")
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(url + path, data=data, method=method)
+    request.add_header("x-superposition-secret", secret)
+    request.add_header("Accept", "application/json")
+    for name, value in headers.items():
+        request.add_header(name, value)
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as err:
+        raise UpstreamError(err.code, describe_failure(err, "Superposition", method, url + path)) from None
+    except urllib.error.URLError as err:
+        raise UpstreamError(0, f"Superposition at {url} unreachable: {err.reason}") from None
+    return json.loads(raw) if raw else None
+
+
+def de_call(de: DecisionEngine, method: str, path: str, body=None, timeout: int = 120):
+    url, admin_secret, headers = de.snapshot()
+    if not url:
+        raise UpstreamError(0, "no decision engine URL set — open Environment and give one")
+    if not admin_secret:
+        raise UpstreamError(0, "no decision engine admin secret set — open Environment and paste it")
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(url + path, data=data, method=method)
+    request.add_header("x-admin-secret", admin_secret)
+    request.add_header("Accept", "application/json")
+    for name, value in headers.items():
+        request.add_header(name, value)
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as err:
+        raise UpstreamError(err.code, describe_failure(err, "decision engine", method, url + path)) from None
+    except urllib.error.URLError as err:
+        raise UpstreamError(0, f"decision engine at {url} unreachable: {err.reason}") from None
+    return json.loads(raw) if raw else None
+
+
+def merge_profile_result(by_profile, order, profile, request_id: str = ""):
+    """Fold one profile's result into the run. A profile appears once per page of its rules, so
+    a large profile's outcome is the union of its passes rather than whichever page came last.
+
+    The batch's request id is kept with it, and a profile walked in several passes keeps one per
+    pass: an outcome that says only "something went wrong" is looked up in Hyperswitch's own log
+    by the id of the request that produced it, so the two are reported together."""
+    profile_id = profile["profile_id"]
+    existing = by_profile.get(profile_id)
+    if existing is None:
+        profile["request_ids"] = [request_id] if request_id else []
+        by_profile[profile_id] = profile
+        order.append(profile_id)
+        return
+    for key in ("success", "skipped", "errors", "not_applicable"):
+        existing.setdefault(key, []).extend(profile.get(key) or [])
+    if request_id and request_id not in existing.setdefault("request_ids", []):
+        existing["request_ids"].append(request_id)
+    if profile.get("not_attempted") and not existing.get("not_attempted"):
+        existing["not_attempted"] = profile["not_attempted"]
+
+
+class Job:
+    """One background run — a scan or a migration — polled by the browser through /api/state."""
+
+    def __init__(self, kind: str):
+        self.kind = kind
+        self.lock = threading.Lock()
+        self.thread: threading.Thread | None = None
+        self.reset()
+
+    def reset(self):
+        self.running = False
+        self.done = 0
+        self.total = 0
+        self.message = ""
+        self.error: str | None = None
+        self.started_at: float | None = None
+        self.finished_at: float | None = None
+        self.result = None
+
+    def snapshot(self):
+        with self.lock:
+            return {
+                "kind": self.kind,
+                "running": self.running,
+                "done": self.done,
+                "total": self.total,
+                "message": self.message,
+                "error": self.error,
+                "started_at": self.started_at,
+                "finished_at": self.finished_at,
+                "result": self.result,
+            }
+
+    def progress(self, done=None, total=None, message=None):
+        with self.lock:
+            if done is not None:
+                self.done = done
+            if total is not None:
+                self.total = total
+            if message is not None:
+                self.message = message
+
+    def start(self, target, *args):
+        with self.lock:
+            if self.running:
+                return False
+            self.reset()
+            self.running = True
+            self.started_at = time.time()
+
+        def run():
+            try:
+                result = target(*args)
+                with self.lock:
+                    self.result = result
+            except Exception as err:  # surfaced in the UI rather than only in this terminal
+                with self.lock:
+                    self.error = str(err)
+            finally:
+                with self.lock:
+                    self.running = False
+                    self.finished_at = time.time()
+
+        self.thread = threading.Thread(target=run, daemon=True)
+        self.thread.start()
+        return True
+
+
+class Dashboard:
+    def __init__(self, target: Target, superposition: Superposition,
+                 decision_engine: DecisionEngine, environments: Environments):
+        self.target = target
+        self.superposition = superposition
+        self.decision_engine = decision_engine
+        self.environments = environments
+        self.scan_job = Job("scan")
+        self.migrate_job = Job("migrate")
+        self.cutover_job = Job("cutover")
+        self.scope_job = Job("scopes")
+        self.lock = threading.Lock()
+        self.scan_result = None
+        self.rows: list[dict] = []       # every profile read so far, in the order read
+        self.next_offset = 0             # where the next page of the status feed resumes
+        self.has_more = True
+        # merchant_id -> {"organization_id", "merchant_name"}, successful lookups only. A failed
+        # one is not cached: it can mean the account is genuinely gone, or that Hyperswitch was
+        # briefly unable to read it, and caching the second case would strand those profiles as
+        # unmigratable for the life of this process.
+        self.merchants: dict[str, dict] = {}
+
+    def forget_scan(self):
+        """Drop everything read from the previous environment. Profile and merchant ids are not
+        comparable across environments, so carrying a scan over would show one estate's rows
+        under another one's name."""
+        with self.lock:
+            self.scan_result = None
+            self.rows = []
+            self.next_offset = 0
+            self.has_more = True
+            self.merchants = {}
+        self.migrate_job.reset()
+        self.cutover_job.reset()
+        self.scope_job.reset()
+        self.scan_job.reset()
+
+    # ------------------------------------------------------------ environments
+
+    def remember_current(self, previous_name: str = ""):
+        """Park what is on screen back in the store, under the name it now goes by."""
+        record = env_record(self.target, self.superposition, self.decision_engine)
+        self.environments.rename(previous_name or record["name"], record)
+        return record
+
+    def use_environment(self, record: dict):
+        """Load another environment over the one on screen. The scan goes with it: profile ids
+        are not comparable across environments, so carrying it would show one estate's rows
+        under another one's name."""
+        self.remember_current()
+        apply_env(record, self.target, self.superposition, self.decision_engine)
+        self.forget_scan()
+
+    # ---------------------------------------------------------------- scanning
+
+    def run_scan(self, pages: int, restart: bool):
+        """Read `pages` more pages of the status feed, or every remaining page when pages is 0.
+
+        A restart re-reads from the first page; anything else continues from where the last scan
+        stopped, so a large estate is walked in pieces without losing what is already on screen.
+        """
+        job = self.scan_job
+        with self.lock:
+            if restart:
+                self.rows = []
+                self.next_offset = 0
+                self.has_more = True
+            rows = list(self.rows)
+            offset = self.next_offset
+            seen = {row["profile_id"] for row in rows}
+
+        read = 0
+        # Held locally and published with the rows it belongs to. Reported live, it would say
+        # the whole estate is read while the rows from that last page are still being resolved.
+        has_more = self.has_more
+        job.progress(done=len(rows), message="reading migration status")
+        while has_more and (pages == 0 or read < pages):
+            page = hs_call(
+                self.target,
+                "GET",
+                "/routing/migration/status",
+                query={"limit": STATUS_PAGE_SIZE, "offset": offset},
+            )
+            profiles = page.get("profiles", [])
+            for profile in profiles:
+                # A profile added upstream between two pages shifts the window, which would
+                # otherwise show the same profile twice.
+                if profile["profile_id"] not in seen:
+                    seen.add(profile["profile_id"])
+                    rows.append(profile)
+            offset += STATUS_PAGE_SIZE
+            read += 1
+            has_more = bool(page.get("has_more"))
+            job.progress(
+                done=len(rows),
+                total=len(rows) + (STATUS_PAGE_SIZE if has_more else 0),
+                message=f"{len(rows)} profiles read",
+            )
+
+        self.enrich_merchants(rows, job)
+        scopes = self.check_scopes(rows, job)
+        for row in rows:
+            self.decorate(row)
+
+        result = {
+            "scanned_at": time.time(),
+            "rows": rows,
+            "totals": self.totals(rows),
+            "scopes": scopes,
+            "has_more": has_more,
+            "pages_read": (offset // STATUS_PAGE_SIZE),
+        }
+        with self.lock:
+            self.rows = rows
+            self.next_offset = offset
+            self.has_more = has_more
+            self.scan_result = result
+        return {"profiles": len(rows), "has_more": has_more}
+
+    def enrich_merchants(self, rows, job: Job):
+        """Attach org and merchant name. The status feed names a merchant but not its org, and
+        the org is the level an operator plans a migration at."""
+        wanted = sorted({row["merchant_id"] for row in rows} - self.merchants.keys())
+        # Everything not already resolved is asked for again on every scan, which is how a
+        # merchant that becomes readable turns back into a migratable profile.
+        if wanted:
+            job.progress(done=0, total=len(wanted), message=f"resolving {len(wanted)} merchants")
+            counter = {"n": 0}
+            counter_lock = threading.Lock()
+
+            def resolve(merchant_id: str):
+                entry = None
+                try:
+                    account = hs_call(
+                        self.target, "GET", f"/accounts/{urllib.parse.quote(merchant_id)}", timeout=30
+                    )
+                    entry = {
+                        "organization_id": account.get("organization_id"),
+                        "merchant_name": account.get("merchant_name"),
+                    }
+                except UpstreamError:
+                    # Rules can outlive the merchant account they were written for. Those
+                    # profiles are reported as-is; a migration run would answer
+                    # "merchant account could not be read" for them.
+                    pass
+                with counter_lock:
+                    counter["n"] += 1
+                    job.progress(done=counter["n"])
+                return merchant_id, entry
+
+            with ThreadPoolExecutor(max_workers=8) as pool:
+                for merchant_id, entry in pool.map(resolve, wanted):
+                    if entry is not None:
+                        self.merchants[merchant_id] = entry
+
+        for row in rows:
+            entry = self.merchants.get(row["merchant_id"])
+            row["organization_id"] = (entry or {}).get("organization_id")
+            row["merchant_name"] = (entry or {}).get("merchant_name")
+            row["merchant_resolved"] = entry is not None
+
+    def check_scopes(self, rows, job: Job):
+        """Ask the decision engine which of these profiles it actually holds a scope for.
+
+        Nothing else in this tool can answer that. Hyperswitch's status endpoint reads the
+        decision engine for rules alone — `routing_algorithm WHERE created_by = <profile>` —
+        which never touches the `merchant_account` table the scope lives in. A profile with no
+        scope answers with an empty rule list, indistinguishable from a scope that simply holds
+        no rules yet: it reads `pending` before a migration and `migrated` after one, while
+        `decide-gateway` would answer MERCHANT_NOT_FOUND for it and the SSO handoff TE_04.
+
+        `reconcile` is read-only and writes nothing, so it runs on every scan.
+        """
+        if not self.decision_engine.public()["ready"]:
+            for row in rows:
+                row["scope_in_de"] = None
+                row["ancestry_missing"] = False
+            return None
+        job.progress(message="checking decision engine scopes")
+        try:
+            # `reconcile` classifies on profile and merchant ids alone and writes nothing, so
+            # the tree it is handed needs no names and no true organization — the placeholder
+            # never reaches anything stored. Provisioning is Hyperswitch's job precisely because
+            # it *does* store what it is given.
+            report = de_call(
+                self.decision_engine,
+                "POST",
+                DE_RECONCILE_PATH,
+                body={
+                    "orgs": [
+                        {
+                            "org_id": row.get("organization_id") or "org_unresolved",
+                            "merchants": [
+                                {
+                                    "merchant_id": row["merchant_id"],
+                                    "profiles": [{"profile_id": row["profile_id"]}],
+                                }
+                            ],
+                        }
+                        for row in rows
+                    ],
+                    # Every scope, not just the stranded ones, because a scope can exist with
+                    # no ancestry recorded against it — provisioned before Hyperswitch synced
+                    # the hierarchy, or registered by something that never had a tree to write.
+                    # It costs response size and no extra reads: `reconcile` loads every
+                    # merchant account either way and this only decides which it reports.
+                    "include_all_scopes": True,
+                },
+            )
+        except UpstreamError as err:
+            # A scan that reached Hyperswitch is still worth having. Every profile is left
+            # saying the scope was not read rather than claiming it is there, so nothing is cut
+            # over on the strength of a check that did not happen.
+            for row in rows:
+                row["scope_in_de"] = None
+                row["ancestry_missing"] = False
+            return {"error": str(err)}
+
+        missing = set(report.get("missing_in_de") or [])
+        entries = report.get("scopes") or []
+        # A scope the decision engine holds but has no ancestry against. It routes perfectly
+        # well — `decide-gateway` needs only the row — but the dashboard cannot name the
+        # organization or merchant above it, and a grant cannot expand to reach it. Tracked
+        # apart from a missing scope because only the latter can block a cutover.
+        no_ancestry = {
+            entry.get("scope_id")
+            for entry in entries
+            if entry.get("classification") == "linked" and not entry.get("has_ancestry")
+        }
+        for row in rows:
+            row["scope_in_de"] = row["profile_id"] not in missing
+            row["ancestry_missing"] = row["profile_id"] in no_ancestry
+        return {
+            "checked_at": time.time(),
+            "missing": sorted(missing),
+            "no_ancestry": sorted(pid for pid in no_ancestry if pid),
+            "linked": report.get("linked", 0),
+            "unlinked": report.get("unlinked", 0),
+            # Scopes whose id is an HS *merchant* id rather than a profile id. They hold live
+            # rules and scores that no profile inherits, and this is the only place they are
+            # visible, so they are carried through even though nothing here acts on them.
+            "stranded": [
+                entry.get("scope_id")
+                for entry in entries
+                if entry.get("classification") == "stranded"
+            ],
+        }
+
+    @staticmethod
+    def decorate(row):
+        """Derive what the table sorts, filters and acts on, so the browser holds no rules of
+        its own about what a state means."""
+        missing = row.get("rules_missing_in_decision_engine") or []
+        row["rules_pending"] = len(missing)
+        row["rules_extra"] = len(row.get("rules_only_in_decision_engine") or [])
+        # What "migrate selected" would actually move. A profile whose only rules are dynamic or
+        # 3DS has nothing to carry, and one whose merchant account is gone cannot be attempted —
+        # both would otherwise sit in `pending` forever and read as unfinished work.
+        row["migratable"] = (
+            row["rules_pending"] > 0
+            and row.get("state") in UNFINISHED_STATES
+            and row.get("merchant_resolved", False)
+        )
+        # Which direction, if any, a cutover may take this profile. `migrated` means every rule
+        # is across and Hyperswitch is still deciding, which is exactly what a cutover changes.
+        #
+        # A profile the decision engine has no scope for is held back from that direction even
+        # so: `decide-gateway` loads the `merchant_account` row before anything else and answers
+        # MERCHANT_NOT_FOUND without one, so the override would move live traffic onto an engine
+        # that refuses the profile. Rolling back stays offered in every case — for a profile
+        # already cut over into that state, it is the way out.
+        state = row.get("state")
+        row["scope_missing"] = row.get("scope_in_de") is False
+        # What a provisioning run would put right. A scope with no ancestry against it is not a
+        # routing problem — only a naming and grant one — so it is worth a run without being
+        # worth holding a cutover for.
+        row["needs_provision"] = row["scope_missing"] or bool(row.get("ancestry_missing"))
+        crossed = state in CUTOVER_FROM and not row["scope_missing"]
+        row["cutover"] = "to_de" if crossed else ("to_hs" if state in ROLLBACK_FROM else None)
+        if row.get("rules_hyperswitch", 0) == 0 and row.get("rules_out_of_scope", 0) > 0:
+            row["blocker"] = "out_of_scope_only"
+        elif not row.get("merchant_resolved", False):
+            row["blocker"] = "no_merchant_account"
+        else:
+            row["blocker"] = None
+
+    @staticmethod
+    def totals(rows):
+        totals = {
+            "profiles": len(rows),
+            "merchants": len({row["merchant_id"] for row in rows}),
+            "organizations": len(
+                {row.get("organization_id") for row in rows if row.get("organization_id")}
+            ),
+            "rules_hyperswitch": 0,
+            "rules_decision_engine": 0,
+            "rules_pending": 0,
+            "rules_out_of_scope": 0,
+            "migratable_profiles": 0,
+            "cutover_ready": 0,
+            "scopes_missing": 0,
+            "scopes_no_ancestry": 0,
+            "scopes_checked": 0,
+            "states": {},
+        }
+        for row in rows:
+            totals["rules_hyperswitch"] += row.get("rules_hyperswitch") or 0
+            totals["rules_decision_engine"] += row.get("rules_decision_engine") or 0
+            totals["rules_pending"] += row.get("rules_pending") or 0
+            totals["rules_out_of_scope"] += row.get("rules_out_of_scope") or 0
+            totals["migratable_profiles"] += 1 if row.get("migratable") else 0
+            totals["cutover_ready"] += 1 if row.get("cutover") == "to_de" else 0
+            totals["scopes_missing"] += 1 if row.get("scope_missing") else 0
+            totals["scopes_no_ancestry"] += 1 if row.get("ancestry_missing") else 0
+            totals["scopes_checked"] += 1 if row.get("scope_in_de") is not None else 0
+            state = row.get("state", "unknown")
+            totals["states"][state] = totals["states"].get(state, 0) + 1
+        return totals
+
+    # --------------------------------------------------------------- migrating
+
+    def run_migrate(self, profile_ids, batch_size, job=None):
+        job = job or self.migrate_job
+        passes = [
+            (profile_ids[i : i + batch_size], 0)
+            for i in range(0, len(profile_ids), batch_size)
+        ]
+        # A profile holding more rules than one page needs its own run per page: the endpoint
+        # reads `offset..offset+limit` of that profile's rules, and rules already carried are
+        # skipped rather than rewritten.
+        for profile_id, rule_count in self.rule_counts(profile_ids).items():
+            for offset in range(RULE_PAGE_LIMIT, rule_count, RULE_PAGE_LIMIT):
+                passes.append(([profile_id], offset))
+
+        job.progress(done=0, total=len(passes), message=f"{len(passes)} batches queued")
+        by_profile = {}
+        order = []
+        totals = {
+            "profiles": 0,
+            "rules_migrated": 0,
+            "rules_skipped": 0,
+            "rules_failed": 0,
+            "rules_not_applicable": 0,
+            "profiles_not_attempted": 0,
+        }
+        failures = []
+        for index, (batch, offset) in enumerate(passes, start=1):
+            try:
+                response, request_id = hs_call(
+                    self.target,
+                    "POST",
+                    "/routing/rule/migrate",
+                    body={"profile_ids": batch, "limit": RULE_PAGE_LIMIT, "offset": offset},
+                    with_request_id=True,
+                )
+                for profile in response.get("profiles", []):
+                    merge_profile_result(by_profile, order, profile, request_id)
+                for key in totals:
+                    totals[key] += response.get("totals", {}).get(key, 0)
+            except UpstreamError as err:
+                # One batch failing says nothing about the rest, and the endpoint is idempotent,
+                # so the run continues and reports the batch that did not land.
+                failures.append(
+                    {
+                        "batch": index,
+                        "profile_ids": batch,
+                        "error": str(err),
+                        "request_id": err.request_id,
+                    }
+                )
+            job.progress(done=index, message=f"batch {index} of {len(passes)}")
+
+        # Rule counters add up across passes because each pass carries different rules, but the
+        # profile counters do not: a profile walked in four passes is still one profile.
+        totals["profiles"] = len(order)
+        totals["profiles_not_attempted"] = sum(
+            1 for profile in by_profile.values() if profile.get("not_attempted")
+        )
+        # The table is stale the moment rules land, so the pages already read are re-read here
+        # rather than leaving the operator looking at counts the migration just changed.
+        job.progress(message="refreshing status")
+        try:
+            self.run_scan(pages=SCAN_PAGES_DEFAULT, restart=True)
+        except Exception as err:
+            failures.append({"batch": None, "profile_ids": [], "error": f"rescan failed: {err}"})
+
+        return {
+            "profiles": [by_profile[pid] for pid in order],
+            "totals": totals,
+            "failures": failures,
+        }
+
+    # ----------------------------------------------------------------- scopes
+
+    def run_scope_provision(self, profile_ids):
+        """Create the decision engine scopes these profiles have none of, through Hyperswitch.
+
+        `/routing/rule/migrate` provisions the scope, with its ancestry, as the first thing it
+        does for a profile — before it reads a single rule. Re-running it for a profile whose
+        rules are already across therefore writes no rule and creates the scope, named with the
+        organization, merchant and profile that only Hyperswitch can read: the profile name lives
+        in `business_profile`, which is encrypted per merchant, and the owning merchant is the
+        rule's processor rather than the provider the status feed reports.
+
+        Building that tree here instead is what the decision engine's own `/admin/hierarchy/sync`
+        would need, and this tool cannot do it without recording ancestry it knows to be wrong.
+        """
+        result = self.run_migrate(profile_ids, MIGRATE_BATCH_SIZE, self.scope_job)
+        # Read from the rescan the run finishes with, so this is what the table now shows rather
+        # than what the run hoped for.
+        with self.lock:
+            rows = {row["profile_id"]: row for row in (self.rows or [])}
+        result["requested"] = len(profile_ids)
+        result["still_missing"] = sorted(
+            profile_id
+            for profile_id in profile_ids
+            if (rows.get(profile_id) or {}).get("scope_missing")
+        )
+        result["still_without_ancestry"] = sorted(
+            profile_id
+            for profile_id in profile_ids
+            if (rows.get(profile_id) or {}).get("ancestry_missing")
+        )
+        return result
+
+    # ---------------------------------------------------------------- cutover
+
+    def run_cutover(self, profile_ids, source):
+        """Point each profile's routing at `source` by writing a Superposition override."""
+        job = self.cutover_job
+        _, _, _, config_key = self.superposition.snapshot()
+        to_de = source == SOURCE_DECISION_ENGINE
+        engine = "Decision Engine" if to_de else "Hyperswitch Routing Engine"
+        job.progress(done=0, total=len(profile_ids), message=f"{len(profile_ids)} profiles queued")
+
+        results = {}
+        counter = {"n": 0}
+        counter_lock = threading.Lock()
+
+        def put(profile_id: str, key: str):
+            return superposition_call(
+                self.superposition,
+                "PUT",
+                "/context",
+                body={
+                    "context": {"profile_id": profile_id},
+                    "override": {key: source},
+                    "description": f"Cut over profile {profile_id} to {engine}",
+                    "change_reason": "DE cutover" if to_de else "DE rollback",
+                },
+            )
+
+        def write(profile_id: str):
+            entry = {"profile_id": profile_id, "ok": False, "error": None, "context_id": None,
+                     "key_used": None}
+            key = self.superposition.snapshot()[3]
+            try:
+                response = put(profile_id, key)
+            except UpstreamError as err:
+                alternate = alternate_key(key)
+                if SCHEMA_REFUSAL not in err.body or alternate == key:
+                    # One profile failing says nothing about the rest: each is its own override.
+                    entry["error"] = str(err)
+                    return finish(entry)
+                try:
+                    response = put(profile_id, alternate)
+                except UpstreamError as second:
+                    entry["error"] = f"{err} · under {alternate}: {second}"
+                    return finish(entry)
+                key = alternate
+                self.superposition.adopt_key(key)
+            entry["ok"] = True
+            entry["key_used"] = key
+            if isinstance(response, dict):
+                entry["context_id"] = response.get("context_id") or response.get("id")
+            return finish(entry)
+
+        def finish(entry):
+            with counter_lock:
+                counter["n"] += 1
+                job.progress(done=counter["n"], message=f"{counter['n']} of {len(profile_ids)} written")
+            return entry
+
+        # Four at a time: enough to move hundreds of profiles in a window, gentle enough that a
+        # shared Superposition is not the thing that breaks during a migration.
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            for entry in pool.map(write, profile_ids):
+                results[entry["profile_id"]] = entry
+
+        # The table is left as the last scan read it: the override is the thing that was asked
+        # for, and re-reading the estate to watch it take effect costs a full status walk.
+        ordered = [results[pid] for pid in profile_ids if pid in results]
+        keys_used = {entry["key_used"] for entry in ordered if entry["key_used"]}
+        return {
+            "source": source,
+            "config_key": config_key,
+            # What the workspace actually took, which is not the configured name when it had no
+            # schema for it and the other one landed.
+            "key_used": sorted(keys_used),
+            "key_switched": config_key if keys_used and config_key not in keys_used else None,
+            "profiles": ordered,
+            "totals": {
+                "profiles": len(ordered),
+                "written": sum(1 for e in ordered if e["ok"]),
+                "failed": sum(1 for e in ordered if not e["ok"]),
+            },
+        }
+
+    def ineligible_for(self, profile_ids, source):
+        """Profiles the last scan says this direction does not apply to, with the state that
+        makes them ineligible."""
+        want = "to_de" if source == SOURCE_DECISION_ENGINE else "to_hs"
+        with self.lock:
+            rows = {row["profile_id"]: row for row in (self.rows or [])}
+        blocked = {}
+        for profile_id in profile_ids:
+            row = rows.get(profile_id)
+            if row is None:
+                blocked[profile_id] = "not in the last scan"
+            elif row.get("cutover") != want:
+                # The state alone would read as a contradiction here — a `migrated` profile
+                # refused a cutover to the decision engine — so the real reason is named.
+                blocked[profile_id] = (
+                    "no scope in the decision engine"
+                    if want == "to_de" and row.get("scope_missing")
+                    else row.get("state") or "unknown"
+                )
+        return blocked
+
+    def not_provisionable(self, profile_ids):
+        """Profiles the last scan says a provisioning run has nothing to do for, with why. The
+        page is not taken on trust here for the same reason a cutover is not: a stale tab would
+        otherwise run against a reconcile that has since been re-read."""
+        with self.lock:
+            rows = {row["profile_id"]: row for row in (self.rows or [])}
+        blocked = {}
+        for profile_id in profile_ids:
+            row = rows.get(profile_id)
+            if row is None:
+                blocked[profile_id] = "not in the last scan"
+            elif row.get("scope_in_de") is None:
+                blocked[profile_id] = "the decision engine was not read"
+            elif not row.get("needs_provision"):
+                blocked[profile_id] = "already has a scope and its ancestry"
+        return blocked
+
+    def rule_counts(self, profile_ids):
+        """Rules held per profile, from the last scan — both the kinds a migration carries and
+        the kinds it does not, since the endpoint pages over all of them together."""
+        with self.lock:
+            scan = self.scan_result
+        if not scan:
+            return {}
+        wanted = set(profile_ids)
+        return {
+            row["profile_id"]: (row.get("rules_hyperswitch") or 0)
+            + (row.get("rules_out_of_scope") or 0)
+            for row in scan["rows"]
+            if row["profile_id"] in wanted
+        }
+
+    # ------------------------------------------------------------------- state
+
+    def state(self, known_scan_at=None):
+        """`known_scan_at` is the stamp of the scan the caller already holds. The scan is nearly
+        all of this payload and changes only when one finishes, while the progress poll runs
+        every 900ms for as long as a job does — so a caller that is already current is told to
+        keep what it has instead of being sent the whole estate again."""
+        with self.lock:
+            scan = self.scan_result
+            has_more = self.has_more
+            pages_read = self.next_offset // STATUS_PAGE_SIZE
+        unchanged = bool(scan) and scan["scanned_at"] == known_scan_at
+        config = self.target.public()
+        config.update(
+            {
+                "superposition": self.superposition.public(),
+                "decision_engine": self.decision_engine.public(),
+                "environments": self.environments.public(self.target.identity()[0]),
+                "env_kinds": [kind.value for kind in EnvKind],
+                "cutover_key_default": CUTOVER_KEY,
+                "migrate_batch_size": MIGRATE_BATCH_SIZE,
+                "status_page_size": STATUS_PAGE_SIZE,
+                "saved": CONFIG_FILE.exists(),
+            }
+        )
+        return {
+            "config": config,
+            "scan_job": self.scan_job.snapshot(),
+            "migrate_job": self.migrate_job.snapshot(),
+            "cutover_job": self.cutover_job.snapshot(),
+            "scope_job": self.scope_job.snapshot(),
+            "scan": None if unchanged else scan,
+            "scan_unchanged": unchanged,
+            "has_more": has_more,
+            "pages_read": pages_read,
+        }
+
+
+class Handler(BaseHTTPRequestHandler):
+    dashboard: Dashboard = None  # set in main
+
+    def log_message(self, fmt, *args):  # one line per request, without the client noise
+        print(f"[dashboard] {fmt % args}")
+
+    def send_json(self, payload, status=200):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = urllib.parse.urlparse(self.path).path
+        if path in ("/", "/index.html"):
+            page = (HERE / "index.html").read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            # The page is read from disk per request, so an edit is live on reload. Without this
+            # the browser serves its own copy back and the edit appears not to have happened.
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(page)))
+            self.end_headers()
+            self.wfile.write(page)
+        elif path == "/api/state":
+            known = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query).get("scan_at")
+            try:
+                known_at = float(known[0]) if known else None
+            except ValueError:
+                known_at = None
+            self.send_json(self.dashboard.state(known_at))
+        else:
+            self.send_json({"error": "not found"}, status=404)
+
+    def do_POST(self):
+        path = urllib.parse.urlparse(self.path).path
+        length = int(self.headers.get("Content-Length") or 0)
+        payload = json.loads(self.rfile.read(length) or b"{}") if length else {}
+        board = self.dashboard
+
+        if path == "/api/config":
+            self.set_config(payload)
+        elif path == "/api/environment":
+            self.switch_environment(payload)
+        elif path == "/api/scan":
+            # A migration re-reads the status feed itself as its last step, so a scan started
+            # now would race that one over the same merchant cache.
+            if board.migrate_job.running or board.cutover_job.running or board.scope_job.running:
+                self.send_json({"error": "a run is in flight, it refreshes the scan when it finishes"}, status=409)
+                return
+            pages = payload.get("pages", SCAN_PAGES_DEFAULT)
+            pages = max(0, min(int(pages), 200))
+            restart = bool(payload.get("restart"))
+            if not board.scan_job.start(board.run_scan, pages, restart):
+                self.send_json({"error": "a scan is already running"}, status=409)
+                return
+            self.send_json({"started": True})
+        elif path == "/api/migrate":
+            profile_ids = payload.get("profile_ids") or []
+            if not profile_ids:
+                self.send_json({"error": "no profiles selected"}, status=400)
+                return
+            if self.stopped_by_live_guard(payload, "writing rules"):
+                return
+            batch_size = int(payload.get("batch_size") or MIGRATE_BATCH_SIZE)
+            if board.scan_job.running or board.scope_job.running:
+                self.send_json({"error": "a scan is running, try again once it finishes"}, status=409)
+                return
+            started = board.migrate_job.start(
+                board.run_migrate, profile_ids, max(1, min(batch_size, 1000))
+            )
+            if not started:
+                self.send_json({"error": "a migration is already running"}, status=409)
+                return
+            self.send_json({"started": True, "profiles": len(profile_ids)})
+        elif path == "/api/cutover":
+            self.cutover(payload)
+        elif path == "/api/de-scopes":
+            self.create_scopes(payload)
+        else:
+            self.send_json({"error": "not found"}, status=404)
+
+    def stopped_by_live_guard(self, payload, action: str) -> bool:
+        """A production environment takes one more answer before anything is written to it: its
+        own name, sent back with the request. The dashboard asks for it and holds it for the
+        rest of the session, so a migration window is not a name typed per batch — but a client
+        that never asked is stopped here rather than only in the browser."""
+        name, label, kind = self.dashboard.target.identity()
+        if not kind.live:
+            return False
+        if (payload.get("live_ack") or "").strip() == name:
+            return False
+        self.send_json(
+            {
+                "error": f"{label} is a production environment: {action} there needs its name "
+                f"({name}) confirmed",
+                "live_ack_required": name,
+            },
+            status=428,
+        )
+        return True
+
+    def switch_environment(self, payload):
+        """Point everything at another environment already configured here."""
+        board = self.dashboard
+        if (board.scan_job.running or board.migrate_job.running
+                or board.cutover_job.running or board.scope_job.running):
+            self.send_json({"error": "a job is running against the current environment"}, status=409)
+            return
+        name = (payload.get("name") or "").strip()
+        record = board.environments.get(name)
+        if record is None:
+            self.send_json({"error": f"no environment named {name!r}"}, status=404)
+            return
+        board.use_environment(record)
+        self.send_json(board.state())
+
+    def create_scopes(self, payload):
+        """Provision the decision engine scopes a set of profiles has none of."""
+        board = self.dashboard
+        profile_ids = payload.get("profile_ids") or []
+        if not profile_ids:
+            self.send_json({"error": "no profiles selected"}, status=400)
+            return
+        if self.stopped_by_live_guard(payload, "provisioning scopes"):
+            return
+        if not board.decision_engine.public()["ready"]:
+            self.send_json(
+                {"error": "set the decision engine URL and admin secret under Environment first"},
+                status=400,
+            )
+            return
+        if board.scan_job.running or board.migrate_job.running or board.cutover_job.running:
+            self.send_json({"error": "a run is in flight, try again once it finishes"}, status=409)
+            return
+        blocked = board.not_provisionable(profile_ids)
+        if blocked:
+            sample = ", ".join(f"{pid} ({why})" for pid, why in list(blocked.items())[:5])
+            self.send_json(
+                {
+                    "error": f"{len(blocked)} of {len(profile_ids)} profiles have nothing to "
+                    f"provision: {sample}" + ("…" if len(blocked) > 5 else ""),
+                    "blocked": blocked,
+                },
+                status=400,
+            )
+            return
+        if not board.scope_job.start(board.run_scope_provision, profile_ids):
+            self.send_json({"error": "a scope run is already running"}, status=409)
+            return
+        self.send_json({"started": True, "profiles": len(profile_ids)})
+
+    def cutover(self, payload):
+        """Point profiles at the decision engine, or back at Hyperswitch."""
+        board = self.dashboard
+        profile_ids = payload.get("profile_ids") or []
+        source = payload.get("source") or SOURCE_DECISION_ENGINE
+        if source not in (SOURCE_DECISION_ENGINE, SOURCE_HYPERSWITCH):
+            self.send_json({"error": f"unknown routing source {source!r}"}, status=400)
+            return
+        if not profile_ids:
+            self.send_json({"error": "no profiles selected"}, status=400)
+            return
+        if self.stopped_by_live_guard(payload, "switching routing"):
+            return
+        if not board.superposition.public()["ready"]:
+            self.send_json({"error": "set the Superposition URL and secret under Environment first"}, status=400)
+            return
+        if board.scan_job.running or board.migrate_job.running or board.scope_job.running:
+            self.send_json({"error": "a run is in flight, try again once it finishes"}, status=409)
+            return
+        # This switches live traffic, so the state each profile was last seen in decides whether
+        # it may be switched at all — the browser's view of it is not taken on trust.
+        if not payload.get("force"):
+            blocked = board.ineligible_for(profile_ids, source)
+            if blocked:
+                sample = ", ".join(f"{pid} ({why})" for pid, why in list(blocked.items())[:5])
+                self.send_json(
+                    {
+                        "error": f"{len(blocked)} of {len(profile_ids)} profiles are not in a state "
+                        f"this direction applies to: {sample}"
+                        + ("…" if len(blocked) > 5 else ""),
+                        "blocked": blocked,
+                    },
+                    status=400,
+                )
+                return
+        if not board.cutover_job.start(board.run_cutover, profile_ids, source):
+            self.send_json({"error": "a cutover is already running"}, status=409)
+            return
+        self.send_json({"started": True, "profiles": len(profile_ids)})
+
+    def set_config(self, payload):
+        board = self.dashboard
+        if (board.scan_job.running or board.migrate_job.running
+                or board.cutover_job.running or board.scope_job.running):
+            self.send_json({"error": "a job is running against the current environment"}, status=409)
+            return
+        hs_url = (payload.get("hyperswitch_url") or "").strip()
+        if not hs_url.startswith(("http://", "https://")):
+            self.send_json({"error": "the URL needs an http:// or https:// scheme"}, status=400)
+            return
+        headers = {
+            (entry.get("name") or "").strip(): (entry.get("value") or "").strip()
+            for entry in (payload.get("headers") or [])
+            if (entry.get("name") or "").strip()
+        }
+        # The other two addresses are checked before anything is applied, so a typo in one of
+        # them cannot leave the console pointed half at the new environment and half at the old.
+        for field, what in (("decision_engine", "decision engine"), ("superposition", "Superposition")):
+            section = payload.get(field)
+            url = (section.get("url") or "").strip() if isinstance(section, dict) else ""
+            if url and not url.startswith(("http://", "https://")):
+                self.send_json({"error": f"the {what} URL needs an http:// or https:// scheme"}, status=400)
+                return
+        # An empty key field means "leave the key alone" while the environment stays the same,
+        # so editing a header does not force the key to be typed again. Pointing somewhere else
+        # drops it: a key belongs to one environment, and carrying it over would send the last
+        # environment's credential to the new host.
+        previous_url, previous_key, _ = board.target.snapshot()
+        previous_name, previous_label, previous_kind = board.target.identity()
+        # The panel either edits the environment on screen or adds one beside it, which is what
+        # the browser says here rather than something guessed from the fields: the same typing
+        # renames an environment in the first case and creates one in the second.
+        creating = bool(payload.get("create"))
+        label = (payload.get("label") or "").strip() or ("" if creating else previous_label)
+        wanted = (payload.get("name") or "").strip() or slug_of(label or host_of(hs_url))
+        # One name is one place to look for one set of credentials, so a name the store already
+        # holds is refused rather than written over — the picker is how you reach that one.
+        if (creating or wanted != previous_name) and board.environments.get(wanted) is not None:
+            self.send_json(
+                {"error": f"an environment named {wanted!r} is already configured — pick it "
+                          f"from the header to work on it"},
+                status=409,
+            )
+            return
+        if creating:
+            # Parked before anything is overwritten, so the environment being left keeps the
+            # addresses and credentials it had.
+            board.remember_current(previous_name)
+        # A credential belongs to one environment: it does not follow the panel to another
+        # address, and never into an environment that is being added.
+        moved = creating or hs_url != previous_url
+        api_key = (payload.get("api_key") or "").strip() or ("" if moved else previous_key)
+        board.target.set(
+            hs_url,
+            api_key,
+            headers,
+            label,
+            (payload.get("name") or "").strip(),
+            # What the environment says it is stands while it points at the same place. A URL
+            # typed over the old one is a different environment, and is read from its address —
+            # which is how a production URL pasted into an empty panel comes out marked as one.
+            payload.get("kind") or (guess_kind(hs_url) if moved else previous_kind),
+        )
+        if moved:
+            board.forget_scan()
+
+        de = payload.get("decision_engine")
+        if isinstance(de, dict):
+            de_url = (de.get("url") or "").strip()
+            previous_de_url, previous_de_secret, _ = board.decision_engine.snapshot()
+            board.decision_engine.set(
+                de_url,
+                (de.get("admin_secret") or "").strip()
+                or ("" if creating or de_url != previous_de_url else previous_de_secret),
+                {
+                    (entry.get("name") or "").strip(): (entry.get("value") or "").strip()
+                    for entry in (de.get("headers") or [])
+                    if (entry.get("name") or "").strip()
+                },
+            )
+
+        sp = payload.get("superposition")
+        if isinstance(sp, dict):
+            sp_url = (sp.get("url") or "").strip()
+            previous_sp_url, previous_secret, _, _ = board.superposition.snapshot()
+            secret = (sp.get("secret") or "").strip() or (
+                "" if creating or sp_url != previous_sp_url else previous_secret
+            )
+            board.superposition.set(
+                sp_url,
+                secret,
+                {
+                    (entry.get("name") or "").strip(): (entry.get("value") or "").strip()
+                    for entry in (sp.get("headers") or [])
+                    if (entry.get("name") or "").strip()
+                },
+                sp.get("config_key") or "",
+            )
+        # Held in the store under whatever it is now called, so the picker offers it and its
+        # credentials are still here after a look at another environment.
+        board.remember_current("" if creating else previous_name)
+        try:
+            if payload.get("remember"):
+                save_config(
+                    board.environments,
+                    board.target.identity()[0],
+                    bool(payload.get("remember_key")),
+                )
+            elif payload.get("forget"):
+                forget_config()
+        except OSError as err:
+            self.send_json({"error": f"config not saved: {err}"}, status=500)
+            return
+        self.send_json(board.state())
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--hs-url", default=os.environ.get("HS_URL", ""))
+    parser.add_argument(
+        "--admin-api-key",
+        default=os.environ.get("HS_ADMIN_API_KEY", ""),
+        help="admin API key; both migration endpoints are admin-authenticated. Optional — it "
+        "can be pasted into the dashboard instead, which is where a hosted key usually comes from",
+    )
+    parser.add_argument(
+        "--de-url",
+        default=os.environ.get("DE_URL", ""),
+        help="decision engine base URL. Optional — without it the dashboard reports rules only "
+        "and says the scope column was not read",
+    )
+    parser.add_argument("--de-admin-secret", default=os.environ.get("DE_ADMIN_SECRET", ""))
+    parser.add_argument(
+        "--env",
+        default=os.environ.get("HS_ENV", ""),
+        help="name of the environment to open on, e.g. sandbox or production-eu. Without it, "
+        "whichever one was last in use",
+    )
+    parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8090")))
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
+    args = parser.parse_args()
+
+    saved = load_saved() or {}
+    environments = Environments(saved.get("environments") or [])
+    environments.seed(ENV_PRESETS)
+    if args.env and environments.get(args.env) is None:
+        parser.error(
+            f"no environment named {args.env!r}; known: "
+            + ", ".join(record["name"] for record in environments.records_list())
+        )
+    record = (
+        environments.get(args.env)
+        or environments.get(saved.get("active") or "")
+        or environments.get(ENV_PRESETS[0]["name"])
+    )
+    # A URL on the command line is the environment to open on: the saved one it belongs to if
+    # there is one, so its credentials come with it, and otherwise an environment of its own.
+    if args.hs_url:
+        hs_url = args.hs_url.rstrip("/")
+        record = next(
+            (r for r in environments.records_list() if r["hyperswitch_url"] == hs_url),
+            normalise_env({"hyperswitch_url": hs_url}),
+        )
+    if args.admin_api_key:
+        record["api_key"] = args.admin_api_key
+    if args.de_url:
+        record["decision_engine"]["url"] = args.de_url
+    if args.de_admin_secret:
+        record["decision_engine"]["admin_secret"] = args.de_admin_secret
+
+    target, superposition, decision_engine = Target(""), Superposition(), DecisionEngine()
+    apply_env(record, target, superposition, decision_engine)
+    environments.remember(env_record(target, superposition, decision_engine))
+    Handler.dashboard = Dashboard(target, superposition, decision_engine, environments)
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    name, label, kind = target.identity()
+    hs_url, api_key, _ = target.snapshot()
+    print(f"migration dashboard  http://{args.host}:{args.port}")
+    print(f"  environment        {label} [{name}]" + ("  ** production **" if kind.live else ""))
+    print(f"  hyperswitch        {hs_url}")
+    print(f"  api key            {'set' if api_key else 'not set — paste it in the dashboard'}")
+    print(f"  superposition      {superposition.public()['url'] or 'not set — paste it in the dashboard'}")
+    print(f"  decision engine    {decision_engine.public()['url'] or 'not set — scopes will not be checked'}")
+    print("  others             " + ", ".join(
+        r["name"] for r in environments.records_list() if r["name"] != name))
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A local console over Hyperswitch's routing-rule migration endpoints — where every profile stands in the move to the decision engine, and a way to move the ones that have not crossed yet.

`scripts/migration-dashboard/server.py` (standard library only, Python 3.9+) serves `index.html` and proxies to Hyperswitch, Superposition and the decision engine:

| Endpoint | Used for |
|---|---|
| `GET /routing/migration/status` (HS) | Every profile holding rules, with its HS and DE rule ids set-diffed |
| `POST /routing/rule/migrate` (HS) | Writing a batch of profiles' rules into the DE, and provisioning the scope they land in |
| `POST /admin/hierarchy/reconcile` (DE) | Which scanned profiles the DE has no scope for. Read-only |
| `PUT /context` (Superposition) | Cutting a profile's routing over, and back |

Rule translation stays in Hyperswitch — it holds the rules, the credentials and the connector context. This tool only reads and drives.

## Why these choices

- **Credentials never reach the browser.** All three are held in the local server process; the page sees only their last four characters. Nothing is written to disk unless *Remember on this machine* is ticked (`~/.config/hs-migration-dashboard/config.json`, mode 0600).
- **Environments are held side by side**, configured in the UI rather than on the command line, because a hosted key is pasted in when it is needed and extra headers differ per environment (sandbox needs `x-feature`). Switching is a pick, not six fields retyped.
- **Scans are background jobs with progress.** Every profile in a status page costs the router one call to the decision engine, so a full-estate scan is not a request you wait on.
- **Scope presence is asked of the decision engine directly.** Hyperswitch's per-profile read lists rules only, so a profile with no scope is indistinguishable from a scope with no rules: it reads `pending`, a migration *succeeds* on it, and the failure only surfaces on live traffic after cutover (`MERCHANT_NOT_FOUND`). Missing scopes are therefore held back from cutover, enforced server-side against the last scan.
- **Provisioning goes through Hyperswitch, not the DE's `/admin/hierarchy/sync`.** A scope is only as good as the ancestry written with it, and the status feed carries no profile or org name — and its `merchant_id` is the *provider* for platform-written rules. `/routing/rule/migrate` provisions scope + ancestry before it reads a rule, so re-running a fully-migrated profile provisions the scope and skips every rule.
- **Production is marked wherever it is named** and takes its environment name typed back before the first migration, cutover or scope run of a session — checked by the server too, so a tab left open cannot write on a click alone.

## Safety

Both Hyperswitch endpoints are idempotent: rules already in the decision engine are skipped, so a partial run repairs itself on the next one. Migration writes rules and does not move traffic. Cutovers move live traffic the moment Superposition accepts the override, but touch no rule in either direction, so they are reversible by rolling back.

## Testing

Run against sandbox and production EU: full-estate scan, single-profile and batch migration, scope reconcile and provisioning, cutover and rollback, and the override-key retry path (`routing_result_source` vs `routing.routing_result_source`).

```bash
scripts/migration-dashboard/server.py   # then open http://127.0.0.1:8090
```

No changes to the decision engine itself — this adds a script directory only.