### PR TITLE
feat(auth): add useVolumeContractsBeta hook to control access for super-admins

### DIFF
--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useSearchParams } from 'react-router-dom'
+import { useVolumeContractsBeta } from '../../store/authStore'
 import useSWR from 'swr'
 import {
   Bar,
@@ -829,9 +830,15 @@ export function AnalyticsPage() {
   // reopens it directly; the default (transactions) is left out of the URL.
   const [searchParams, setSearchParams] = useSearchParams()
   const viewParam = searchParams.get('view')
-  const view: AnalyticsView = ANALYTICS_VIEWS.includes(viewParam as AnalyticsView)
+  // Volume commitments is in beta: only super-admins get the view. For
+  // anyone else a ?view=volume_commitments link behaves like an unknown view and is canonicalised
+  // back to the default by the effect below.
+  const volumeContractsBeta = useVolumeContractsBeta()
+  const requestedView: AnalyticsView = ANALYTICS_VIEWS.includes(viewParam as AnalyticsView)
     ? (viewParam as AnalyticsView)
     : 'transactions'
+  const view: AnalyticsView =
+    requestedView === 'volume_commitments' && !volumeContractsBeta ? 'transactions' : requestedView
   const setView = (nextView: AnalyticsView) => {
     setSearchParams(
       (prev) => {
@@ -1643,14 +1650,16 @@ export function AnalyticsPage() {
           >
             {ANALYTICS_VIEW_LABELS.rule_based}
           </Button>
-          <Button
-            size="sm"
-            variant="secondary"
-            className={sectionButtonClass(view === 'volume_commitments')}
-            onClick={() => setView('volume_commitments')}
-          >
-            {ANALYTICS_VIEW_LABELS.volume_commitments}
-          </Button>
+          {volumeContractsBeta && (
+            <Button
+              size="sm"
+              variant="secondary"
+              className={sectionButtonClass(view === 'volume_commitments')}
+              onClick={() => setView('volume_commitments')}
+            >
+              {ANALYTICS_VIEW_LABELS.volume_commitments}
+            </Button>
+          )}
         </div>
 
         <div className="flex items-center gap-2 justify-self-start xl:justify-self-end">

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -13,7 +13,7 @@ import { Spinner } from '../ui/Spinner'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { useMerchantStore } from '../../store/merchantStore'
 import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
-import { useAuthStore } from '../../store/authStore'
+import { useAuthStore, useVolumeContractsBeta } from '../../store/authStore'
 import { apiErrorStatus, apiPost, fetcher } from '../../lib/api'
 import { ContractSimulationPanel } from './ContractSimulationPanel'
 import { VolumeCommitmentRunChart } from './VolumeCommitmentRunChart'
@@ -1179,6 +1179,9 @@ export function DecisionSimulatorPage() {
   const navigate = useNavigate()
   const { merchantId } = useMerchantStore()
   const authUser = useAuthStore((state) => state.user)
+  // Volume Contracts is in beta: the contract loader and commitment run chart on the Batch tab
+  // are shown only to super-admins.
+  const volumeContractsBeta = useVolumeContractsBeta()
   const authMerchantId = authUser?.merchantId || ''
   const effectiveMerchantId = merchantId || authMerchantId
   const currentScopeKey = explorerScopeKey(
@@ -3956,7 +3959,7 @@ export function DecisionSimulatorPage() {
         style={activeTab === 'rule' ? { display: 'none' } : undefined}
       >
         <div className={`flex flex-col gap-6 min-w-0 ${activeTab === 'batch' ? 'lg:min-h-0' : 'self-start'}`}>
-        {activeTab === 'batch' && (
+        {activeTab === 'batch' && volumeContractsBeta && (
           <ContractSimulationPanel
             merchantId={effectiveMerchantId}
             isSimulating={isSimulating}
@@ -3982,7 +3985,7 @@ export function DecisionSimulatorPage() {
             }}
           />
         )}
-        {activeTab === 'batch' && (
+        {activeTab === 'batch' && volumeContractsBeta && (
           <VolumeCommitmentRunChart
             merchantId={effectiveMerchantId}
             results={simulationResults}

--- a/website/src/components/pages/SRRoutingPage.tsx
+++ b/website/src/components/pages/SRRoutingPage.tsx
@@ -11,7 +11,7 @@ import { ErrorMessage } from '../ui/ErrorMessage'
 import { Spinner } from '../ui/Spinner'
 import { useMerchantStore } from '../../store/merchantStore'
 import { useAuthStore } from '../../store/authStore'
-import { useCanEditRouting } from '../../store/authStore'
+import { useCanEditRouting, useVolumeContractsBeta } from '../../store/authStore'
 import { apiPost, fetcher } from '../../lib/api'
 import { PAYMENT_METHOD_TYPES, PAYMENT_METHODS } from '../../lib/constants'
 import {
@@ -212,11 +212,15 @@ export function SRRoutingPage() {
   // editable. (See sr_auto_calibration.rs — it skips non-autopilot rows and never sets defaults.)
   const features = useMerchantFeatures(merchantId ?? undefined)
   const autopilotOn = features.isEnabled('autopilot')
+  // Volume Contracts is in beta: only super-admins see its tab. A shared
+  // ?tab=volume link opened by anyone else falls back to Autopilot like any unknown tab.
+  const volumeContractsBeta = useVolumeContractsBeta()
   // Active tab is kept in the URL (?tab=…) so a reload or shared link reopens it directly.
   // Unknown/absent values fall back to Autopilot, and the default is left out of the URL.
   const [searchParams, setSearchParams] = useSearchParams()
   const tabParam = searchParams.get('tab')
-  const activeTab: SRTab = SR_TABS.includes(tabParam as SRTab) ? (tabParam as SRTab) : 'autopilot'
+  const requestedTab: SRTab = SR_TABS.includes(tabParam as SRTab) ? (tabParam as SRTab) : 'autopilot'
+  const activeTab: SRTab = requestedTab === 'volume' && !volumeContractsBeta ? 'autopilot' : requestedTab
   const setActiveTab = (tab: SRTab) => {
     setSearchParams(
       (prev) => {
@@ -406,12 +410,14 @@ export function SRRoutingPage() {
           <button type="button" className={tabClass('manual')} onClick={() => setActiveTab('manual')}>Manual</button>
           <button type="button" className={tabClass('flags')} onClick={() => setActiveTab('flags')}>Feature Flags</button>
           <button type="button" className={tabClass('cost')} onClick={() => setActiveTab('cost')}>Cost Estimation</button>
-          <button type="button" className={`${tabClass('volume')} inline-flex items-center gap-1.5`} onClick={() => setActiveTab('volume')}>
-            Volume Contracts
-            <span className="rounded-full bg-violet-100 px-1.5 py-0.5 text-[11px] font-semibold uppercase leading-4 tracking-wide text-violet-600 dark:bg-violet-500/15 dark:text-violet-400">
-              Beta
-            </span>
-          </button>
+          {volumeContractsBeta && (
+            <button type="button" className={`${tabClass('volume')} inline-flex items-center gap-1.5`} onClick={() => setActiveTab('volume')}>
+              Volume Contracts
+              <span className="rounded-full bg-violet-100 px-1.5 py-0.5 text-[11px] font-semibold uppercase leading-4 tracking-wide text-violet-600 dark:bg-violet-500/15 dark:text-violet-400">
+                Beta
+              </span>
+            </button>
+          )}
         </nav>
       </div>
 
@@ -614,7 +620,7 @@ export function SRRoutingPage() {
 
           {/* ── Volume Contracts tab: the contract editor, hosted here beside the other routing
               objectives. It keeps its own data hooks; only the page chrome is dropped. ── */}
-          {activeTab === 'volume' && <VolumeContractsPage embedded />}
+          {activeTab === 'volume' && volumeContractsBeta && <VolumeContractsPage embedded />}
         </>
       )}
     </div>
@@ -800,6 +806,9 @@ function AutopilotConfig({ merchantId }: { merchantId: string | null }) {
   )
 }
 
+/** Feature rows shown only to super-admins while Volume Contracts is in beta. */
+const VOLUME_CONTRACTS_BETA_FEATURES: readonly KnownFeature[] = ['volume-contracts']
+
 const SR_FEATURES: { feature: KnownFeature; title: string; description: string; docsUrl?: string }[] = [
   {
     feature: 'gsm-scoring-filter',
@@ -925,6 +934,10 @@ function SrDimensionsConfig({ merchantId }: { merchantId: string | null }) {
 
 function SRFeatureFlags({ merchantId }: { merchantId: string | null }) {
   const features = useMerchantFeatures(merchantId ?? undefined)
+  const volumeContractsBeta = useVolumeContractsBeta()
+  const visibleFeatures = SR_FEATURES.filter(
+    ({ feature }) => volumeContractsBeta || !VOLUME_CONTRACTS_BETA_FEATURES.includes(feature),
+  )
   const [toggling, setToggling] = useState<KnownFeature | null>(null)
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -961,7 +974,7 @@ function SRFeatureFlags({ merchantId }: { merchantId: string | null }) {
       )}
 
       <Card>
-        {SR_FEATURES.map(({ feature, title, description, docsUrl }, idx) => {
+        {visibleFeatures.map(({ feature, title, description, docsUrl }, idx) => {
           const enabled = features.isEnabled(feature)
           return (
             <div

--- a/website/src/store/authStore.ts
+++ b/website/src/store/authStore.ts
@@ -94,6 +94,16 @@ export function useCanEditRouting(): boolean {
   return useAuthStore((s) => sessionAllows(s.user, 'routing:write'))
 }
 
+/**
+ * Whether this session sees the beta Volume Contracts surfaces (SR routing tab, its feature flag,
+ * the analytics view, and the simulator panel). Super-admins only — the platform roster on
+ * `user_auth.super_admin_emails`, as reported by `/auth/me`. Presentation only: nothing on the API
+ * is gated by it.
+ */
+export function useVolumeContractsBeta(): boolean {
+  return useAuthStore((s) => Boolean(s.user?.isSuperAdmin))
+}
+
 export const useAuthStore = create<AuthStore>()(
   persist(
     (set) => ({


### PR DESCRIPTION
This pull request introduces a new feature flag, `useVolumeContractsBeta`, to control access to "Volume Contracts" features in the application. This beta flag ensures that only super-admin users can see and interact with Volume Contracts-related UI elements across several pages. For all other users, these features are hidden or fallback to default views/tabs. The implementation touches the Analytics, Decision Simulator, and SR Routing pages, and also hides the corresponding feature flag.

**Feature gating for Volume Contracts (Beta):**

* Added a new hook, `useVolumeContractsBeta`, to `authStore.ts` that returns true only for super-admin users, enabling beta access to Volume Contracts UI elements.
* Updated `AnalyticsPage.tsx`, `DecisionSimulatorPage.tsx`, and `SRRoutingPage.tsx` to use `useVolumeContractsBeta` to conditionally show or hide Volume Contracts views, tabs, and components. This includes fallback logic so that non-super-admins are redirected to default views if they attempt to access Volume Contracts via URL. [[1]](diffhunk://#diff-4835fac5bb63d7adadfc6cfb47cc1ced235a34cebd644c21df44e9773509e32cR3) [[2]](diffhunk://#diff-4835fac5bb63d7adadfc6cfb47cc1ced235a34cebd644c21df44e9773509e32cL832-R841) [[3]](diffhunk://#diff-4835fac5bb63d7adadfc6cfb47cc1ced235a34cebd644c21df44e9773509e32cR1653) [[4]](diffhunk://#diff-4835fac5bb63d7adadfc6cfb47cc1ced235a34cebd644c21df44e9773509e32cR1662) [[5]](diffhunk://#diff-88eb5a32c2959189bb65fbbe9bf4c18e6755ef2fc7a15a4c4a020ba8bf7c5bcfL16-R16) [[6]](diffhunk://#diff-88eb5a32c2959189bb65fbbe9bf4c18e6755ef2fc7a15a4c4a020ba8bf7c5bcfR1182-R1184) [[7]](diffhunk://#diff-88eb5a32c2959189bb65fbbe9bf4c18e6755ef2fc7a15a4c4a020ba8bf7c5bcfL3959-R3962) [[8]](diffhunk://#diff-88eb5a32c2959189bb65fbbe9bf4c18e6755ef2fc7a15a4c4a020ba8bf7c5bcfL3985-R3988) [[9]](diffhunk://#diff-fe58dc68dac56078b68a2d3c4e353ef12ec1bf901c26cc75deaea6b9c1f0ecbfL14-R14) [[10]](diffhunk://#diff-fe58dc68dac56078b68a2d3c4e353ef12ec1bf901c26cc75deaea6b9c1f0ecbfR215-R223) [[11]](diffhunk://#diff-fe58dc68dac56078b68a2d3c4e353ef12ec1bf901c26cc75deaea6b9c1f0ecbfR413-R420) [[12]](diffhunk://#diff-fe58dc68dac56078b68a2d3c4e353ef12ec1bf901c26cc75deaea6b9c1f0ecbfL617-R623)
* In `SRRoutingPage.tsx`, hid the Volume Contracts feature flag from non-super-admins by filtering it out of the feature list using the new beta flag. [[1]](diffhunk://#diff-fe58dc68dac56078b68a2d3c4e353ef12ec1bf901c26cc75deaea6b9c1f0ecbfR809-R811) [[2]](diffhunk://#diff-fe58dc68dac56078b68a2d3c4e353ef12ec1bf901c26cc75deaea6b9c1f0ecbfR937-R940) [[3]](diffhunk://#diff-fe58dc68dac56078b68a2d3c4e353ef12ec1bf901c26cc75deaea6b9c1f0ecbfL964-R977)


Not a superadmin
<img width="1713" height="995" alt="image" src="https://github.com/user-attachments/assets/3f052d2b-0a56-443a-946a-cb098cbfb39a" />
Super admin
<img width="1702" height="912" alt="image" src="https://github.com/user-attachments/assets/e7047136-fcb9-4749-bcae-35f423aca1c4" />
