### PR TITLE
refactor(auth): generalize the volume-contracts beta gate into a release roster

### DIFF
--- a/website/src/components/pages/AnalyticsPage.tsx
+++ b/website/src/components/pages/AnalyticsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useSearchParams } from 'react-router-dom'
-import { useVolumeContractsBeta } from '../../store/authStore'
+import { useFeatureReleased } from '../../lib/featureReleases'
 import useSWR from 'swr'
 import {
   Bar,
@@ -830,10 +830,10 @@ export function AnalyticsPage() {
   // reopens it directly; the default (transactions) is left out of the URL.
   const [searchParams, setSearchParams] = useSearchParams()
   const viewParam = searchParams.get('view')
-  // Volume commitments is in beta: only super-admins get the view. For
-  // anyone else a ?view=volume_commitments link behaves like an unknown view and is canonicalised
+  // Volume commitments is gated by the release roster (featureReleases.ts). Outside the audience
+  // a ?view=volume_commitments link behaves like an unknown view and is canonicalised
   // back to the default by the effect below.
-  const volumeContractsBeta = useVolumeContractsBeta()
+  const volumeContractsBeta = useFeatureReleased('volume-contracts')
   const requestedView: AnalyticsView = ANALYTICS_VIEWS.includes(viewParam as AnalyticsView)
     ? (viewParam as AnalyticsView)
     : 'transactions'

--- a/website/src/components/pages/DecisionSimulatorPage.tsx
+++ b/website/src/components/pages/DecisionSimulatorPage.tsx
@@ -13,7 +13,8 @@ import { Spinner } from '../ui/Spinner'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { useMerchantStore } from '../../store/merchantStore'
 import { useMerchantFeatures } from '../../hooks/useMerchantFeatures'
-import { useAuthStore, useVolumeContractsBeta } from '../../store/authStore'
+import { useAuthStore } from '../../store/authStore'
+import { useFeatureReleased } from '../../lib/featureReleases'
 import { apiErrorStatus, apiPost, fetcher } from '../../lib/api'
 import { ContractSimulationPanel } from './ContractSimulationPanel'
 import { VolumeCommitmentRunChart } from './VolumeCommitmentRunChart'
@@ -1179,9 +1180,9 @@ export function DecisionSimulatorPage() {
   const navigate = useNavigate()
   const { merchantId } = useMerchantStore()
   const authUser = useAuthStore((state) => state.user)
-  // Volume Contracts is in beta: the contract loader and commitment run chart on the Batch tab
-  // are shown only to super-admins.
-  const volumeContractsBeta = useVolumeContractsBeta()
+  // Volume Contracts is gated by the release roster (featureReleases.ts): the contract loader
+  // and commitment run chart on the Batch tab are shown only to its audience.
+  const volumeContractsBeta = useFeatureReleased('volume-contracts')
   const authMerchantId = authUser?.merchantId || ''
   const effectiveMerchantId = merchantId || authMerchantId
   const currentScopeKey = explorerScopeKey(

--- a/website/src/components/pages/SRRoutingPage.tsx
+++ b/website/src/components/pages/SRRoutingPage.tsx
@@ -11,7 +11,8 @@ import { ErrorMessage } from '../ui/ErrorMessage'
 import { Spinner } from '../ui/Spinner'
 import { useMerchantStore } from '../../store/merchantStore'
 import { useAuthStore } from '../../store/authStore'
-import { useCanEditRouting, useVolumeContractsBeta } from '../../store/authStore'
+import { useCanEditRouting } from '../../store/authStore'
+import { releaseAdmits, useFeatureReleased, type ReleasedFeature } from '../../lib/featureReleases'
 import { apiPost, fetcher } from '../../lib/api'
 import { PAYMENT_METHOD_TYPES, PAYMENT_METHODS } from '../../lib/constants'
 import {
@@ -212,9 +213,9 @@ export function SRRoutingPage() {
   // editable. (See sr_auto_calibration.rs — it skips non-autopilot rows and never sets defaults.)
   const features = useMerchantFeatures(merchantId ?? undefined)
   const autopilotOn = features.isEnabled('autopilot')
-  // Volume Contracts is in beta: only super-admins see its tab. A shared
-  // ?tab=volume link opened by anyone else falls back to Autopilot like any unknown tab.
-  const volumeContractsBeta = useVolumeContractsBeta()
+  // Volume Contracts is gated by the release roster (featureReleases.ts). A shared
+  // ?tab=volume link opened outside the audience falls back to Autopilot like any unknown tab.
+  const volumeContractsBeta = useFeatureReleased('volume-contracts')
   // Active tab is kept in the URL (?tab=…) so a reload or shared link reopens it directly.
   // Unknown/absent values fall back to Autopilot, and the default is left out of the URL.
   const [searchParams, setSearchParams] = useSearchParams()
@@ -806,10 +807,8 @@ function AutopilotConfig({ merchantId }: { merchantId: string | null }) {
   )
 }
 
-/** Feature rows shown only to super-admins while Volume Contracts is in beta. */
-const VOLUME_CONTRACTS_BETA_FEATURES: readonly KnownFeature[] = ['volume-contracts']
-
-const SR_FEATURES: { feature: KnownFeature; title: string; description: string; docsUrl?: string }[] = [
+// A row with a `gate` is shown only to that feature's release audience (featureReleases.ts).
+const SR_FEATURES: { feature: KnownFeature; title: string; description: string; docsUrl?: string; gate?: ReleasedFeature }[] = [
   {
     feature: 'gsm-scoring-filter',
     title: 'GSM scoring filter',
@@ -840,6 +839,7 @@ const SR_FEATURES: { feature: KnownFeature; title: string; description: string; 
   },
   {
     feature: 'volume-contracts',
+    gate: 'volume-contracts',
     title: 'Volume contracts (meet PSP commitments)',
     description:
       'Multi-objective routing: keeps approval-rate routing in charge, but when a contracted volume commitment is drifting behind pace, steers a little extra volume to that PSP — only onto payments where it approves about as well, so approvals barely move. Runs alongside Cost savings; when both are on, a behind-pace commitment takes priority for eligible payments.',
@@ -934,10 +934,8 @@ function SrDimensionsConfig({ merchantId }: { merchantId: string | null }) {
 
 function SRFeatureFlags({ merchantId }: { merchantId: string | null }) {
   const features = useMerchantFeatures(merchantId ?? undefined)
-  const volumeContractsBeta = useVolumeContractsBeta()
-  const visibleFeatures = SR_FEATURES.filter(
-    ({ feature }) => volumeContractsBeta || !VOLUME_CONTRACTS_BETA_FEATURES.includes(feature),
-  )
+  const user = useAuthStore((s) => s.user)
+  const visibleFeatures = SR_FEATURES.filter((f) => !f.gate || releaseAdmits(user, f.gate))
   const [toggling, setToggling] = useState<KnownFeature | null>(null)
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)

--- a/website/src/lib/featureReleases.ts
+++ b/website/src/lib/featureReleases.ts
@@ -1,0 +1,44 @@
+import type { AuthUser } from '../store/authStore'
+import { useAuthStore } from '../store/authStore'
+
+/**
+ * Who a pre-GA feature is currently released to. Presentation only — it hides surfaces, never
+ * secures APIs; a route that must refuse non-admins needs its own backend guard.
+ */
+export type ReleaseAudience = 'everyone' | 'super_admin' | 'nobody'
+
+/**
+ * The release roster. To gate a new feature, add it here as 'super_admin' and wrap its surfaces
+ * in useFeatureReleased(); to release it, flip the entry to 'everyone', then delete the entry —
+ * the compiler then lists every call site left to unwrap. 'nobody' is the emergency retract.
+ */
+export const FEATURE_RELEASES = {
+  'volume-contracts': 'super_admin',
+} as const satisfies Record<string, ReleaseAudience>
+
+export type ReleasedFeature = keyof typeof FEATURE_RELEASES
+
+function audienceAdmits(user: AuthUser | null, audience: ReleaseAudience): boolean {
+  switch (audience) {
+    case 'everyone':
+      return true
+    case 'nobody':
+      return false
+    case 'super_admin':
+      return Boolean(user?.isSuperAdmin)
+  }
+}
+
+/**
+ * Non-hook evaluator for list filters and plain helpers. Fails closed on a null user — unlike
+ * sessionAllows, which fails open: an unreleased surface briefly shown is a leak, while a
+ * permission gate guessed wrong is just a control the backend refuses.
+ */
+export function releaseAdmits(user: AuthUser | null, feature: ReleasedFeature): boolean {
+  return audienceAdmits(user, FEATURE_RELEASES[feature])
+}
+
+/** Whether this session sees `feature`'s surfaces. */
+export function useFeatureReleased(feature: ReleasedFeature): boolean {
+  return useAuthStore((s) => releaseAdmits(s.user, feature))
+}

--- a/website/src/store/authStore.ts
+++ b/website/src/store/authStore.ts
@@ -94,16 +94,6 @@ export function useCanEditRouting(): boolean {
   return useAuthStore((s) => sessionAllows(s.user, 'routing:write'))
 }
 
-/**
- * Whether this session sees the beta Volume Contracts surfaces (SR routing tab, its feature flag,
- * the analytics view, and the simulator panel). Super-admins only — the platform roster on
- * `user_auth.super_admin_emails`, as reported by `/auth/me`. Presentation only: nothing on the API
- * is gated by it.
- */
-export function useVolumeContractsBeta(): boolean {
-  return useAuthStore((s) => Boolean(s.user?.isSuperAdmin))
-}
-
 export const useAuthStore = create<AuthStore>()(
   persist(
     (set) => ({


### PR DESCRIPTION
## What

Replaces the one-off `useVolumeContractsBeta()` hook from #429 with a generic, config-driven release-gating mechanism, so gating the next pre-GA feature to super-admins is a one-line change.

- **New `website/src/lib/featureReleases.ts`** — a typed roster mapping each pre-GA feature to its release audience (`'everyone' | 'super_admin' | 'nobody'`), a `releaseAdmits()` evaluator for plain-function contexts (list filters), and a `useFeatureReleased(feature)` hook for components. Seeded with `'volume-contracts': 'super_admin'`.
- **`authStore.ts`** — `useVolumeContractsBeta` deleted.
- **The three gated pages** (`SRRoutingPage`, `AnalyticsPage`, `DecisionSimulatorPage`) swap to `useFeatureReleased('volume-contracts')`. In `SRRoutingPage` the parallel `VOLUME_CONTRACTS_BETA_FEATURES` list is gone — the gated flag row now carries `gate: 'volume-contracts'` directly and `SRFeatureFlags` filters with `releaseAdmits`.

## How to gate a future feature

1. Add `'my-feature': 'super_admin'` to `FEATURE_RELEASES` and wrap its surfaces in `useFeatureReleased('my-feature')`.
2. To release it, flip the entry to `'everyone'` (one-line diff, trivially revertible); `'nobody'` is the emergency retract.
3. To remove the gate, delete the entry — the compiler then lists every call site left to unwrap, so no gate can be forgotten half-removed.

## Design notes

- **Fail-closed**, unlike `sessionAllows` (which fails open on missing permissions): an unreleased surface briefly shown is a leak, while a permission gate guessed wrong is just a control the backend refuses. `releaseAdmits(null, …)` is `false`, matching the old `Boolean(user?.isSuperAdmin)` for null/redirect/pre-hydration sessions.
- **Presentation-only**, same stance as #429 — a route that must refuse non-admins needs its own backend guard (the `is_super_admin` roster check used by the `/auth/super-admin/*` routes is the precedent).
- The roster lives in frontend TS rather than backend config because the gated surfaces ship in the same bundle: a roster entry deploys at exactly the moment the UI it governs does, and deployed-env TOML is not repo-controlled.

## Verification

- `tsc` and `vite build` pass.
- Behavior-preserving refactor: filter truth tables, hook ordering, zustand subscription semantics, and the `?tab=volume` / `?view=volume_commitments` fallbacks are unchanged for every user state (null / non-admin / super-admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)