### PR TITLE
fix(analytics): record batch evaluate failures in the Decision Audit

### DIFF
--- a/src/euclid/handlers/routing_rules.rs
+++ b/src/euclid/handlers/routing_rules.rs
@@ -1170,7 +1170,28 @@ pub async fn routing_evaluate_batch(
         None,
     );
 
-    let mut fail_batch = |err: ContainerError<EuclidErrors>| {
+    // One representative request for the batch: a whole-batch failure has no single entry to
+    // attribute, but without it the audit records a request hit and never an outcome.
+    let batch_error_payload = RoutingRequest {
+        payment_id: None,
+        created_by: payload.created_by.clone(),
+        fallback_output: payload.fallback_output.clone(),
+        parameters: payload
+            .requests
+            .first()
+            .map(|entry| entry.parameters.clone())
+            .unwrap_or_default(),
+        algorithm_for: payload.algorithm_for.clone(),
+    };
+    let mut fail_batch = |err: ContainerError<EuclidErrors>, stage: &'static str| {
+        record_routing_evaluate_preview_error(
+            &batch_error_payload,
+            &err,
+            stage,
+            request_id.clone(),
+            global_request_id.clone(),
+            trace_id.clone(),
+        );
         API_REQUEST_COUNTER
             .with_label_values(&["routing_evaluate_batch", "failure"])
             .inc();
@@ -1203,6 +1224,7 @@ pub async fn routing_evaluate_batch(
                 MAX_BATCH_EVALUATIONS
             ))
             .into(),
+            "batch_size_validation_failed",
         );
     }
 
@@ -1213,12 +1235,12 @@ pub async fn routing_evaluate_batch(
         .ok_or(EuclidErrors::GlobalRoutingConfigsUnavailable)
     {
         Ok(config) => config,
-        Err(e) => return fail_batch(e.into()),
+        Err(e) => return fail_batch(e.into(), "batch_routing_config_unavailable"),
     };
 
     for entry in &payload.requests {
         if let Err(e) = validate_evaluation_parameters(routing_config, &entry.parameters) {
-            return fail_batch(e);
+            return fail_batch(e, "batch_parameter_validation_failed");
         }
     }
 
@@ -1265,7 +1287,7 @@ pub async fn routing_evaluate_batch(
             }
             return Ok(Json(RoutingBatchResponse { results }));
         }
-        Err(e) => return fail_batch(e),
+        Err(e) => return fail_batch(e, "batch_active_routing_lookup_failed"),
     };
 
     let algorithm_data: StaticRoutingAlgorithm =
@@ -1278,7 +1300,7 @@ pub async fn routing_evaluate_batch(
             EuclidErrors::InvalidRequest(format!("Invalid algorithm data format: {}", e))
         }) {
             Ok(data) => data,
-            Err(e) => return fail_batch(e.into()),
+            Err(e) => return fail_batch(e.into(), "batch_routing_algorithm_parse_failed"),
         };
 
     let mut results = Vec::with_capacity(payload.requests.len());


### PR DESCRIPTION
## The gap

A `4xx` from `/routing/evaluate/batch` showed on the Hyperswitch dashboard but **not** in the Decision Audit.

The two evaluate endpoints disagreed about what a failure looks like:

| | failure counter | audit event |
|---|---|---|
| `fail_preview` (`/routing/evaluate`) | ✅ | ✅ `record_error(...)` |
| `fail_batch` (`/routing/evaluate/batch`) | ✅ | ❌ **none** |

`fail_batch` incremented `API_REQUEST_COUNTER` and returned. It never wrote a `DomainAnalyticsEvent`.

Worse than simply missing: the handler *does* call `record_request_hit` on entry, so a failed batch call appeared in the audit as an evaluation that **started and never concluded** — and it is counted by the call-count metric added in #387 with no matching outcome.

Five failure paths were affected: batch too large, routing config unavailable, parameter validation, `resolve_active_algorithm` (the batch twin of the no-active-rule 400), and algorithm-data parse.

## The change

`fail_batch` now records the same `RoutingEvaluateError` event `fail_preview` does, and each site names its stage.

Stages carry a `batch_` prefix deliberately: `AnalyticsRoute` has no batch variant, so batch traffic is filed under `routing_evaluate`. Until that is split, the stage is what distinguishes the two. **Splitting the route label is intentionally not in this PR** — it would move existing batch volume between labels and shift any dashboard filtering on `routing_evaluate`.

A whole-batch failure has no single entry to attribute, so the event is built from one representative request: the caller, the shared `fallback_output` and `algorithm_for`, and the first entry's parameters.

## Verified against a live engine

Same oversized batch (51 entries, limit 50) fired at both binaries. Both returned an identical `400`; only the audit differs:

| merchant | binary | rows in `analytics_domain_events` |
|---|---|---|
| `auditprobe_control` | current `main` | `request_hit` only — **the 400 left no trace** |
| `auditprobe_merchant` | this branch | `request_hit` + `routing_evaluate_error` / `batch_size_validation_failed` / `failure` |

`cargo clippy` and `cargo fmt --check` clean.

## Note

The batch endpoint has **no Playwright coverage at all** — no spec under `tests/` exercises `/routing/evaluate/batch`. Worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #403
