### PR TITLE
fix(routing): treat a profile with no rules like one with none active

### DIFF
--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -29,9 +29,8 @@ use crate::euclid::{
 };
 use crate::generics::MeshError;
 use crate::{euclid::types::RoutingAlgorithm, logger, metrics};
-use async_bb8_diesel::AsyncRunQueryDsl;
 use axum::{extract::Path, response::IntoResponse, Json};
-use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods, QueryDsl};
+use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods};
 use error_stack::ResultExt;
 
 use crate::app::get_tenant_app_state;
@@ -622,69 +621,6 @@ async fn no_active_algorithm_response(
     response
 }
 
-/// Whether the profile has any routing rule at all, scoped the same way the active-mapper
-/// lookup is. Separates a profile that deactivated its rules from one the engine has never
-/// been given any -- the two are indistinguishable from the mapper miss alone, but callers
-/// must treat them oppositely: the first is an authoritative "no rule", the second means the
-/// engine simply has nothing to say about this profile.
-async fn profile_has_any_routing_rule(
-    state: &crate::app::TenantAppState,
-    created_by: &str,
-    algorithm_for: Option<&str>,
-) -> bool {
-    let conn = match state.db.get_conn().await {
-        Ok(conn) => conn,
-        Err(error) => {
-            logger::error!(
-                ?error,
-                created_by = %created_by,
-                "routing_evaluate: no connection to check for existing routing rules"
-            );
-            return false;
-        }
-    };
-
-    // A deactivated profile has no cache entry and no active mapper row, so this runs on every
-    // evaluate it makes. Selecting one id keeps it off the row itself, whose `algorithm_data`
-    // holds the whole rule program.
-    let existing: Result<Vec<String>, _> = match algorithm_for {
-        Some(algorithm_for) => {
-            dsl::routing_algorithm
-                .filter(
-                    dsl::created_by
-                        .eq(created_by.to_string())
-                        .and(dsl::algorithm_for.eq(algorithm_for.to_string())),
-                )
-                .select(dsl::id)
-                .limit(1)
-                .get_results_async(&*conn)
-                .await
-        }
-        None => {
-            dsl::routing_algorithm
-                .filter(dsl::created_by.eq(created_by.to_string()))
-                .select(dsl::id)
-                .limit(1)
-                .get_results_async(&*conn)
-                .await
-        }
-    };
-
-    match existing {
-        Ok(found) => !found.is_empty(),
-        Err(error) => {
-            // Reported as "no rules", which routes the caller down the error path it already
-            // took before this check existed.
-            logger::error!(
-                ?error,
-                created_by = %created_by,
-                "routing_evaluate: failed to check for existing routing rules"
-            );
-            false
-        }
-    }
-}
-
 /// Resolves the active routing algorithm for a merchant: Redis cache first, DB with
 /// cache back-fill on a miss. Extracted so the batch endpoint can resolve once and
 /// evaluate many parameter sets against the same algorithm.
@@ -1022,16 +958,16 @@ pub async fn routing_evaluate(
     let algorithm = match resolve_active_algorithm(&state, &payload.created_by, algorithm_for).await
     {
         Ok(algo) => algo,
-        // A profile that has rules but none active has deliberately deactivated them,
-        // and that is an answer rather than a failure: the caller should route by its
-        // fallback. A profile with no rules at all stays an error, so a caller can still
-        // tell that the engine has nothing for it.
+        // No rule to apply is an answer, not a failure: the caller routes by the fallback
+        // it supplied. This covers a profile whose rules are all deactivated and one that
+        // has no rules at all — Hyperswitch treats both the same, and a profile awaiting
+        // migration is reported by the caller, which warns when a cut-over profile gets an
+        // empty result.
         Err(e)
             if matches!(
                 e.get_inner(),
                 EuclidErrors::ActiveRoutingAlgorithmNotFound(_)
-            ) && profile_has_any_routing_rule(&state, &payload.created_by, algorithm_for)
-                .await =>
+            ) =>
         {
             API_REQUEST_COUNTER
                 .with_label_values(&["routing_evaluate", "success"])
@@ -1227,15 +1163,13 @@ pub async fn routing_evaluate_batch(
     let algorithm = match resolve_active_algorithm(&state, &payload.created_by, algorithm_for).await
     {
         Ok(algo) => algo,
-        // Same semantics as the single endpoint: rules exist but none are active is an
-        // authoritative "route by your fallback", answered once per entry so eligibility
+        // Same semantics as the single endpoint, answered once per entry so eligibility
         // narrowing still runs against each entry's own parameters.
         Err(e)
             if matches!(
                 e.get_inner(),
                 EuclidErrors::ActiveRoutingAlgorithmNotFound(_)
-            ) && profile_has_any_routing_rule(&state, &payload.created_by, algorithm_for)
-                .await =>
+            ) =>
         {
             let mut results = Vec::with_capacity(payload.requests.len());
             for entry in payload.requests {

--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -958,16 +958,16 @@ pub async fn routing_evaluate(
     let algorithm = match resolve_active_algorithm(&state, &payload.created_by, algorithm_for).await
     {
         Ok(algo) => algo,
-        // No rule to apply is an answer, not a failure: the caller routes by the fallback
-        // it supplied. This covers a profile whose rules are all deactivated and one that
-        // has no rules at all — Hyperswitch treats both the same, and a profile awaiting
-        // migration is reported by the caller, which warns when a cut-over profile gets an
-        // empty result.
+        // A no-rule profile is an answer rather than a failure when the caller supplied a
+        // fallback to answer with; with nothing to answer with, that stays an error.
         Err(e)
             if matches!(
                 e.get_inner(),
                 EuclidErrors::ActiveRoutingAlgorithmNotFound(_)
-            ) =>
+            ) && payload
+                .fallback_output
+                .as_ref()
+                .is_some_and(|fallback| !fallback.is_empty()) =>
         {
             API_REQUEST_COUNTER
                 .with_label_values(&["routing_evaluate", "success"])
@@ -1169,7 +1169,10 @@ pub async fn routing_evaluate_batch(
             if matches!(
                 e.get_inner(),
                 EuclidErrors::ActiveRoutingAlgorithmNotFound(_)
-            ) =>
+            ) && payload
+                .fallback_output
+                .as_ref()
+                .is_some_and(|fallback| !fallback.is_empty()) =>
         {
             let mut results = Vec::with_capacity(payload.requests.len());
             for entry in payload.requests {

--- a/tests/api/routing/routing-rule-mutations.spec.ts
+++ b/tests/api/routing/routing-rule-mutations.spec.ts
@@ -115,13 +115,25 @@ test.describe('Routing rule mutations (API)', () => {
     expect(evaluated.body.evaluated_output.map((c: any) => c.gateway_name)).not.toContain('stripe')
   })
 
-  test('evaluating for a merchant with no rules at all still errors', async ({ api, merchant }) => {
-    // The opposite state: the engine was never given a rule for this profile, so it has nothing to
-    // say and the caller should fall back to its own configuration. That stays a 400.
+  test('evaluating for a merchant with no rules at all answers with the fallback', async ({ api, merchant }) => {
+    // Indistinguishable to the caller from a profile whose rules are all switched off: both mean
+    // "route by your fallback", so both are answered the same way.
     const evaluated = await api.evaluateRoutingAlgorithm(
       factory.ruleEvaluatePayload(merchant.id, {}, {
         fallback_output: [factory.gatewayConnector('adyen')],
       }),
+      { failOnStatusCode: false },
+    )
+
+    expect(evaluated.status).toBe(200)
+    expect(evaluated.body.status).toBe('no_active_algorithm')
+    expect(evaluated.body.evaluated_output.map((c: any) => c.gateway_name)).toEqual(['adyen'])
+  })
+
+  test('evaluating with no rules and no fallback still errors', async ({ api, merchant }) => {
+    // Nothing to answer with -- a 200 carrying an empty output would read as a decision to nowhere.
+    const evaluated = await api.evaluateRoutingAlgorithm(
+      factory.ruleEvaluatePayload(merchant.id, {}, {}),
       { failOnStatusCode: false },
     )
 


### PR DESCRIPTION
## Description

`routing_evaluate` answered `ActiveRoutingAlgorithmNotFound` with a `200` and the caller's fallback only when the profile already had at least one routing rule. A profile the engine had never been given a rule for got a hard `400` instead — ~1,664/day, all shadow-path, from ~30 `cyMerchant_*` Cypress profiles.

To the caller those two states are the same: Hyperswitch routes by the fallback it supplied either way, so the `400` only ever produced a failure it could not act on. Both now take the same `200`.

## The condition is "did the caller supply a fallback", not "does the profile have rules"

The graceful path is taken when the caller supplied a **non-empty `fallback_output`**. With no rule *and* no fallback there is nothing to answer with — `no_active_algorithm_response` defaults the output to empty, so a `200` would read as a successful routing decision to nowhere. That stays an error, and `routing-hybrid.spec.ts:71` already enforced it.

This also drops `profile_has_any_routing_rule` and the per-request `SELECT` it performed. That query had neither a cache entry nor an active mapper row to short-circuit it, so it ran on *every* evaluate from a profile with no active rule — exactly the profiles least able to justify an extra round trip.

## ⚠️ This changes a documented contract

`routing-rule-mutations.spec.ts` previously asserted:

> `evaluating for a merchant with no rules at all still errors` — *"the engine was never given a rule for this profile, so it has nothing to say and the caller should fall back to its own configuration. That stays a 400."*

That is the exact behaviour the shadow traffic fails on, so the test now asserts the fallback answer instead, and a new case covers the no-fallback guard. **Flagging explicitly for whoever wrote that spec** — if the `400` was load-bearing for a caller I haven't found, say so and I'll close this in favour of the Hyperswitch-side fix alone.

## Why it stays safe

`resolve_active_algorithm` raises `ActiveRoutingAlgorithmNotFound` only for `MeshError::NotFound`. Every other storage error becomes `EuclidErrors::StorageError`, so an unreachable database still surfaces as a failure and never as a silent fallback.

## Companion change

Hyperswitch-side, shadow evaluation now requires an active routing algorithm, so these calls stop being made at all for such profiles. This PR is the backstop that makes the engine answer correctly for any caller that still reaches it.

## Verification

- `cargo check` / `cargo clippy` / `cargo fmt --check` — clean
- `routing-rule-mutations.spec.ts` + `routing-hybrid.spec.ts` run locally against a live engine: **13 passed**, including the unchanged no-fallback guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #400
