### PR TITLE
fix(config): serialize concurrent feature-flag updates on the shared conf row

### DIFF
--- a/src/routes/merchant_account_config.rs
+++ b/src/routes/merchant_account_config.rs
@@ -135,48 +135,41 @@ impl KnownFeature {
 
     /// Updates the FeatureConf row in service_configuration by adding or removing
     /// the merchant. This is the only write path — no per-merchant keys involved.
+    /// The read-modify-write runs under a row lock (update_config_atomic) because all
+    /// merchants share one row per feature — unlocked writers lose each other's updates.
     async fn update_conf(
         &self,
         merchant_id: &str,
         enabled: bool,
     ) -> error_stack::Result<(), crate::generics::MeshError> {
         let key = self.feature_conf_key().to_string();
+        let merchant_id = merchant_id.to_string();
 
-        let existing = service_configuration::find_config_by_name(key.clone())
-            .await
-            .unwrap_or(None);
+        service_configuration::update_config_atomic(key, move |current| {
+            let mut conf: FeatureConf = current
+                .and_then(|v| serde_json::from_str(&v).ok())
+                .unwrap_or(FeatureConf {
+                    enableAll: false,
+                    enableAllRollout: None,
+                    disableAny: None,
+                    merchants: Some(vec![]),
+                });
 
-        let exists = existing.is_some();
+            let mut merchants = conf.merchants.take().unwrap_or_default();
+            merchants.retain(|m| m.merchantId.to_lowercase() != merchant_id.to_lowercase());
+            if enabled {
+                merchants.push(FeatureMerchant {
+                    merchantId: merchant_id,
+                    rollout: 100,
+                });
+            }
+            conf.merchants = Some(merchants);
 
-        let mut conf: FeatureConf = existing
-            .and_then(|c| c.value)
-            .and_then(|v| serde_json::from_str(&v).ok())
-            .unwrap_or(FeatureConf {
-                enableAll: false,
-                enableAllRollout: None,
-                disableAny: None,
-                merchants: Some(vec![]),
-            });
-
-        let mut merchants = conf.merchants.take().unwrap_or_default();
-        merchants.retain(|m| m.merchantId.to_lowercase() != merchant_id.to_lowercase());
-        if enabled {
-            merchants.push(FeatureMerchant {
-                merchantId: merchant_id.to_string(),
-                rollout: 100,
-            });
-        }
-        conf.merchants = Some(merchants);
-
-        let serialized = serde_json::to_string(&conf)
-            .map_err(|e| error_stack::report!(e))
-            .change_context(crate::generics::MeshError::Others)?;
-
-        if exists {
-            service_configuration::update_config(key, Some(serialized)).await
-        } else {
-            service_configuration::insert_config(key, Some(serialized)).await
-        }
+            serde_json::to_string(&conf)
+                .map(Some)
+                .map_err(|_| crate::generics::MeshError::Others)
+        })
+        .await
     }
 }
 

--- a/src/types/service_configuration.rs
+++ b/src/types/service_configuration.rs
@@ -1,9 +1,11 @@
 use crate::app::get_tenant_app_state;
+use crate::logger;
 use crate::redis::cache::{evict_service_config, write_through_service_config};
 #[cfg(feature = "mysql")]
 use crate::storage::schema::service_configuration::dsl;
 #[cfg(feature = "postgres")]
 use crate::storage::schema_pg::service_configuration::dsl;
+use async_bb8_diesel::AsyncConnection;
 use diesel::associations::HasTable;
 use diesel::*;
 use std::option::Option;
@@ -73,6 +75,102 @@ pub async fn update_config(
     match value {
         Some(v) => write_through_service_config(name, &v).await,
         None => evict_service_config(name).await,
+    }
+    Ok(())
+}
+
+enum AtomicUpdateError {
+    Diesel(diesel::result::Error),
+    Transform(crate::generics::MeshError),
+}
+
+impl From<diesel::result::Error> for AtomicUpdateError {
+    fn from(e: diesel::result::Error) -> Self {
+        Self::Diesel(e)
+    }
+}
+
+/// Read-modify-write a config row atomically: `transform` receives the current value and
+/// returns the new one, all inside one DB transaction holding a `SELECT ... FOR UPDATE`
+/// row lock, so concurrent writers to the same key can't lose each other's updates.
+/// Inserts the row if it doesn't exist yet.
+pub async fn update_config_atomic<F>(
+    name: String,
+    transform: F,
+) -> error_stack::Result<(), crate::generics::MeshError>
+where
+    F: FnOnce(Option<String>) -> Result<Option<String>, crate::generics::MeshError>
+        + Send
+        + 'static,
+{
+    let app_state = get_tenant_app_state().await;
+    let conn = app_state
+        .db
+        .get_conn()
+        .await
+        .map_err(|_| crate::generics::MeshError::DatabaseConnectionError)?;
+
+    let cache_name = name.clone();
+    let new_value = conn
+        .run(move |conn| {
+            conn.transaction::<Option<String>, AtomicUpdateError, _>(|conn| {
+                // FOR UPDATE locks nothing when the row is absent, so also take an advisory
+                // lock on the key to serialize concurrent first-time inserts. Savepoint-wrapped:
+                // backends without advisory locks (e.g. CockroachDB) fall through to the row lock.
+                #[cfg(feature = "postgres")]
+                let _ = conn.transaction::<_, diesel::result::Error, _>(|conn| {
+                    diesel::sql_query(
+                        "SELECT pg_advisory_xact_lock(hashtext('service_configuration'), hashtext($1))",
+                    )
+                    .bind::<diesel::sql_types::Text, _>(name.clone())
+                    .execute(conn)
+                    .map(|_| ())
+                });
+
+                let existing = dsl::service_configuration
+                    .filter(dsl::name.eq(&name))
+                    .order(dsl::id.asc())
+                    .limit(1)
+                    .for_update()
+                    .get_result::<ServiceConfiguration>(conn)
+                    .optional()?;
+
+                let new_value = transform(existing.as_ref().and_then(|c| c.value.clone()))
+                    .map_err(AtomicUpdateError::Transform)?;
+
+                match existing {
+                    Some(row) => {
+                        diesel::update(dsl::service_configuration.filter(dsl::id.eq(row.id)))
+                            .set(dsl::value.eq(new_value.clone()))
+                            .execute(conn)?;
+                    }
+                    None => {
+                        diesel::insert_into(dsl::service_configuration)
+                            .values(ServiceConfigurationNew {
+                                name: name.clone(),
+                                value: new_value.clone(),
+                                new_value: None,
+                                previous_value: None,
+                                new_value_status: None,
+                            })
+                            .execute(conn)?;
+                    }
+                }
+                Ok(new_value)
+            })
+        })
+        .await
+        .map_err(|e| match e {
+            AtomicUpdateError::Transform(err) => error_stack::report!(err),
+            AtomicUpdateError::Diesel(err) => {
+                logger::error!("update_config_atomic: transaction failed: {:?}", err);
+                error_stack::report!(crate::generics::MeshError::Others)
+            }
+        })?;
+
+    match new_value {
+        Some(v) => write_through_service_config(cache_name, &v).await,
+        None => evict_service_config(cache_name).await,
     }
     Ok(())
 }

--- a/tests/api/merchant/merchant-features.spec.ts
+++ b/tests/api/merchant/merchant-features.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/test'
+import { test, expect, factory } from '../../fixtures/test'
 
 /**
  * Merchant feature flags + debit-routing toggle. These are operator-facing switches that gate real
@@ -22,6 +22,37 @@ test.describe('Merchant features & debit routing (API)', () => {
     const get = await api.raw('GET', `/merchant-account/${merchant.id}/debit-routing`)
     expect(get.status).toBe(200)
     expect(get.body.debit_routing_enabled).toBe(false)
+  })
+
+  test('concurrent feature enables for distinct merchants all survive', async ({ api }) => {
+    // All merchants share ONE service_configuration row per feature, so parallel enables
+    // exercise the locked read-modify-write path; a lost update surfaces as a disabled flag.
+    const ids = Array.from({ length: 6 }, () => factory.merchantId('pwconc'))
+    const flagPath = (id: string) => `/merchant-account/${id}/features/multi-objective-routing`
+
+    try {
+      await Promise.all(ids.map((id) => api.ensureMerchantAccount(id)))
+
+      const enables = await Promise.all(
+        ids.map((id) => api.raw('POST', flagPath(id), { body: { enabled: true } })),
+      )
+      for (const r of enables) expect(r.status).toBe(200)
+
+      for (const id of ids) {
+        const get = await api.raw('GET', `/merchant-account/${id}/features`)
+        const entry = get.body.features.find((f: any) => f.feature === 'multi-objective-routing')
+        expect(entry?.enabled, `flag for ${id} was lost by a concurrent update`).toBe(true)
+      }
+    } finally {
+      // Parallel disables double as the removal-path concurrency check; then drop the merchants.
+      const disables = await Promise.all(
+        ids.map((id) =>
+          api.raw('POST', flagPath(id), { body: { enabled: false }, failOnStatusCode: false }),
+        ),
+      )
+      for (const r of disables) expect(r.status).toBe(200)
+      await Promise.all(ids.map((id) => api.cleanupTestData(id)))
+    }
   })
 
   test('debit routing flag toggles on and off and persists', async ({ api, merchant }) => {


### PR DESCRIPTION
## Problem

`POST /merchant-account/{merchant_id}/features/{feature}` (`KnownFeature::update_conf`) updates a `FeatureConf` stored as **one shared `service_configuration` row per feature** (e.g. `multi_objective_routing_enabled`): it read the row, modified the merchants list in memory, and wrote the whole row back with no locking or compare-and-set.

Two concurrent calls for **different merchants** lose one update: merchant A enables, merchant B's concurrent enable overwrites the row without A's entry, and A's flag silently reads back as disabled. Reproduced by the sticky-routing Playwright suite when tests ran fully parallel (each test enabling the feature for its own merchant).

## Fix

Database-level locking only — no new Redis keys, no schema changes.

- New `service_configuration::update_config_atomic(name, transform)`: runs the read-modify-write inside **one DB transaction holding `SELECT ... FOR UPDATE`** on the row. A concurrent writer blocks until the first commits, then reads the committed value and applies its change on top. After commit it does the same Redis/memory write-through as `update_config`.
- `KnownFeature::update_conf` now passes its add/remove-merchant logic as the `transform` closure.
- **First-ever write to a key**: `service_configuration.name` has no unique index, so `FOR UPDATE` has no row to lock and two racers could insert duplicate rows. On postgres the transaction additionally takes `pg_advisory_xact_lock(hashtext('service_configuration'), hashtext(key))` — transaction-scoped, nothing persisted. It is savepoint-wrapped so backends without advisory locks degrade to the plain row lock instead of failing the request. On mysql the unindexed `name` scan already serializes writers via InnoDB next-key locks.
- Row selection is `ORDER BY id LIMIT 1 FOR UPDATE` and the update targets the locked `id`, so behavior stays deterministic even if legacy duplicate rows exist.

`read_effective` already reads the DB directly, so dashboard reads reflect the committed row immediately; the TTL-bounded cache write-through behavior is unchanged.

## Test

New Playwright test (`tests/api/merchant/merchant-features.spec.ts`): fires **6 parallel enables for distinct merchants** against the shared row and asserts every flag survives; parallel disables on teardown exercise the removal path.

- Against the unfixed binary it fails on the first run with a lost flag (one of its cleanup disables got eaten by the same race).
- Against the fixed binary: passed 6/6 repeated runs, full spec green, and the DB kept a single clean row for the key.

`cargo check` passes for both `--no-default-features --features postgres` and the default mysql feature set; clippy and fmt clean.

## Follow-up (out of scope)

Several other callers do the same unlocked `find_config_by_name` → mutate → `update_config` pattern on shared rows (sr_auto_calibration, cost_ingestion creds/mapping/overrides/invoice, multi_objective seed_store, routing_rules SR dimensions, merchant hierarchy). They can migrate to `update_config_atomic` incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)