### PR TITLE
ci: add a CI Gate job that aggregates every PR check

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -292,3 +292,29 @@ jobs:
             test-results/
           retention-days: 7
           if-no-files-found: ignore
+
+  # The single check the branch ruleset requires. Jobs above are gated by path filters, and a job
+  # GitHub skips reports no status at all — required directly, each one would leave unrelated PRs
+  # waiting forever on a check that is never going to arrive. This job always runs, so it always
+  # reports, and it fails unless every job it depends on succeeded or was deliberately skipped.
+  # Adding a job to `needs` here is what makes it blocking; the ruleset does not need touching.
+  ci-gate:
+    name: CI Gate
+    needs:
+      - changes
+      - fmt
+      - clippy
+      - typos
+      - ci-hack
+      - unit-tests
+      - frontend-typecheck
+      - helm
+      - e2e-playwright
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every upstream job to have succeeded or been skipped
+        run: |
+          echo '${{ toJSON(needs) }}' | jq .
+          echo '${{ toJSON(needs) }}' \
+            | jq -e 'all(.[]; .result == "success" or .result == "skipped")'


### PR DESCRIPTION
## Why

The \`Required Checks\` ruleset targeted \`refs/heads/"main"\` — with literal quotes — so it matched no branch and **no CI status was ever required to merge into \`main\`**. That ref pattern and the blanket admin bypass on both rulesets are now fixed directly in repo settings.

Four jobs were also missing from the required list: \`Unit Tests\`, \`Frontend Type Check\`, \`Helm Chart Validation\`, \`E2E (Playwright)\`.

\`E2E (Playwright)\` can't be required by name: it is \`if: needs.changes.outputs.e2e == 'true'\`, and a job GitHub skips reports no status, so a doc-only PR would wait forever on a check that never arrives.

## What

Adds a \`CI Gate\` job that always runs, depends on every other job, and fails unless each one succeeded or was skipped. The ruleset then requires that single context instead of enumerating jobs — and adding a job to \`needs\` is all it takes to make a future check blocking.
