### PR TITLE
feat(metrics): integrate OpenTelemetry for metrics collection and export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +156,128 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.2",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.2",
+ "futures-lite",
+ "rustix 1.0.3",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.44",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -156,6 +301,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -929,6 +1080,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "blowfish"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1467,15 @@ dependencies = [
  "url",
  "utoipa",
  "uuid",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2071,6 +2244,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.2",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2445,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2568,18 @@ dependencies = [
  "log",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2513,6 +2737,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hermit-abi"
@@ -3147,6 +3377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3497,9 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lopdf"
@@ -3701,15 +3943,16 @@ dependencies = [
  "jemalloc-ctl",
  "jemallocator",
  "josekit",
- "lazy_static",
  "lettre",
  "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=v1.111.1)",
  "mysqlclient-sys",
  "nanoid",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "pdf-extract",
  "pin-project-lite",
- "prometheus",
  "rand 0.8.5",
  "rand_distr",
  "rdkafka",
@@ -3784,6 +4027,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,6 +4125,12 @@ dependencies = [
  "elliptic-curve",
  "sha2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4016,6 +4332,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4057,6 +4384,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix 0.38.44",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4188,21 +4530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4233,12 +4560,6 @@ checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
@@ -6209,6 +6530,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068e763e8279de7ab94b6afebded2cb701678af094feb1c12ccb061b4783c1be"
 
 [[package]]
 name = "vaultrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,10 @@ chrono-tz = "0.10"
 cpu-time = "1.0.0"
 jemallocator = "0.5"
 jemalloc-ctl = "0.5"
-prometheus = "0.13"
-lazy_static = "1.4"
+# OpenTelemetry metrics pushed over OTLP to the otel-collector, as Hyperswitch does; `internal-logs` surfaces export failures in tracing.
+opentelemetry = { version = "0.27.1", default-features = false, features = ["metrics", "internal-logs"] }
+opentelemetry_sdk = { version = "0.27.1", default-features = false, features = ["metrics", "rt-tokio", "internal-logs"] }
+opentelemetry-otlp = { version = "0.27.0", default-features = false, features = ["grpc-tonic", "metrics", "internal-logs"] }
 zstd = { version = "0.12", optional = true }
 
 async-bb8-diesel = { git = "https://github.com/jarnura/async-bb8-diesel", rev = "53b4ab901aab7635c8215fd1c2d542c8db443094" }
@@ -122,6 +124,7 @@ regex = "1.10"
 # -------------------------------------
 
 [dev-dependencies]
+opentelemetry_sdk = { version = "0.27.1", default-features = false, features = ["metrics", "rt-tokio", "internal-logs", "testing"] }
 rand = "0.8.5"
 rand_distr = "0.4"
 criterion = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For the full local dev environment (API + dashboard on port 5173 + docs), run:
 ./oneclick.sh
 ```
 
-This brings up Postgres, Redis, ClickHouse, and Kafka via Docker Compose, runs migrations, and starts the API server and dashboard locally. See [Local Setup Guide](docs/local-setup.md) for full details and options like `ONECLICK_KEEP_INFRA=1`.
+This brings up Postgres, Redis, ClickHouse, Kafka, an OpenTelemetry collector and Prometheus via Docker Compose, runs migrations, and starts the API server and dashboard locally. The API pushes its metrics to the collector on `localhost:4317`; browse them at `http://localhost:9898/metrics` or in Prometheus at `http://localhost:9090`. See [Local Setup Guide](docs/local-setup.md) for full details and options like `ONECLICK_KEEP_INFRA=1`.
 
 ### Verify
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,7 +8,6 @@ metrics_enabled = false # push metrics to the OpenTelemetry collector over OTLP/
 ignore_errors = true    # log and continue if the OTLP exporter cannot be built
 otel_exporter_otlp_endpoint = "http://localhost:4317" # OTLP/gRPC address of the OpenTelemetry collector
 otel_exporter_otlp_timeout = 10000 # milliseconds per export request (exporter default)
-metrics_export_interval_secs = 5   # how often the collected metrics are pushed
 
 [server]
 host = "127.0.0.1" # The host that the server should be exposed to

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,6 +3,13 @@ enabled = true         # To enable logging in console
 level = "DEBUG"        # level to be set for the logging framework
 log_format = "default" # format to be used for logging default | json
 
+[log.telemetry]
+metrics_enabled = false # push metrics to the OpenTelemetry collector over OTLP/gRPC; oneclick.sh and the compose monitoring profile turn this on
+ignore_errors = true    # log and continue if the OTLP exporter cannot be built
+otel_exporter_otlp_endpoint = "http://localhost:4317" # OTLP/gRPC address of the OpenTelemetry collector
+otel_exporter_otlp_timeout = 10000 # milliseconds per export request (exporter default)
+metrics_export_interval_secs = 5   # how often the collected metrics are pushed
+
 [server]
 host = "127.0.0.1" # The host that the server should be exposed to
 port = 3001        # The port where the server should be hosted on

--- a/config/development.toml
+++ b/config/development.toml
@@ -3,13 +3,16 @@ enabled = true
 level = "DEBUG"
 log_format = "default"
 
+[log.telemetry]
+metrics_enabled = false # push metrics to the OpenTelemetry collector over OTLP/gRPC; oneclick.sh and the compose monitoring profile turn this on
+ignore_errors = true    # log and continue if the OTLP exporter cannot be built
+otel_exporter_otlp_endpoint = "http://localhost:4317" # OTLP/gRPC address of the OpenTelemetry collector
+otel_exporter_otlp_timeout = 10000 # milliseconds per export request (exporter default)
+metrics_export_interval_secs = 5   # how often the collected metrics are pushed
+
 [server]
 host = "127.0.0.1"
 port = 8080
-
-[metrics]
-host = "127.0.0.1"
-port = 9094
 
 [limit]
 request_count = 1

--- a/config/development.toml
+++ b/config/development.toml
@@ -8,7 +8,6 @@ metrics_enabled = false # push metrics to the OpenTelemetry collector over OTLP/
 ignore_errors = true    # log and continue if the OTLP exporter cannot be built
 otel_exporter_otlp_endpoint = "http://localhost:4317" # OTLP/gRPC address of the OpenTelemetry collector
 otel_exporter_otlp_timeout = 10000 # milliseconds per export request (exporter default)
-metrics_export_interval_secs = 5   # how often the collected metrics are pushed
 
 [server]
 host = "127.0.0.1"

--- a/config/docker-configuration.toml
+++ b/config/docker-configuration.toml
@@ -3,13 +3,16 @@ enabled = true
 level = "INFO"
 log_format = "json"
 
+[log.telemetry]
+metrics_enabled = false # push metrics to the OpenTelemetry collector over OTLP/gRPC; oneclick.sh and the compose monitoring profile turn this on
+ignore_errors = true    # log and continue if the OTLP exporter cannot be built
+otel_exporter_otlp_endpoint = "http://otel-collector:4317" # OTLP/gRPC address of the OpenTelemetry collector
+otel_exporter_otlp_timeout = 10000 # milliseconds per export request (exporter default)
+metrics_export_interval_secs = 5   # how often the collected metrics are pushed
+
 [server]
 host = "0.0.0.0"
 port = 8080
-
-[metrics]
-host = "0.0.0.0"
-port = 9094
 
 [limit]
 request_count = 1

--- a/config/docker-configuration.toml
+++ b/config/docker-configuration.toml
@@ -8,7 +8,6 @@ metrics_enabled = false # push metrics to the OpenTelemetry collector over OTLP/
 ignore_errors = true    # log and continue if the OTLP exporter cannot be built
 otel_exporter_otlp_endpoint = "http://otel-collector:4317" # OTLP/gRPC address of the OpenTelemetry collector
 otel_exporter_otlp_timeout = 10000 # milliseconds per export request (exporter default)
-metrics_export_interval_secs = 5   # how often the collected metrics are pushed
 
 [server]
 host = "0.0.0.0"

--- a/config/otel-collector.yaml
+++ b/config/otel-collector.yaml
@@ -1,0 +1,20 @@
+# Local otel-collector for the `monitoring` profile: OTLP in on :4317, Prometheus format out on :9898, as in the Hyperswitch clusters.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch: {}
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:9898
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]

--- a/config/prometheus.yaml
+++ b/config/prometheus.yaml
@@ -1,30 +1,12 @@
-# my global config
+# Local Prometheus for the `monitoring` profile: scrapes the otel-collector, never the app, as vmagent does in the clusters.
 global:
-  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  # scrape_timeout is set to the global default (10s).
+  scrape_interval: 15s
+  evaluation_interval: 15s
 
-# alter manager if required
-# Alertmanager configuration
-# alerting:
-#   alertmanagers:
-#     - static_configs:
-#         - targets:
-#         - alertmanager:9093
-
-# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
-rule_files:
-  # - "first_rules.yml"
-  # - "second_rules.yml"
-
-# A scrape configuration containing exactly one endpoint to scrape:
-# Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: "open-router"
-
+  - job_name: "otel-collector"
     metrics_path: /metrics
-    # scheme defaults to 'http'.
-
+    # Keep the app's own job="decision-engine" label instead of renaming it to exported_job.
+    honor_labels: true
     static_configs:
-      - targets: ["decision-engine-api:9094"]
+      - targets: ["otel-collector:9898"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-      - "9094:9094"
     depends_on:
       postgresql:
         condition: service_healthy
@@ -36,6 +35,9 @@ services:
           - decision-engine-api
     environment:
       - GROOVY_RUNNER_HOST=host.docker.internal:8085
+      # Metrics are pushed to the otel-collector (monitoring profile); off unless asked for.
+      - DECISION_ENGINE__LOG__TELEMETRY__METRICS_ENABLED=${DE_METRICS_ENABLED:-false}
+      - DECISION_ENGINE__LOG__TELEMETRY__OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 
   open-router-mysql-ghcr:
     image: ghcr.io/juspay/decision-engine:${DECISION_ENGINE_TAG:-v1.4}
@@ -72,6 +74,9 @@ services:
           - decision-engine-api
     environment:
       - GROOVY_RUNNER_HOST=host.docker.internal:8085
+      # Metrics are pushed to the otel-collector (monitoring profile); off unless asked for.
+      - DECISION_ENGINE__LOG__TELEMETRY__METRICS_ENABLED=${DE_METRICS_ENABLED:-false}
+      - DECISION_ENGINE__LOG__TELEMETRY__OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 
   # ==========================================
   # Decision Engine Runtime (Local Build)
@@ -90,7 +95,6 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-      - "9094:9094"
     depends_on:
       postgresql:
         condition: service_healthy
@@ -114,6 +118,9 @@ services:
           - decision-engine-api
     environment:
       - GROOVY_RUNNER_HOST=host.docker.internal:8085
+      # Metrics are pushed to the otel-collector (monitoring profile); off unless asked for.
+      - DECISION_ENGINE__LOG__TELEMETRY__METRICS_ENABLED=${DE_METRICS_ENABLED:-false}
+      - DECISION_ENGINE__LOG__TELEMETRY__OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 
   open-router-mysql-local:
     build:
@@ -154,6 +161,9 @@ services:
           - decision-engine-api
     environment:
       - GROOVY_RUNNER_HOST=host.docker.internal:8085
+      # Metrics are pushed to the otel-collector (monitoring profile); off unless asked for.
+      - DECISION_ENGINE__LOG__TELEMETRY__METRICS_ENABLED=${DE_METRICS_ENABLED:-false}
+      - DECISION_ENGINE__LOG__TELEMETRY__OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 
   # ==========================================
   # Dashboard and Docs
@@ -203,12 +213,29 @@ services:
   # ==========================================
   # Supporting Services
   # ==========================================
+  # Receives OTLP metrics from the app and re-exposes them for Prometheus, as in the Hyperswitch clusters.
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.116.1
+    profiles:
+      - monitoring
+    networks:
+      - open-router-network
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./config/otel-collector.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "9898:9898"
+    restart: unless-stopped
+
   prometheus:
     image: prom/prometheus:latest
     profiles:
       - monitoring
     networks:
       - open-router-network
+    depends_on:
+      - otel-collector
     volumes:
       - ./config/prometheus.yaml:/etc/prometheus/prometheus.yml
     ports:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,10 +46,9 @@ metrics_enabled = true
 ignore_errors = true
 otel_exporter_otlp_endpoint = "http://localhost:4317"
 otel_exporter_otlp_timeout = 10000 # milliseconds per export request
-metrics_export_interval_secs = 5   # how often the collected metrics are pushed
 ```
 
-There is no metrics port to scrape. When `metrics_enabled` is on, metrics are pushed over OTLP/gRPC to an OpenTelemetry collector every `metrics_export_interval_secs`. In the Hyperswitch clusters the collector re-exposes them to vmagent, so they land in VictoriaMetrics and the Grafana `VictoriaMetrics` datasource. The collector adds `source_namespace`, `source_pod` and `source_app` labels; filter by `source_namespace="decision-engine"` in Grafana. With `metrics_enabled = false` the instruments are no-ops.
+There is no metrics port to scrape. When `metrics_enabled` is on, metrics are pushed over OTLP/gRPC to an OpenTelemetry collector every 3 seconds, the same cadence as Hyperswitch. In the Hyperswitch clusters the collector re-exposes them to vmagent, so they land in VictoriaMetrics and the Grafana `VictoriaMetrics` datasource. The collector adds `source_namespace`, `source_pod` and `source_app` labels; filter by `source_namespace="decision-engine"` in Grafana. With `metrics_enabled = false` the instruments are no-ops.
 
 `metrics_enabled` defaults to `false` and the endpoint defaults to the local collector (`http://localhost:4317` for a native binary, `http://otel-collector:4317` inside Compose), so enabling is a single flag. `oneclick.sh` starts the collector and Prometheus and runs the API with metrics enabled; the `monitoring` Compose profile adds Grafana. Metrics are then at `http://localhost:9898/metrics` on the collector and in Prometheus at `http://localhost:9090`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,15 +38,22 @@ log_format = "default"
 
 `log_format` accepts `"default"` (human-readable) or `"json"` (structured, recommended for prod).
 
-### Metrics
+### Metrics (OpenTelemetry push)
 
 ```toml
-[metrics]
-host = "0.0.0.0"
-port = 9094
+[log.telemetry]
+metrics_enabled = true
+ignore_errors = true
+otel_exporter_otlp_endpoint = "http://localhost:4317"
+otel_exporter_otlp_timeout = 10000 # milliseconds per export request
+metrics_export_interval_secs = 5   # how often the collected metrics are pushed
 ```
 
-Prometheus metrics are exposed at `host:port/metrics`. Used by the `monitoring` Compose profile (Prometheus scrapes `9094`, Grafana at `3000`).
+There is no metrics port to scrape. When `metrics_enabled` is on, metrics are pushed over OTLP/gRPC to an OpenTelemetry collector every `metrics_export_interval_secs`. In the Hyperswitch clusters the collector re-exposes them to vmagent, so they land in VictoriaMetrics and the Grafana `VictoriaMetrics` datasource. The collector adds `source_namespace`, `source_pod` and `source_app` labels; filter by `source_namespace="decision-engine"` in Grafana. With `metrics_enabled = false` the instruments are no-ops.
+
+`metrics_enabled` defaults to `false` and the endpoint defaults to the local collector (`http://localhost:4317` for a native binary, `http://otel-collector:4317` inside Compose), so enabling is a single flag. `oneclick.sh` starts the collector and Prometheus and runs the API with metrics enabled; the `monitoring` Compose profile adds Grafana. Metrics are then at `http://localhost:9898/metrics` on the collector and in Prometheus at `http://localhost:9090`.
+
+Environment variables follow the usual prefix, e.g. `DECISION_ENGINE__LOG__TELEMETRY__METRICS_ENABLED=true` and `DECISION_ENGINE__LOG__TELEMETRY__OTEL_EXPORTER_OTLP_ENDPOINT=...`.
 
 ### Rate Limiting
 

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -58,7 +58,7 @@ You must pass at least one profile.
 
 | Profile | Adds |
 |---|---|
-| `monitoring` | Prometheus + Grafana |
+| `monitoring` | OpenTelemetry collector + Prometheus + Grafana |
 | `groovy-ghcr` | Groovy runner image |
 | `groovy-local` | Groovy runner built from local source |
 | `analytics-clickhouse` | Kafka topic init + ClickHouse analytics bootstrap only |
@@ -94,11 +94,13 @@ npm run test:e2e:docker
 
 This flow:
 
-- starts PostgreSQL, Redis, Kafka, ClickHouse, and the analytics init jobs with Docker Compose
+- starts PostgreSQL, Redis, Kafka, ClickHouse, the analytics init jobs, an OpenTelemetry collector and Prometheus with Docker Compose
 - waits for infra health
 - runs PostgreSQL migrations
-- starts the API locally with `cargo run --no-default-features --features postgres`
+- starts the API locally with `cargo run --no-default-features --features postgres`, with metrics enabled and pushed to the collector at `localhost:4317`
 - starts the dashboard locally with Vite on `http://localhost:5173/`
+
+Metrics show up at `http://localhost:9898/metrics` (the collector's Prometheus-format view) and in Prometheus at `http://localhost:9090`. Grafana is not started by `oneclick.sh` because its port 3000 is taken by the docs preview; use the `monitoring` Compose profile for Grafana.
 
 By default, `Ctrl+C` stops the local API/dashboard processes and any infra services that `oneclick.sh`
 started itself. To keep infra running after exit:
@@ -224,8 +226,11 @@ Dashboard profiles also expose:
 
 Monitoring profile also exposes:
 
-- Prometheus: `http://localhost:9090`
+- OpenTelemetry collector: OTLP/gRPC on `localhost:4317`, Prometheus-format metrics at `http://localhost:9898/metrics`
+- Prometheus: `http://localhost:9090` (scrapes the collector)
 - Grafana: `http://localhost:3000`
+
+The app only pushes metrics when telemetry is enabled. `oneclick.sh` turns it on for the natively run binary; for the Compose app profiles set `DE_METRICS_ENABLED=true` (the endpoint `http://otel-collector:4317` is already configured). For any other setup set `DECISION_ENGINE__LOG__TELEMETRY__METRICS_ENABLED=true` and, if needed, `DECISION_ENGINE__LOG__TELEMETRY__OTEL_EXPORTER_OTLP_ENDPOINT`.
 
 ## Troubleshooting
 

--- a/oneclick.sh
+++ b/oneclick.sh
@@ -75,8 +75,14 @@ KAFKA_HOST="${KAFKA_HOST:-localhost}"
 KAFKA_PORT="${KAFKA_PORT:-9092}"
 MAILPIT_HOST="${MAILPIT_HOST:-localhost}"
 MAILPIT_UI_PORT="${MAILPIT_UI_PORT:-8025}"
+# Metrics: the API pushes OTLP to the collector, which re-exposes them for Prometheus to scrape.
+OTEL_COLLECTOR_HOST="${OTEL_COLLECTOR_HOST:-localhost}"
+OTEL_COLLECTOR_GRPC_PORT="${OTEL_COLLECTOR_GRPC_PORT:-4317}"
+OTEL_COLLECTOR_PROM_PORT="${OTEL_COLLECTOR_PROM_PORT:-9898}"
+OTEL_COLLECTOR_ENDPOINT="http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_GRPC_PORT}"
+OTEL_COLLECTOR_METRICS_URL="http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PROM_PORT}/metrics"
 
-PORTS=(8080 5173 "$DOCS_PORT" 9094)
+PORTS=(8080 5173 "$DOCS_PORT")
 EXPECTED_CLICKHOUSE_TABLES=(
     analytics_api_events_queue
     analytics_domain_events_queue
@@ -239,6 +245,11 @@ check_mailpit() {
     # `/api/v1/messages` is the message-listing endpoint — it confirms the API is serving, not
     # just that the web UI's index renders.
     curl -fsS "http://${MAILPIT_HOST}:${MAILPIT_UI_PORT}/api/v1/messages" >/dev/null 2>&1
+}
+
+check_otel_collector() {
+    # The collector's Prometheus-format endpoint is up once OTLP ingest is up.
+    curl -fsS "${OTEL_COLLECTOR_METRICS_URL}" >/dev/null 2>&1
 }
 
 check_clickhouse_schema() {
@@ -413,12 +424,19 @@ run_infra_checklist() {
         MAILPIT_READY=0
     fi
 
+    if check_otel_collector; then
+        OTEL_READY=1
+    else
+        OTEL_READY=0
+    fi
+
     print_service_status "Docker daemon" "$DOCKER_READY"
     print_service_status "Postgres (${POSTGRES_HOST}:${POSTGRES_PORT})" "$POSTGRES_READY"
     print_service_status "Redis (${REDIS_HOST}:${REDIS_PORT})" "$REDIS_READY"
     print_service_status "Kafka (${KAFKA_HOST}:${KAFKA_PORT})" "$KAFKA_READY"
     print_service_status "ClickHouse (${CLICKHOUSE_HTTP_URL})" "$CLICKHOUSE_READY"
     print_service_status "Mailpit UI (${MAILPIT_HOST}:${MAILPIT_UI_PORT}) / SMTP :1025" "$MAILPIT_READY"
+    print_service_status "OpenTelemetry collector (${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PROM_PORT}) / OTLP :${OTEL_COLLECTOR_GRPC_PORT}" "$OTEL_READY"
     echo ""
 }
 
@@ -527,6 +545,27 @@ wait_for_mailpit() {
     return 1
 }
 
+wait_for_otel_collector() {
+    local attempts=0
+    local max_attempts=30
+
+    echo "Waiting for the OpenTelemetry collector on ${OTEL_COLLECTOR_METRICS_URL}..."
+
+    while [ $attempts -lt $max_attempts ]; do
+        if check_otel_collector; then
+            echo "OpenTelemetry collector is healthy."
+            echo ""
+            return 0
+        fi
+
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+
+    echo "OpenTelemetry collector did not become healthy within ${max_attempts}s."
+    return 1
+}
+
 wait_for_backend() {
     local attempts=0
     local max_attempts=480
@@ -584,15 +623,16 @@ wait_for_docs() {
 check_and_kill_ports
 run_infra_checklist
 
-if [ "${DOCKER_READY}" -eq 0 ] && ([ "${POSTGRES_READY}" -eq 0 ] || [ "${REDIS_READY}" -eq 0 ] || [ "${KAFKA_READY}" -eq 0 ] || [ "${CLICKHOUSE_READY}" -eq 0 ] || [ "${MAILPIT_READY}" -eq 0 ]); then
+if [ "${DOCKER_READY}" -eq 0 ] && ([ "${POSTGRES_READY}" -eq 0 ] || [ "${REDIS_READY}" -eq 0 ] || [ "${KAFKA_READY}" -eq 0 ] || [ "${CLICKHOUSE_READY}" -eq 0 ] || [ "${MAILPIT_READY}" -eq 0 ] || [ "${OTEL_READY}" -eq 0 ]); then
     echo "Cannot start missing infrastructure services because Docker is not available."
     echo "Start Docker/OrbStack first, then rerun ./oneclick.sh."
     cleanup 1
 fi
 
-if [ "${POSTGRES_READY}" -eq 0 ] || [ "${REDIS_READY}" -eq 0 ] || [ "${KAFKA_READY}" -eq 0 ] || [ "${CLICKHOUSE_READY}" -eq 0 ] || [ "${MAILPIT_READY}" -eq 0 ]; then
+if [ "${POSTGRES_READY}" -eq 0 ] || [ "${REDIS_READY}" -eq 0 ] || [ "${KAFKA_READY}" -eq 0 ] || [ "${CLICKHOUSE_READY}" -eq 0 ] || [ "${MAILPIT_READY}" -eq 0 ] || [ "${OTEL_READY}" -eq 0 ]; then
     echo "Starting infrastructure services..."
-    COMPOSE_PROFILES= docker compose --profile postgres-ghcr --profile analytics-clickhouse up -d postgresql redis kafka kafka-init clickhouse mailpit
+    # otel-collector and prometheus are named explicitly so the monitoring profile's Grafana (port 3000, the docs preview here) stays off.
+    COMPOSE_PROFILES= docker compose --profile postgres-ghcr --profile analytics-clickhouse up -d postgresql redis kafka kafka-init clickhouse mailpit otel-collector prometheus
     echo ""
 fi
 
@@ -613,6 +653,10 @@ if [ "${CLICKHOUSE_READY}" -eq 0 ] && ! wait_for_clickhouse; then
 fi
 
 if [ "${MAILPIT_READY}" -eq 0 ] && ! wait_for_mailpit; then
+    cleanup 1
+fi
+
+if [ "${OTEL_READY}" -eq 0 ] && ! wait_for_otel_collector; then
     cleanup 1
 fi
 
@@ -668,6 +712,8 @@ if [ "${CARGO_BUILD_MODE}" = "release" ]; then
     echo "  (release build: the first compile takes longer, but runtime — including large report ingestion — is far faster)"
 fi
 
+DECISION_ENGINE__LOG__TELEMETRY__METRICS_ENABLED=true \
+DECISION_ENGINE__LOG__TELEMETRY__OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_COLLECTOR_ENDPOINT}" \
 cargo run ${CARGO_PROFILE_FLAG} --no-default-features --features postgres &
 SERVER_PID=$!
 

--- a/oneclick.sh
+++ b/oneclick.sh
@@ -83,6 +83,8 @@ OTEL_COLLECTOR_ENDPOINT="http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_GRPC_POR
 OTEL_COLLECTOR_METRICS_URL="http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PROM_PORT}/metrics"
 
 PORTS=(8080 5173 "$DOCS_PORT")
+# Ports of Compose-managed infra oneclick starts itself; our own containers on them are reused, anything else is a conflict.
+INFRA_PORTS=("$OTEL_COLLECTOR_GRPC_PORT" "$OTEL_COLLECTOR_PROM_PORT" 9090)
 EXPECTED_CLICKHOUSE_TABLES=(
     analytics_api_events_queue
     analytics_domain_events_queue
@@ -94,14 +96,22 @@ EXPECTED_CLICKHOUSE_TABLES=(
     cost_bin_product
 )
 
+# True when the container publishing $1 belongs to this Compose project (so it is ours to reuse).
+is_own_compose_container() {
+    local port="$1"
+    local container_id
+    container_id=$(docker ps --filter "publish=$port" -q 2>/dev/null | head -1 || true)
+    [ -n "$container_id" ] && docker compose ps -q 2>/dev/null | grep -q "^${container_id}"
+}
+
 check_and_kill_ports() {
     local pids_to_kill=()
     local ports_in_use=()
 
-    echo "Checking for processes on ports ${PORTS[*]}..."
+    echo "Checking for processes on ports ${PORTS[*]} ${INFRA_PORTS[*]}..."
     echo ""
 
-    for port in "${PORTS[@]}"; do
+    for port in "${PORTS[@]}" "${INFRA_PORTS[@]}"; do
         local pids
         pids=$(lsof -t -iTCP:$port -sTCP:LISTEN 2>/dev/null || true)
         if [ -n "$pids" ]; then
@@ -114,6 +124,10 @@ check_and_kill_ports() {
                 # processes. Killing them would take down the entire container runtime.
                 # Stop the container instead.
                 if echo "$cmd" | grep -qiE "OrbStack|com\.docker\.backend|dockerd"; then
+                    if is_own_compose_container "$port"; then
+                        echo "  [ok] Port $port is forwarded by this project's own container — reusing it."
+                        continue
+                    fi
                     local container_id
                     container_id=$(docker ps --filter "publish=$port" -q 2>/dev/null | head -1 || true)
                     if [ -n "$container_id" ]; then
@@ -160,10 +174,14 @@ check_and_kill_ports() {
 
         sleep 1
 
-        for port in "${PORTS[@]}"; do
+        for port in "${PORTS[@]}" "${INFRA_PORTS[@]}"; do
             local pid
             pid=$(lsof -t -iTCP:$port -sTCP:LISTEN 2>/dev/null || true)
             if [ -n "$pid" ]; then
+                # Never force-kill the container runtime's port forwarder: that takes down every container.
+                if ps -p "$pid" -o command= 2>/dev/null | grep -qiE "OrbStack|com\.docker\.backend|dockerd"; then
+                    continue
+                fi
                 kill -9 "$pid" 2>/dev/null || true
                 echo "  Force killed PID $pid on port $port"
             fi
@@ -172,7 +190,7 @@ check_and_kill_ports() {
         echo "Done. All ports cleared."
         echo ""
     else
-        echo "No processes found on ports ${PORTS[*]}."
+        echo "No conflicting processes found on ports ${PORTS[*]} ${INFRA_PORTS[*]}."
         echo ""
     fi
 }

--- a/src/bin/open_router.rs
+++ b/src/bin/open_router.rs
@@ -16,6 +16,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ["tower_http"],
     );
 
+    // Instruments bind to the global meter provider at first use, so this must run before anything records a metric.
+    let _metrics_guard = open_router::metrics::init(&global_config.log.telemetry)
+        .expect("Failed to set up the metrics pipeline");
+
     #[allow(clippy::expect_used)]
     global_config
         .validate()
@@ -52,12 +56,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("Failed while building the main server")
     });
 
-    let metrics_server_handle = tokio::spawn(async move {
-        open_router::metrics::metrics_server_builder(global_config.clone())
-            .await
-            .expect("Failed while building the metrics server")
-    });
-
     // The pacing scheduler, on a port of its own. It owns the clock: when a merchant's forecast
     // comes due it calls the main server, which does the work.
     let volume_commitment_server_handle = tokio::spawn(async move {
@@ -70,11 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Wait for the servers to complete (they should run indefinitely)
-    tokio::try_join!(
-        main_server_handle,
-        metrics_server_handle,
-        volume_commitment_server_handle
-    )?;
+    tokio::try_join!(main_server_handle, volume_commitment_server_handle)?;
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,6 @@ use std::{
 #[derive(Clone, serde::Deserialize, Debug)]
 pub struct GlobalConfig {
     pub server: Server,
-    pub metrics: Server,
     #[cfg(feature = "mysql")]
     pub database: Database,
     #[cfg(feature = "postgres")]

--- a/src/decider/gatewaydecider/volume_commitment/server.rs
+++ b/src/decider/gatewaydecider/volume_commitment/server.rs
@@ -1,4 +1,4 @@
-//! The scheduler's own axum listener (like the metrics server): `/health`, `/schedule`, and the loop.
+//! The scheduler's own axum listener: `/health`, `/schedule`, and the loop.
 
 use std::sync::Arc;
 
@@ -9,8 +9,8 @@ use tokio::signal::unix::{signal, SignalKind};
 
 use super::scheduler::{ScheduleEntry, Scheduler};
 use super::Deps;
+use crate::error::ConfigurationError;
 use crate::logger;
-use crate::metrics::ConfigurationError;
 
 /// Serve the scheduler's port, and run its loop, until SIGTERM. A no-op unless
 /// `volume_commitment.enabled` — two schedulers would double every run.

--- a/src/logger/config.rs
+++ b/src/logger/config.rs
@@ -26,8 +26,6 @@ pub struct LogTelemetry {
     pub otel_exporter_otlp_endpoint: Option<String>,
     /// Timeout (in milliseconds) for one export.
     pub otel_exporter_otlp_timeout: Option<u64>,
-    /// Seconds between two exports. Defaults to 5.
-    pub metrics_export_interval_secs: Option<u64>,
 }
 
 /// Logging to a console.

--- a/src/logger/config.rs
+++ b/src/logger/config.rs
@@ -9,6 +9,25 @@ use serde::Deserialize;
 pub struct Log {
     /// Logging to a console.
     pub console: LogConsole,
+    /// Telemetry export.
+    #[serde(default)]
+    pub telemetry: LogTelemetry,
+}
+
+/// Telemetry export: metrics pushed to an OpenTelemetry collector over OTLP/gRPC.
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct LogTelemetry {
+    /// Whether metrics are pushed to the collector; when off, every instrument is a no-op.
+    pub metrics_enabled: bool,
+    /// Whether a failure to build the exporter is logged and ignored instead of failing startup.
+    pub ignore_errors: bool,
+    /// OTLP/gRPC endpoint of the collector, e.g. `http://otel-collector:4317`.
+    pub otel_exporter_otlp_endpoint: Option<String>,
+    /// Timeout (in milliseconds) for one export.
+    pub otel_exporter_otlp_timeout: Option<u64>,
+    /// Seconds between two exports. Defaults to 5.
+    pub metrics_export_interval_secs: Option<u64>,
 }
 
 /// Logging to a console.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,170 +1,542 @@
+//! Application metrics: OpenTelemetry instruments behind a Prometheus-shaped facade, pushed over OTLP to the collector when `[log.telemetry].metrics_enabled` is set; [`init`] must run before any metric is touched.
+
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
 use error_stack::ResultExt;
-use lazy_static::lazy_static;
-use prometheus::{
-    self, exponential_buckets, register_histogram_vec, register_int_counter_vec,
-    register_int_gauge_vec, Encoder, HistogramVec, IntCounterVec, IntGaugeVec, TextEncoder,
+use opentelemetry::{
+    global,
+    metrics::{Counter, Gauge, Histogram, Meter},
+    KeyValue,
 };
-use tokio::signal::unix::{signal, SignalKind};
-lazy_static! {
-    /// Total count of API requests by endpoint
-    pub static ref API_REQUEST_TOTAL_COUNTER: IntCounterVec = register_int_counter_vec!(
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider, Temporality};
+
+use crate::logger::config::LogTelemetry;
+
+/// Service name reported as the OpenTelemetry `service.name` resource attribute.
+const SERVICE_NAME: &str = "decision-engine";
+const DEFAULT_EXPORT_INTERVAL_SECS: u64 = 5;
+const EXPORT_TIMEOUT_SECS: u64 = 10;
+
+/// Meter every instrument is created from; resolved per instrument so anything created after [`init`] binds to the real provider.
+fn meter() -> Meter {
+    global::meter(SERVICE_NAME)
+}
+
+/// Total count of API requests by endpoint
+pub static API_REQUEST_TOTAL_COUNTER: LazyLock<CounterVec> = LazyLock::new(|| {
+    CounterVec::new(
         "api_requests_total",
         "Total Count of API requests by endpoint",
-        &["endpoint"]
+        &["endpoint"],
     )
-    .unwrap();
+});
 
-    /// Count of API requests grouped by endpoint and result status
-    pub static ref API_REQUEST_COUNTER: IntCounterVec = register_int_counter_vec!(
+/// Count of API requests grouped by endpoint and result status
+pub static API_REQUEST_COUNTER: LazyLock<CounterVec> = LazyLock::new(|| {
+    CounterVec::new(
         "api_requests_by_status",
         "Count of API requests grouped by endpoint and result",
-        &["endpoint", "status"]
-    ).unwrap();
+        &["endpoint", "status"],
+    )
+});
 
-    /// Latency of API calls grouped by endpoint
-    pub static ref API_LATENCY_HISTOGRAM: HistogramVec = register_histogram_vec!(
+/// Latency of API calls grouped by endpoint
+pub static API_LATENCY_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
+    HistogramVec::new(
         "api_latency_seconds",
         "Latency of API calls grouped by endpoint",
         &["endpoint"],
-        exponential_buckets(0.0005, 2.0, 10).unwrap()
-    ).unwrap();
+        exponential_buckets(0.0005, 2.0, 10),
+    )
+});
 
-    /// Count of routing decisions grouped by routing approach and result status
-    pub static ref ROUTING_DECISION_COUNTER: IntCounterVec = register_int_counter_vec!(
+/// Count of routing decisions grouped by routing approach and result status
+pub static ROUTING_DECISION_COUNTER: LazyLock<CounterVec> = LazyLock::new(|| {
+    CounterVec::new(
         "routing_decisions_total",
         "Count of routing decisions grouped by routing approach and result status",
-        &["approach", "status"]
-    ).unwrap();
+        &["approach", "status"],
+    )
+});
 
-    /// Count of priority logic rule hits grouped by rule name
-    pub static ref ROUTING_RULE_HIT_COUNTER: IntCounterVec = register_int_counter_vec!(
+/// Count of priority logic rule hits grouped by rule name
+pub static ROUTING_RULE_HIT_COUNTER: LazyLock<CounterVec> = LazyLock::new(|| {
+    CounterVec::new(
         "routing_rule_hits_total",
         "Count of priority logic rule hits grouped by rule name",
-        &["rule_name"]
-    ).unwrap();
+        &["rule_name"],
+    )
+});
 
-    /// Count of analytics events captured by flow type
-    pub static ref ANALYTICS_EVENT_COUNTER: IntCounterVec = register_int_counter_vec!(
+/// Count of analytics events captured by flow type
+pub static ANALYTICS_EVENT_COUNTER: LazyLock<CounterVec> = LazyLock::new(|| {
+    CounterVec::new(
         "analytics_events_total",
         "Count of analytics events captured by flow type",
-        &["flow_type"]
-    ).unwrap();
+        &["flow_type"],
+    )
+});
 
-    pub static ref ANALYTICS_SINK_WRITES_TOTAL: IntCounterVec = register_int_counter_vec!(
+pub static ANALYTICS_SINK_WRITES_TOTAL: LazyLock<CounterVec> = LazyLock::new(|| {
+    CounterVec::new(
         "analytics_sink_writes_total",
         "Count of analytics sink write attempts grouped by sink, stream and result",
-        &["sink", "stream", "result"]
-    ).unwrap();
+        &["sink", "stream", "result"],
+    )
+});
 
-    pub static ref ANALYTICS_SINK_WRITE_LATENCY_HISTOGRAM: HistogramVec = register_histogram_vec!(
+pub static ANALYTICS_SINK_WRITE_LATENCY_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
+    HistogramVec::new(
         "analytics_sink_write_latency_seconds",
         "Latency of analytics sink writes",
         &["sink", "stream"],
-        exponential_buckets(0.001, 2.0, 12).unwrap()
-    ).unwrap();
+        exponential_buckets(0.001, 2.0, 12),
+    )
+});
 
-    pub static ref ANALYTICS_EVENTS_DROPPED_TOTAL: IntCounterVec = register_int_counter_vec!(
+pub static ANALYTICS_EVENTS_DROPPED_TOTAL: LazyLock<CounterVec> = LazyLock::new(|| {
+    CounterVec::new(
         "analytics_events_dropped_total",
         "Count of dropped analytics events",
-        &["stream", "reason"]
-    ).unwrap();
+        &["stream", "reason"],
+    )
+});
 
-    pub static ref ANALYTICS_SINK_QUEUE_DEPTH: IntGaugeVec = register_int_gauge_vec!(
+pub static ANALYTICS_SINK_QUEUE_DEPTH: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
         "analytics_sink_queue_depth",
         "Current analytics queue depth by stream",
-        &["stream"]
-    ).unwrap();
+        &["stream"],
+    )
+});
 
-    pub static ref ANALYTICS_KAFKA_PRODUCE_TOTAL: IntCounterVec = register_int_counter_vec!(
+pub static ANALYTICS_KAFKA_PRODUCE_TOTAL: LazyLock<CounterVec> = LazyLock::new(|| {
+    CounterVec::new(
         "analytics_kafka_produce_total",
         "Count of Kafka analytics produce attempts grouped by stream and result",
-        &["stream", "result"]
-    ).unwrap();
+        &["stream", "result"],
+    )
+});
 
-    pub static ref ANALYTICS_KAFKA_DELIVERY_LATENCY_HISTOGRAM: HistogramVec = register_histogram_vec!(
-        "analytics_kafka_delivery_latency_seconds",
-        "Latency of Kafka analytics delivery acknowledgements",
-        &["stream"],
-        exponential_buckets(0.001, 2.0, 12).unwrap()
-    ).unwrap();
+pub static ANALYTICS_KAFKA_DELIVERY_LATENCY_HISTOGRAM: LazyLock<HistogramVec> =
+    LazyLock::new(|| {
+        HistogramVec::new(
+            "analytics_kafka_delivery_latency_seconds",
+            "Latency of Kafka analytics delivery acknowledgements",
+            &["stream"],
+            exponential_buckets(0.001, 2.0, 12),
+        )
+    });
 
+/// `count` bucket boundaries starting at `start`, each `factor` times the previous one.
+fn exponential_buckets(start: f64, factor: f64, count: i32) -> Vec<f64> {
+    (0..count).map(|i| start * factor.powi(i)).collect()
 }
 
-pub async fn metrics_handler() -> error_stack::Result<String, MetricsError> {
-    let mut buffer = Vec::new();
-    let encoder = TextEncoder::new();
-    let metric_families = prometheus::gather();
-    encoder
-        .encode(&metric_families, &mut buffer)
-        .change_context(MetricsError::EncodingError)?;
-    String::from_utf8(buffer).change_context(MetricsError::Utf8Error)
+/// Pairs label names with the values a call site passed, in order.
+fn attributes(label_names: &[&'static str], values: &[&str]) -> Vec<KeyValue> {
+    debug_assert_eq!(
+        label_names.len(),
+        values.len(),
+        "metric label value count does not match its label names"
+    );
+    label_names
+        .iter()
+        .zip(values)
+        .map(|(name, value)| KeyValue::new(*name, (*value).to_owned()))
+        .collect()
+}
+
+/// A monotonically increasing counter with a fixed set of label names.
+pub struct CounterVec {
+    counter: Counter<u64>,
+    label_names: &'static [&'static str],
+}
+
+impl CounterVec {
+    fn new(
+        name: &'static str,
+        description: &'static str,
+        label_names: &'static [&'static str],
+    ) -> Self {
+        Self {
+            counter: meter()
+                .u64_counter(name)
+                .with_description(description)
+                .build(),
+            label_names,
+        }
+    }
+
+    pub fn with_label_values(&self, values: &[&str]) -> BoundCounter<'_> {
+        BoundCounter {
+            counter: &self.counter,
+            attributes: attributes(self.label_names, values),
+        }
+    }
+}
+
+/// A [`CounterVec`] bound to one set of label values.
+pub struct BoundCounter<'a> {
+    counter: &'a Counter<u64>,
+    attributes: Vec<KeyValue>,
+}
+
+impl BoundCounter<'_> {
+    pub fn inc(&self) {
+        self.counter.add(1, &self.attributes);
+    }
+
+    pub fn inc_by(&self, value: u64) {
+        self.counter.add(value, &self.attributes);
+    }
+}
+
+/// A distribution of `f64` observations with a fixed set of label names.
+pub struct HistogramVec {
+    histogram: Histogram<f64>,
+    label_names: &'static [&'static str],
+}
+
+impl HistogramVec {
+    fn new(
+        name: &'static str,
+        description: &'static str,
+        label_names: &'static [&'static str],
+        boundaries: Vec<f64>,
+    ) -> Self {
+        Self {
+            histogram: meter()
+                .f64_histogram(name)
+                .with_description(description)
+                .with_boundaries(boundaries)
+                .build(),
+            label_names,
+        }
+    }
+
+    pub fn with_label_values(&self, values: &[&str]) -> BoundHistogram<'_> {
+        BoundHistogram {
+            histogram: &self.histogram,
+            attributes: attributes(self.label_names, values),
+        }
+    }
+}
+
+/// A [`HistogramVec`] bound to one set of label values.
+pub struct BoundHistogram<'a> {
+    histogram: &'a Histogram<f64>,
+    attributes: Vec<KeyValue>,
+}
+
+impl BoundHistogram<'_> {
+    pub fn observe(&self, value: f64) {
+        self.histogram.record(value, &self.attributes);
+    }
+
+    /// Starts a timer recorded by [`HistogramTimer::observe_duration`], or on drop if never observed explicitly.
+    pub fn start_timer(&self) -> HistogramTimer {
+        HistogramTimer {
+            histogram: self.histogram.clone(),
+            attributes: self.attributes.clone(),
+            start: Instant::now(),
+            observed: false,
+        }
+    }
+}
+
+/// Records the time elapsed since it was started into a histogram, exactly once.
+pub struct HistogramTimer {
+    histogram: Histogram<f64>,
+    attributes: Vec<KeyValue>,
+    start: Instant,
+    observed: bool,
+}
+
+impl HistogramTimer {
+    pub fn observe_duration(mut self) {
+        self.observe_now();
+    }
+
+    /// Drops the timer without recording anything.
+    pub fn stop_and_discard(mut self) {
+        self.observed = true;
+    }
+
+    fn observe_now(&mut self) {
+        if !self.observed {
+            self.observed = true;
+            self.histogram
+                .record(self.start.elapsed().as_secs_f64(), &self.attributes);
+        }
+    }
+}
+
+impl Drop for HistogramTimer {
+    fn drop(&mut self) {
+        self.observe_now();
+    }
+}
+
+/// A last-value gauge with a fixed set of label names.
+pub struct IntGaugeVec {
+    gauge: Gauge<i64>,
+    label_names: &'static [&'static str],
+}
+
+impl IntGaugeVec {
+    fn new(
+        name: &'static str,
+        description: &'static str,
+        label_names: &'static [&'static str],
+    ) -> Self {
+        Self {
+            gauge: meter()
+                .i64_gauge(name)
+                .with_description(description)
+                .build(),
+            label_names,
+        }
+    }
+
+    pub fn with_label_values(&self, values: &[&str]) -> BoundGauge<'_> {
+        BoundGauge {
+            gauge: &self.gauge,
+            attributes: attributes(self.label_names, values),
+        }
+    }
+}
+
+/// An [`IntGaugeVec`] bound to one set of label values.
+pub struct BoundGauge<'a> {
+    gauge: &'a Gauge<i64>,
+    attributes: Vec<KeyValue>,
+}
+
+impl BoundGauge<'_> {
+    pub fn set(&self, value: i64) {
+        self.gauge.record(value, &self.attributes);
+    }
+}
+
+/// Keeps the meter provider alive and flushes it on shutdown.
+#[derive(Debug)]
+pub struct MetricsGuard {
+    provider: Option<SdkMeterProvider>,
+}
+
+impl Drop for MetricsGuard {
+    fn drop(&mut self) {
+        if let Some(Err(error)) = self.provider.as_ref().map(SdkMeterProvider::shutdown) {
+            tracing::warn!(?error, "Failed to shut down the metrics provider cleanly");
+        }
+    }
+}
+
+/// Installs the global meter provider with the OTLP push reader; call inside the Tokio runtime, before any metric is used.
+pub fn init(config: &LogTelemetry) -> error_stack::Result<MetricsGuard, MetricsError> {
+    if !config.metrics_enabled {
+        tracing::info!(
+            category = "SERVER",
+            action = "metrics_pipeline_setup",
+            "Metrics export is disabled"
+        );
+        return Ok(MetricsGuard { provider: None });
+    }
+
+    let reader = match build_otlp_reader(config) {
+        Ok(reader) => reader,
+        Err(error) if config.ignore_errors => {
+            tracing::warn!(
+                ?error,
+                "Failed to build the OTLP metrics exporter, continuing without metrics"
+            );
+            return Ok(MetricsGuard { provider: None });
+        }
+        Err(error) => return Err(error),
+    };
+
+    let provider = SdkMeterProvider::builder()
+        .with_reader(reader)
+        .with_resource(resource())
+        .build();
+    global::set_meter_provider(provider.clone());
+
+    tracing::info!(
+        category = "SERVER",
+        action = "metrics_pipeline_setup",
+        otlp_endpoint = config
+            .otel_exporter_otlp_endpoint
+            .as_deref()
+            .unwrap_or("default"),
+        "Metrics pipeline initialised"
+    );
+
+    Ok(MetricsGuard {
+        provider: Some(provider),
+    })
+}
+
+fn resource() -> opentelemetry_sdk::Resource {
+    let mut attributes = vec![KeyValue::new("service.name", SERVICE_NAME)];
+    if let Ok(pod) = std::env::var("POD_NAME") {
+        attributes.push(KeyValue::new("pod", pod));
+    }
+    opentelemetry_sdk::Resource::new(attributes)
+}
+
+fn build_otlp_reader(config: &LogTelemetry) -> error_stack::Result<PeriodicReader, MetricsError> {
+    use opentelemetry_otlp::WithExportConfig;
+
+    let mut export_config = opentelemetry_otlp::ExportConfig {
+        protocol: opentelemetry_otlp::Protocol::Grpc,
+        endpoint: config.otel_exporter_otlp_endpoint.clone(),
+        ..Default::default()
+    };
+    if let Some(timeout_ms) = config.otel_exporter_otlp_timeout {
+        export_config.timeout = Duration::from_millis(timeout_ms);
+    }
+
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_tonic()
+        // The collector's prometheus exporter needs cumulative sums.
+        .with_temporality(Temporality::Cumulative)
+        .with_export_config(export_config)
+        .build()
+        .change_context(MetricsError::ExporterSetup)?;
+
+    let interval = config
+        .metrics_export_interval_secs
+        .unwrap_or(DEFAULT_EXPORT_INTERVAL_SECS);
+
+    Ok(
+        PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio)
+            .with_interval(Duration::from_secs(interval))
+            .with_timeout(Duration::from_secs(EXPORT_TIMEOUT_SECS))
+            .build(),
+    )
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum MetricsError {
-    #[error("Error encoding metrics")]
-    EncodingError,
-    #[error("Error converting metrics to utf8")]
-    Utf8Error,
+    #[error("Error setting up the OTLP metrics exporter")]
+    ExporterSetup,
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ConfigurationError {
-    #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
-}
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use opentelemetry_sdk::metrics::data;
+    use opentelemetry_sdk::testing::metrics::InMemoryMetricExporter;
 
-pub async fn metrics_server_builder(
-    config: crate::config::GlobalConfig,
-) -> Result<(), ConfigurationError> {
-    let listener = config.tcp_listener("Metrics").await?;
+    use super::*;
 
-    let router = axum::Router::new().route(
-        "/metrics",
-        axum::routing::get(|| async {
-            let output = metrics_handler().await;
-            match output {
-                Ok(metrics) => Ok(metrics),
-                Err(error) => {
-                    tracing::error!(?error, "Error fetching metrics");
+    fn find<'a>(metrics: &'a [data::ResourceMetrics], name: &str) -> &'a data::Metric {
+        metrics
+            .iter()
+            .flat_map(|resource| resource.scope_metrics.iter())
+            .flat_map(|scope| scope.metrics.iter())
+            .find(|metric| metric.name == name)
+            .unwrap_or_else(|| panic!("metric {name} was not exported"))
+    }
 
-                    Err((
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        "Error fetching metrics".to_string(),
-                    ))
-                }
-            }
-        }),
-    );
+    /// The facade must export the same names, labels and values the call sites expect.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn facade_exports_plain_names_labels_and_values() {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone(), opentelemetry_sdk::runtime::Tokio)
+            .with_interval(Duration::from_secs(3600))
+            .build();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(resource())
+            .build();
+        global::set_meter_provider(provider.clone());
 
-    // Create a signal stream for SIGTERM
-    let mut sigterm = signal(SignalKind::terminate()).expect("Failed to create SIGTERM handler");
+        let counter = CounterVec::new("metrics_facade_test_total", "test counter", &["endpoint"]);
+        counter.with_label_values(&["decide"]).inc();
+        counter.with_label_values(&["decide"]).inc_by(2);
 
-    axum::serve(listener, router.into_make_service())
-        .with_graceful_shutdown(async move {
-            let _ = sigterm.recv().await;
-            tracing::debug!("Metrics server shutting down gracefully");
-        })
-        .await?;
+        let histogram = HistogramVec::new(
+            "metrics_facade_test_seconds",
+            "test histogram",
+            &["endpoint"],
+            exponential_buckets(0.0005, 2.0, 10),
+        );
+        histogram
+            .with_label_values(&["decide"])
+            .start_timer()
+            .observe_duration();
+        histogram.with_label_values(&["decide"]).observe(0.25);
 
-    Ok(())
-}
+        let gauge = IntGaugeVec::new("metrics_facade_test_depth", "test gauge", &["stream"]);
+        gauge.with_label_values(&["api"]).set(7);
 
-impl crate::config::GlobalConfig {
-    pub async fn tcp_listener(
-        &self,
-        server: &str,
-    ) -> Result<tokio::net::TcpListener, ConfigurationError> {
-        let loc = format!("{}:{}", self.metrics.host, self.metrics.port);
+        provider.force_flush().expect("flush");
+        let exported = exporter.get_finished_metrics().expect("exported metrics");
 
-        tracing::info!(
-            category = "SERVER",
-            action = "metrics_server_startup",
-            server,
-            bind_address = %loc,
-            "Metrics server listening"
+        let sum = find(&exported, "metrics_facade_test_total")
+            .data
+            .as_any()
+            .downcast_ref::<data::Sum<u64>>()
+            .expect("counter is a u64 sum");
+        assert!(sum.is_monotonic);
+        assert_eq!(sum.data_points.len(), 1);
+        assert_eq!(sum.data_points[0].value, 3);
+        assert_eq!(
+            sum.data_points[0].attributes,
+            vec![KeyValue::new("endpoint", "decide")]
         );
 
-        Ok(tokio::net::TcpListener::bind(loc).await?)
+        let hist = find(&exported, "metrics_facade_test_seconds")
+            .data
+            .as_any()
+            .downcast_ref::<data::Histogram<f64>>()
+            .expect("histogram is f64");
+        assert_eq!(hist.data_points.len(), 1);
+        assert_eq!(hist.data_points[0].count, 2);
+        assert_eq!(hist.data_points[0].bounds.len(), 10);
+        assert_eq!(hist.data_points[0].bounds[0], 0.0005);
+
+        let gauge = find(&exported, "metrics_facade_test_depth")
+            .data
+            .as_any()
+            .downcast_ref::<data::Gauge<i64>>()
+            .expect("gauge is i64");
+        assert_eq!(gauge.data_points[0].value, 7);
+        assert_eq!(
+            gauge.data_points[0].attributes,
+            vec![KeyValue::new("stream", "api")]
+        );
+    }
+
+    /// The push reader must build and run without a reachable collector; failed exports never take the process down.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn otlp_reader_survives_an_unreachable_collector() {
+        use opentelemetry::metrics::MeterProvider as _;
+
+        let config = LogTelemetry {
+            metrics_enabled: true,
+            ignore_errors: false,
+            otel_exporter_otlp_endpoint: Some("http://127.0.0.1:1".to_owned()),
+            otel_exporter_otlp_timeout: Some(200),
+            metrics_export_interval_secs: Some(1),
+        };
+        let reader = build_otlp_reader(&config).expect("otlp reader");
+        let provider = SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(resource())
+            .build();
+
+        provider
+            .meter("test")
+            .u64_counter("otlp_test_total")
+            .build()
+            .add(1, &[]);
+
+        // Both fail because nothing listens on the endpoint; the point is that they return.
+        let _ = provider.force_flush();
+        let _ = provider.shutdown();
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,7 +15,8 @@ use crate::logger::config::LogTelemetry;
 
 /// Service name reported as the OpenTelemetry `service.name` resource attribute.
 const SERVICE_NAME: &str = "decision-engine";
-const DEFAULT_EXPORT_INTERVAL_SECS: u64 = 5;
+// Same push cadence and timeout as Hyperswitch's exporter.
+const EXPORT_INTERVAL_SECS: u64 = 3;
 const EXPORT_TIMEOUT_SECS: u64 = 10;
 
 /// Meter every instrument is created from; resolved per instrument so anything created after [`init`] binds to the real provider.
@@ -136,10 +137,11 @@ fn exponential_buckets(start: f64, factor: f64, count: i32) -> Vec<f64> {
 
 /// Pairs label names with the values a call site passed, in order.
 fn attributes(label_names: &[&'static str], values: &[&str]) -> Vec<KeyValue> {
-    debug_assert_eq!(
+    // Enforced in every build: a silent mismatch would corrupt series. Call sites pass literal label sets.
+    assert_eq!(
         label_names.len(),
         values.len(),
-        "metric label value count does not match its label names"
+        "metric label value count does not match its label names {label_names:?}"
     );
     label_names
         .iter()
@@ -406,13 +408,9 @@ fn build_otlp_reader(config: &LogTelemetry) -> error_stack::Result<PeriodicReade
         .build()
         .change_context(MetricsError::ExporterSetup)?;
 
-    let interval = config
-        .metrics_export_interval_secs
-        .unwrap_or(DEFAULT_EXPORT_INTERVAL_SECS);
-
     Ok(
         PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio)
-            .with_interval(Duration::from_secs(interval))
+            .with_interval(Duration::from_secs(EXPORT_INTERVAL_SECS))
             .with_timeout(Duration::from_secs(EXPORT_TIMEOUT_SECS))
             .build(),
     )
@@ -511,6 +509,12 @@ mod tests {
         );
     }
 
+    #[test]
+    #[should_panic(expected = "metric label value count does not match")]
+    fn label_arity_mismatch_panics_in_every_build() {
+        attributes(&["endpoint", "status"], &["decide"]);
+    }
+
     /// The push reader must build and run without a reachable collector; failed exports never take the process down.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn otlp_reader_survives_an_unreachable_collector() {
@@ -521,7 +525,6 @@ mod tests {
             ignore_errors: false,
             otel_exporter_otlp_endpoint: Some("http://127.0.0.1:1".to_owned()),
             otel_exporter_otlp_timeout: Some(200),
-            metrics_export_interval_secs: Some(1),
         };
         let reader = build_otlp_reader(&config).expect("otlp reader");
         let provider = SdkMeterProvider::builder()


### PR DESCRIPTION
## What

Decision Engine now ships its metrics the way Hyperswitch does: pushed over OTLP/gRPC to
the cluster's OpenTelemetry collector, which vmagent already scrapes into VictoriaMetrics.
The separate Prometheus `/metrics` server and its `[metrics]` host/port config are removed.

- `src/metrics.rs` is rebuilt on OpenTelemetry behind a Prometheus-shaped facade
  (`with_label_values(..).inc()`, `start_timer()`, `observe()`, `set()`), so none of the
  call sites change. Metric names, labels, and histogram buckets are unchanged.
- New `[log.telemetry]` config (`metrics_enabled`, `ignore_errors`,
  `otel_exporter_otlp_endpoint`, `otel_exporter_otlp_timeout`), overridable as
  `DECISION_ENGINE__LOG__TELEMETRY__*`. Off by default; when off every instrument is a
  no-op. The push cadence is fixed at 3s with a 10s timeout, the same as Hyperswitch.
- `metrics::init` runs right after logger setup, before anything records a metric.
- Dependencies: `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp` at 0.27 (matches
  Hyperswitch and the tonic 0.12 already in the lockfile). `prometheus`, `lazy_static`, and
  the metrics listener are gone. `internal-logs` is enabled so export failures reach tracing.
- Local dev: the compose `monitoring` profile gains an otel-collector
  (`config/otel-collector.yaml`); Prometheus scrapes the collector instead of the app.
  `oneclick.sh` starts the collector and Prometheus and runs the API with metrics enabled.

```toml
[log.telemetry]
metrics_enabled = true
ignore_errors = true
otel_exporter_otlp_endpoint = "http://otel-collector-opentelemetry-collector.monitoring.svc.cluster.local:4317"
```

## Flow

```mermaid
flowchart LR
    subgraph app["Decision Engine pod"]
        DE["Instruments in src/metrics.rs<br/>counters · histograms · gauge"]
        RD["PeriodicReader<br/>every 3s, cumulative"]
        DE --> RD
    end

    subgraph col["otel-collector · monitoring namespace"]
        IN["OTLP/gRPC receiver<br/>:4317"]
        K8S["k8sattributes<br/>adds source_namespace, source_pod"]
        OUT["Prometheus exporter<br/>:9898 /metrics"]
        IN --> K8S --> OUT
    end

    subgraph store["VictoriaMetrics"]
        VA["vmagent<br/>scrapes :9898 every 15s<br/>via the collector's ServiceMonitor"]
        VS["vmstorage<br/>persistent volumes, 1y prod / 3M sandbox"]
        VA --> VS
    end

    G["Grafana<br/>VictoriaMetrics datasource<br/>exported_job=&quot;decision-engine&quot;"]

    RD -- "push (outbound only, no port on DE)" --> IN
    OUT -- "pull" --> VA
    VS --> G

    HS["Hyperswitch router"] -. "same push, same collector" .-> IN
```

Locally the `monitoring` Compose profile plays the same roles with an otel-collector container
in place of the cluster collector and Prometheus in place of vmagent + VictoriaMetrics:

```mermaid
flowchart LR
    DE["Decision Engine<br/>(oneclick or Compose)"] -- "OTLP push :4317" --> C["otel-collector container"]
    C -- ":9898 /metrics, scraped every 15s" --> P["Prometheus :9090"]
    P --> GF["Grafana"]
```

## Why

Nothing in the clusters scraped the old metrics port: no ServiceMonitor, no vmagent job, no
annotation. The metrics existed but never reached Grafana. Hyperswitch avoids the scrape
problem entirely by pushing to the collector, so every link after that (collector →
vmagent → VictoriaMetrics → the Grafana `VictoriaMetrics` datasource) already exists and DE
inherits it with no monitoring-stack changes. Push also means no port to keep reachable,
no per-pod discovery, and nothing to reconfigure when pods move or scale.

## Metrics exported

`api_requests_total{endpoint}`, `api_requests_by_status{endpoint,status}`,
`api_latency_seconds{endpoint}`, `routing_decisions_total{approach,status}`,
`routing_rule_hits_total{rule_name}`, `analytics_events_total{flow_type}`,
`analytics_events_dropped_total{stream,reason}`, `analytics_sink_queue_depth{stream}`,
`analytics_kafka_produce_total{stream,result}`,
`analytics_kafka_delivery_latency_seconds{stream}`, plus the two declared-but-unrecorded
`analytics_sink_writes_total` and `analytics_sink_write_latency_seconds`.

Notes for dashboards: the collector appends `_total` to counters that lack it
(`api_requests_by_status` → `api_requests_by_status_total`); the app's `service.name`
arrives as `job="decision-engine"`, which vmagent renames to `exported_job` because the
collector's ServiceMonitor does not honour labels.

## Rollout

Per environment, add to the DE deployment's `extraEnvVars` in hyperswitch-infra:

```yaml
DECISION_ENGINE__LOG__TELEMETRY__METRICS_ENABLED: "true"
DECISION_ENGINE__LOG__TELEMETRY__IGNORE_ERRORS: "true"
DECISION_ENGINE__LOG__TELEMETRY__OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector-opentelemetry-collector.monitoring.svc.cluster.local:4317"
```

The old `DECISION_ENGINE__METRICS__*` variables and the chart's `metrics` service port become
unused but harmless. The old us-east-1 cluster has no collector; do not enable there.

## Verification

- `cargo check`, `cargo clippy --tests`, `cargo fmt` clean on the postgres backend.
- Two new unit tests: the facade exports the expected names, labels, and values through an
  in-memory exporter; the OTLP reader builds and shuts down cleanly with no collector
  reachable.
- End to end locally: `oneclick.sh` → decide-gateway and update-gateway-score traffic →
  series visible on the collector, in Prometheus, and on a Grafana dashboard.
  
  
  
<img width="1910" height="962" alt="Screenshot 2026-09-07 at 6 51 12 AM" src="https://github.com/user-attachments/assets/c8d49ddd-4b25-49d6-98a8-3c6a52c26656" />

